### PR TITLE
Fast path for ascii user agents shorter than 1024 characters.

### DIFF
--- a/uasurfer.go
+++ b/uasurfer.go
@@ -179,6 +179,8 @@ func parse(ua string, dest *UserAgent) {
 	}
 }
 
+// normalise normalises the user supplied agent string so that
+// we can more easily parse it.
 func normalise(ua string) string {
 	if len(ua) <= 1024 {
 		var buf [1024]byte
@@ -195,7 +197,7 @@ func normalise(ua string) string {
 
 // copyLower copies a lowercase version of s to b. It assumes s contains only single byte characters
 // and will panic if b is nil or is not long enough to contain all the bytes from s.
-// It returns early with false if any chacracters were non ascii.
+// It returns early with false if any characters were non ascii.
 func copyLower(b []byte, s string) bool {
 	for j := 0; j < len(s); j++ {
 		c := s[j]


### PR DESCRIPTION
Falls back to old method if not.

```
benchmark                         old ns/op     new ns/op     delta
BenchmarkAgentSurfer-4            5568          4918          -11.67%
BenchmarkAgentSurferReuse-4       5453          5412          -0.75%
BenchmarkEvalSystem-4             2942          3162          +7.48%
BenchmarkEvalBrowserName-4        725           774           +6.76%
BenchmarkEvalBrowserVersion-4     89.5          96.8          +8.16%
BenchmarkEvalDevice-4             824           1066          +29.37%
BenchmarkParseChromeMac-4         2711          1609          -40.65%
BenchmarkParseChromeWin-4         2532          1383          -45.38%
BenchmarkParseChromeAndroid-4     6376          4950          -22.37%
BenchmarkParseSafariMac-4         3626          2349          -35.22%
BenchmarkParseSafariiPad-4        3841          2478          -35.49%

benchmark                         old allocs     new allocs     delta
BenchmarkAgentSurfer-4            2              2              +0.00%
BenchmarkAgentSurferReuse-4       1              1              +0.00%
BenchmarkEvalSystem-4             0              0              +0.00%
BenchmarkEvalBrowserName-4        0              0              +0.00%
BenchmarkEvalBrowserVersion-4     0              0              +0.00%
BenchmarkEvalDevice-4             0              0              +0.00%
BenchmarkParseChromeMac-4         3              2              -33.33%
BenchmarkParseChromeWin-4         3              2              -33.33%
BenchmarkParseChromeAndroid-4     3              2              -33.33%
BenchmarkParseSafariMac-4         3              2              -33.33%
BenchmarkParseSafariiPad-4        3              2              -33.33%

benchmark                         old bytes     new bytes     delta
BenchmarkAgentSurfer-4            320           207           -35.31%
BenchmarkAgentSurferReuse-4       240           127           -47.08%
BenchmarkEvalSystem-4             0             0             +0.00%
BenchmarkEvalBrowserName-4        0             0             +0.00%
BenchmarkEvalBrowserVersion-4     0             0             +0.00%
BenchmarkEvalDevice-4             0             0             +0.00%
BenchmarkParseChromeMac-4         336           208           -38.10%
BenchmarkParseChromeWin-4         304           192           -36.84%
BenchmarkParseChromeAndroid-4     368           224           -39.13%
BenchmarkParseSafariMac-4         336           208           -38.10%
BenchmarkParseSafariiPad-4        336           208           -38.10%
```