### PR TITLE
classify some new UA strings generated by OCSP fetchers.

### DIFF
--- a/system.go
+++ b/system.go
@@ -46,7 +46,7 @@ func (u *UserAgent) evalOS(ua string) bool {
 	case "ipad", "iphone", "ipod touch", "ipod":
 		u.evaliOS(specs, agentPlatform)
 
-	case "macintosh":
+	case "macintosh", "CFNetwork":
 		u.evalMacintosh(ua)
 
 	default:
@@ -61,7 +61,7 @@ func (u *UserAgent) evalOS(ua string) bool {
 			u.evalWindowsPhone(agentPlatform)
 
 		// Windows, Xbox
-		case strings.Contains(ua, "windows "):
+		case strings.Contains(ua, "windows ") || strings.Contains(ua, "Microsoft-CryptoAPI"):
 			u.evalWindows(ua)
 
 		// Kindle


### PR DESCRIPTION
examples of those UA strings are:
  "ocspd (unknown version) CFNetwork/520.5.3 Darwin/11.4.2 (x86_64)(iMac11%2C2)",
  "ocspd (unknown version) CFNetwork/520.5.3 Darwin/11.4.2 (x86_64)(MacBookAir5%2C2)",
  "trustd (unknown version) CFNetwork/811.7.2 Darwin/16.7.0 (x86_64)",
  "securityd (unknown version) CFNetwork/808.0.2 Darwin/16.0.0",
  "Microsoft-CryptoAPI/6.2", "Microsoft-CryptoAPI/6.1", and
  "Microsoft-CryptoAPI/10.0"