### PR TITLE
cmd/uastats: Rename package.

### DIFF
--- a/cmd/uastats/main.go
+++ b/cmd/uastats/main.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"text/tabwriter"
 
-	"code.avct.io/uasurfer"
+	"github.com/avct/uasurfer"
 )
 
 func main() {


### PR DESCRIPTION
We use code.avct.io internally but most external users will most likely
use github.com/avct. As this package has been open sourced it makes
sense to rename it.