### PR TITLE
Better detection for mobile safari.

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -1,6 +1,8 @@
 package uasurfer
 
-import "strings"
+import (
+	"strings"
+)
 
 // Browser struct contains the lowercase name of the browser, along
 // with its browser version number. Browser are grouped together without
@@ -18,7 +20,6 @@ import "strings"
 
 // Retrieve browser name from UA strings
 func (u *UserAgent) evalBrowserName(ua string) bool {
-
 	// Blackberry goes first because it reads as MSIE & Safari
 	if strings.Contains(ua, "blackberry") || strings.Contains(ua, "playbook") || strings.Contains(ua, "bb10") || strings.Contains(ua, "rim ") {
 		u.Browser.Name = BrowserBlackberry
@@ -54,7 +55,7 @@ func (u *UserAgent) evalBrowserName(ua string) bool {
 			u.Browser.Name = BrowserSpotify
 
 		// presume it's safari unless an esoteric browser is being specified (webOSBrowser, SamsungBrowser, etc.)
-		case strings.Contains(ua, "like gecko") && strings.Contains(ua, "mozilla/") && !strings.Contains(ua, "linux") && !strings.Contains(ua, "android") && strings.Contains(ua, "safari/") && !strings.Contains(ua, "browser/") && !strings.Contains(ua, "os/"):
+		case strings.Contains(ua, "like gecko") && strings.Contains(ua, "mozilla/") && !strings.Contains(ua, "linux") && !strings.Contains(ua, "android") && !strings.Contains(ua, "browser/") && !strings.Contains(ua, "os/"):
 			u.Browser.Name = BrowserSafari
 
 		// Google's search app on iPhone, leverages native Safari rather than Chrome

--- a/browser.go
+++ b/browser.go
@@ -55,7 +55,11 @@ func (u *UserAgent) evalBrowserName(ua string) bool {
 			u.Browser.Name = BrowserSpotify
 
 		// presume it's safari unless an esoteric browser is being specified (webOSBrowser, SamsungBrowser, etc.)
-		case strings.Contains(ua, "like gecko") && strings.Contains(ua, "mozilla/") && !strings.Contains(ua, "linux") && !strings.Contains(ua, "android") && !strings.Contains(ua, "browser/") && !strings.Contains(ua, "os/"):
+		case strings.Contains(ua, "like gecko") && strings.Contains(ua, "mozilla/") && strings.Contains(ua, "safari/") && !strings.Contains(ua, "linux") && !strings.Contains(ua, "android") && !strings.Contains(ua, "browser/") && !strings.Contains(ua, "os/"):
+			u.Browser.Name = BrowserSafari
+
+		// if we got this far and the device is iPhone or iPad, assume safari. Some agents don't actually contain the word "safari"
+		case strings.Contains(ua, "iphone") || strings.Contains(ua, "ipad"):
 			u.Browser.Name = BrowserSafari
 
 		// Google's search app on iPhone, leverages native Safari rather than Chrome
@@ -64,6 +68,7 @@ func (u *UserAgent) evalBrowserName(ua string) bool {
 
 		default:
 			goto notwebkit
+
 		}
 		return u.isBot()
 	}

--- a/uasurfer_test.go
+++ b/uasurfer_test.go
@@ -1,10 +1,6 @@
 package uasurfer
 
-import
-// "bufio"
-// "fmt"
-// "os"
-"testing"
+import "testing"
 
 var testUAVars = []struct {
 	UA string
@@ -615,6 +611,10 @@ var testUAVars = []struct {
 	{"Mozilla/5.0 (iPad; CPU OS 7_0_2 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A501 Safari/9537.53",
 		UserAgent{
 			Browser{BrowserSafari, Version{7, 0, 0}}, OS{PlatformiPad, OSiOS, Version{7, 0, 2}}, DeviceTablet}},
+
+	{"Mozilla/5.0 (iPhone; CPU iPhone OS 10_2_1 like Mac OS X) AppleWebKit/602.4.6 (KHTML, like Gecko) Mobile/14D27 [FBAN/FBIOS;FBAV/86.0.0.48.52;FBBV/53842252;FBDV/iPhone9,1;FBMD/iPhone;FBSN/iOS;FBSV/10.2.1;FBSS/2;FBCR/Verizon;FBID/phone;FBLC/en_US;FBOP/5;FBRV/0]",
+		UserAgent{
+			Browser{BrowserSafari, Version{10, 2, 1}}, OS{PlatformiPhone, OSiOS, Version{10, 2, 1}}, DevicePhone}},
 
 	// TODO handle default browser based on iOS version
 	// {"Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/538.34.9 (KHTML, like Gecko) Mobile/12A4265u",

--- a/uasurfer_test.go
+++ b/uasurfer_test.go
@@ -277,6 +277,9 @@ var testUAVars = []struct {
 			Browser{BrowserIE, Version{9, 0, 0}}, OS{PlatformXbox, OSXbox, Version{6, 1, 0}}, DeviceConsole}},
 
 	// Playstation
+	{"Mozilla/5.0 (PlayStation 4 4.50) AppleWebKit/601.2 (KHTML, like Gecko)",
+		UserAgent{
+			Browser{BrowserUnknown, Version{0, 0, 0}}, OS{PlatformPlaystation, OSPlaystation, Version{0, 0, 0}}, DeviceConsole}},
 
 	{"Mozilla/5.0 (Playstation Vita 1.61) AppleWebKit/531.22.8 (KHTML, like Gecko) Silk/3.2",
 		UserAgent{


### PR DESCRIPTION
Mobile safari often doesn't include "safari" in the useragent string and
we were discarding potential matches.

I looked at occurrences of unknown browser and the majority are fixed by this change.