### PR TITLE
Add StringTrimPrefix methods to a few types.

### DIFF
--- a/uasurfer.go
+++ b/uasurfer.go
@@ -24,6 +24,11 @@ const (
 	DeviceTV
 )
 
+// StringTrimPrefix is like String() but trims the "Device" prefix
+func (d DeviceType) StringTrimPrefix() string {
+	return strings.TrimPrefix(d.String(), "Device")
+}
+
 // BrowserName (int) returns a constant.
 type BrowserName int
 
@@ -66,6 +71,11 @@ const (
 	BrowserYahooBot // Bot list ends here
 )
 
+// StringTrimPrefix is like String() but trims the "Browser" prefix
+func (b BrowserName) StringTrimPrefix() string {
+	return strings.TrimPrefix(b.String(), "Browser")
+}
+
 // OSName (int) returns a constant.
 type OSName int
 
@@ -91,6 +101,11 @@ const (
 	OSBot
 )
 
+// StringTrimPrefix is like String() but trims the "OS" prefix
+func (o OSName) StringTrimPrefix() string {
+	return strings.TrimPrefix(o.String(), "OS")
+}
+
 // Platform (int) returns a constant.
 type Platform int
 
@@ -113,6 +128,11 @@ const (
 	PlatformNintendo
 	PlatformBot
 )
+
+// StringTrimPrefix is like String() but trims the "Platform" prefix
+func (p Platform) StringTrimPrefix() string {
+	return strings.TrimPrefix(p.String(), "Platform")
+}
 
 type Version struct {
 	Major int

--- a/uasurfer_test.go
+++ b/uasurfer_test.go
@@ -1087,3 +1087,36 @@ func BenchmarkParseSafariiPad(b *testing.B) {
 		Parse("Mozilla/5.0 (iPad; CPU OS 8_1_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B440 Safari/600.1.4")
 	}
 }
+
+func TestStringTrimPrefix(t *testing.T) {
+	testCases := []struct {
+		f        func() string
+		expected string
+	}{
+		{
+			f:        DeviceUnknown.StringTrimPrefix,
+			expected: "Unknown",
+		},
+		{
+			f:        BrowserUnknown.StringTrimPrefix,
+			expected: "Unknown",
+		},
+		{
+			f:        OSUnknown.StringTrimPrefix,
+			expected: "Unknown",
+		},
+		{
+			f:        PlatformUnknown.StringTrimPrefix,
+			expected: "Unknown",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			s := tc.f()
+			if tc.expected != s {
+				t.Fatalf("Expected %q, got %q", tc.expected, s)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This allows converting types to their string representation while
removing the type prefix.

For example BrowserUnknown will be "Unkown" rather than "BrowserUnknown"

https://github.com/avct/uasurfer/issues/39