### PR TITLE
Don't return a pointer to UserAgent.

### DIFF
--- a/uasurfer.go
+++ b/uasurfer.go
@@ -141,7 +141,7 @@ type OS struct {
 }
 
 // Parse accepts a raw user agent (string) and returns the UserAgent.
-func Parse(ua string) *UserAgent {
+func Parse(ua string) UserAgent {
 	ua = strings.ToLower(ua)
 	resp := &UserAgent{}
 
@@ -160,5 +160,5 @@ func Parse(ua string) *UserAgent {
 		resp.evalDevice(ua)
 	}
 
-	return resp
+	return *resp
 }

--- a/uasurfer_test.go
+++ b/uasurfer_test.go
@@ -1,10 +1,6 @@
 package uasurfer
 
-import
-// "bufio"
-// "fmt"
-// "os"
-"testing"
+import "testing"
 
 var testUAVars = []struct {
 	UA string


### PR DESCRIPTION
We always return something so returning a pointer is confusing and means
that client have to check if the return value is nil.

This is a breaking change, but minor.