### PR TITLE
fix detect for ios (DeviceAtlas compatibility)

### DIFF
--- a/system.go
+++ b/system.go
@@ -31,21 +31,21 @@ func (u *UserAgent) evalOS(ua string) bool {
 	}
 
 	//strict OS & version identification
-	switch specs {
-	case "android":
+	switch {
+	case specs == "android":
 		u.evalLinux(ua, agentPlatform)
 
-	case "bb10", "playbook":
+	case specs == "bb10" || specs == "playbook":
 		u.OS.Platform = PlatformBlackberry
 		u.OS.Name = OSBlackberry
 
-	case "x11", "linux":
+	case specs == "x11" || specs == "linux":
 		u.evalLinux(ua, agentPlatform)
 
-	case "ipad", "iphone", "ipod touch", "ipod":
+	case strings.HasPrefix(specs, "ipad") || strings.HasPrefix(specs, "iphone") || strings.HasPrefix(specs, "ipod touch") || strings.HasPrefix(specs, "ipod"):
 		u.evaliOS(specs, agentPlatform)
 
-	case "macintosh":
+	case specs == "macintosh":
 		u.evalMacintosh(ua)
 
 	default:
@@ -160,21 +160,21 @@ func (u *UserAgent) evalLinux(ua string, agentPlatform string) {
 // 'ipad' or 'iphone' listed as their platform.
 func (u *UserAgent) evaliOS(uaPlatform string, agentPlatform string) {
 
-	switch uaPlatform {
+	switch {
 	// iPhone
-	case "iphone":
+	case strings.HasPrefix(uaPlatform, "iphone"):
 		u.OS.Platform = PlatformiPhone
 		u.OS.Name = OSiOS
 		u.OS.getiOSVersion(agentPlatform)
 
 	// iPad
-	case "ipad":
+	case strings.HasPrefix(uaPlatform, "ipad"):
 		u.OS.Platform = PlatformiPad
 		u.OS.Name = OSiOS
 		u.OS.getiOSVersion(agentPlatform)
 
 	// iPod
-	case "ipod touch", "ipod":
+	case strings.HasPrefix(uaPlatform, "ipod touch") || strings.HasPrefix(uaPlatform, "ipod"):
 		u.OS.Platform = PlatformiPod
 		u.OS.Name = OSiOS
 		u.OS.getiOSVersion(agentPlatform)

--- a/uasurfer_test.go
+++ b/uasurfer_test.go
@@ -31,6 +31,10 @@ var testUAVars = []struct {
 		UserAgent{
 			Browser{BrowserSafari, Version{8, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{8, 0, 2}}, DevicePhone}},
 
+	{"Mozilla/5.0 (iPhone10,3; CPU iPhone OS 8_0_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12A405 Safari/600.1.4",
+		UserAgent{
+			Browser{BrowserSafari, Version{8, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{8, 0, 2}}, DevicePhone}},
+
 	// iPad
 	{"Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10",
 		UserAgent{


### PR DESCRIPTION
Device Atlas (device detection solution) is recomended to modify iOS's useragent like following(including device model):
｀Mozilla/5.0 (iPhone10,1; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148｀

uasurfer detects this as UnknownPlatform.
｀&{{BrowserSafari {0 0 0}} {PlatformUnknown OSUnknown {0 0 0}} DevicePhone}｀

So then, check prefix instead of matching full phrase.

about DeviceAtlas:
https://deviceatlas.com/