### PR TITLE
Get browser names, get device types, get OS names, get OS platform names functions

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -18,6 +18,28 @@ import (
 // 		}
 // }
 
+// Return all valid browser names
+func GetBrowserNames() []string {
+	return []string{
+		"BrowserChrome",
+		"BrowserSafari",
+		"BrowserIE",
+		"BrowserFirefox",
+		"BrowserAndroid",
+		"BrowserOpera",
+		"BrowserUCBrowser",
+		"BrowserSilk",
+		"BrowserQQ",
+		"BrowserSpotify",
+		"BrowserBlackberry",
+		"BrowserYandex",
+		"BrowserNintendo",
+		"BrowserSamsung",
+		"BrowserCocCoc",
+		"BrowserUnknown",
+	}
+}
+
 // Retrieve browser name from UA strings
 func (u *UserAgent) evalBrowserName(ua string) bool {
 	// Blackberry goes first because it reads as MSIE & Safari

--- a/device.go
+++ b/device.go
@@ -4,6 +4,19 @@ import (
 	"strings"
 )
 
+// Return all valid device types
+func GetDeviceTypes() []string {
+	return []string{
+		"DeviceComputer",
+		"DevicePhone",
+		"DeviceTablet",
+		"DeviceTV",
+		"DeviceConsole",
+		"DeviceWearable",
+		"DeviceUnknown",
+	}
+}
+
 func (u *UserAgent) evalDevice(ua string) {
 	switch {
 

--- a/system.go
+++ b/system.go
@@ -10,6 +10,41 @@ var (
 	amazonFireFingerprint = regexp.MustCompile("\\s(k[a-z]{3,5}|sd\\d{4}ur)\\s") //tablet or phone
 )
 
+// Return all valid OS names
+func GetOSNames() []string {
+	return []string{
+		"OSWindows",
+		"OSMacOSX",
+		"OSiOS",
+		"OSAndroid",
+		"OSChromeOS",
+		"OSWebOS",
+		"OSLinux",
+		"OSPlaystation",
+		"OSXbox",
+		"OSNintendo",
+		"OSUnknown",
+	}
+}
+
+// Return all valid OS platform names
+func GetOSPlatformNames() []string {
+	return []string{
+		"PlatformWindows",
+		"PlatformMac",
+		"PlatformLinux",
+		"PlatformiPad",
+		"PlatformiPhone",
+		"PlatformBlackberry",
+		"PlatformWindowsPhone",
+		"PlatformKindle",
+		"PlatformPlaystation",
+		"PlatformXbox",
+		"PlatformNintendo",
+		"PlatformUnknown",
+	}
+}
+
 func (u *UserAgent) evalOS(ua string) bool {
 	s := strings.IndexRune(ua, '(')
 	e := strings.IndexRune(ua, ')')


### PR DESCRIPTION
Adds simple functions that will return all of the valid names for browser names, device types, OS names and OS platform types.

This will be a useful addition to help developers easily get all the valid names as such functions exist in other user agent packages in other programming languages.

It should be added in the documentation that these functions will need to be updated if new names are added to the package.