### PR TITLE
classify some new UA strings generated by OCSP fetchers.

### DIFF
--- a/system.go
+++ b/system.go
@@ -61,7 +61,7 @@ func (u *UserAgent) evalOS(ua string) bool {
 			u.evalWindowsPhone(agentPlatform)
 
 		// Windows, Xbox
-		case strings.Contains(ua, "windows "):
+		case strings.Contains(ua, "windows ") || strings.Contains(ua, "microsoft-cryptoapi"):
 			u.evalWindows(ua)
 
 		// Kindle
@@ -91,6 +91,10 @@ func (u *UserAgent) evalOS(ua string) bool {
 		// Android
 		case strings.Contains(ua, "android"):
 			u.evalLinux(ua, agentPlatform)
+
+		// Apple CFNetwork
+		case strings.Contains(ua, "cfnetwork") && strings.Contains(ua, "darwin"):
+			u.evalMacintosh(ua)
 
 		default:
 			u.OS.Platform = PlatformUnknown

--- a/uasurfer_test.go
+++ b/uasurfer_test.go
@@ -340,6 +340,16 @@ var testUAVars = []struct {
 		UserAgent{
 			Browser{BrowserSpotify, Version{1, 0, 9}}, OS{PlatformMac, OSMacOSX, Version{10, 10, 2}}, DeviceComputer}},
 
+	// OCSP fetchers
+	{"Microsoft-CryptoAPI/10.0",
+		UserAgent{
+			Browser{BrowserUnknown, Version{0, 0, 0}}, OS{PlatformWindows, OSUnknown, Version{0, 0, 0}}, DeviceComputer}},
+	{"trustd (unknown version) CFNetwork/811.7.2 Darwin/16.7.0 (x86_64)",
+		UserAgent{
+			Browser{BrowserUnknown, Version{0, 0, 0}}, OS{PlatformMac, OSUnknown, Version{0, 0, 0}}, DeviceComputer}},
+	{"ocspd (unknown version) CFNetwork/520.5.3 Darwin/11.4.2 (x86_64)(MacBookAir5%2C2)",
+		UserAgent{
+			Browser{BrowserUnknown, Version{0, 0, 0}}, OS{PlatformMac, OSUnknown, Version{0, 0, 0}}, DeviceComputer}},
 	// Bots
 	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Applebot/0.1; +http://www.apple.com/go/applebot)",
 		UserAgent{


### PR DESCRIPTION
examples of those UA strings are:
  "ocspd (unknown version) CFNetwork/520.5.3 Darwin/11.4.2 (x86_64)(iMac11%2C2)",
  "ocspd (unknown version) CFNetwork/520.5.3 Darwin/11.4.2 (x86_64)(MacBookAir5%2C2)",
  "trustd (unknown version) CFNetwork/811.7.2 Darwin/16.7.0 (x86_64)",
  "securityd (unknown version) CFNetwork/808.0.2 Darwin/16.0.0",
  "Microsoft-CryptoAPI/6.2", "Microsoft-CryptoAPI/6.1", and
  "Microsoft-CryptoAPI/10.0"