### PR TITLE
Continuous testing on TravisCI + README badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: false
+ 
+language: go
+ 
+go:
+  - tip
+  - 1.7
+  - 1.6
+  - 1.5
+ 
+script:
+  - go test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/avct/uasurfer.svg?branch=master)](https://travis-ci.org/avct/uasurfer)  [![GoDoc](https://godoc.org/github.com/avct/uasurfer?status.svg)](https://godoc.org/github.com/avct/uasurfer)  [![Go Report Card](https://goreportcard.com/badge/github.com/avct/uasurfer)](https://goreportcard.com/report/github.com/avct/uasurfer)
+
 # uasurfer
 
 ![uasurfer-100px](https://cloud.githubusercontent.com/assets/597902/16172506/9debc136-357a-11e6-90fb-c7c46f50dff0.png)


### PR DESCRIPTION
Adds TravisCI configuration file - once you add the project to https://travis-ci.org/ (free for open source projects) new commits and pull requests will have tests running automatically.

Added badges to README:
- TravisCI build status
- Godoc link
- Go report card (if it's A+ why not boast about it)