### PR TITLE
Improved bot and CTV detection; better tests and fuzzing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ Thumbs.db
 # Dev Tools #
 ######################
 .vagrant
+# Fuzzing artefacts. A crasher belongs in a named test in the relevant
+# _test.go file, not in a generated seed file: see TestVersionParseOverflow,
+# which is what FuzzParse found here.
+testdata/fuzz/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,10 @@ explicit decision. Constants are append-only and must keep their values: callers
 persist them as ints. Internal naming, file layout and implementation are free to
 change.
 
-`BrowserBot`..`BrowserYahooBot` must stay a contiguous block at the end of the
-`BrowserName` list — `IsBot` is a range check over it.
+The bot constants must stay a contiguous block at the **end** of the
+`BrowserName` list: `IsBot` is a range check from `BrowserBot` to the terminator,
+so a non-bot appended after them silently becomes a bot.
+`TestBrowserNameStrings` pins the last one by name and fails if that happens.
 
 ## Naming
 
@@ -61,6 +63,23 @@ Every type here is a handful of ints, cheap to copy. So:
 `UserAgent.IsBot` is the one exception: it does not mutate but keeps its pointer
 receiver because it is exported and the API is frozen.
 
+## Bot markers
+
+`botMarkers` in `bot.go` is deliberately not a list of crawler names: the generic
+tokens (`bot` as a word, `spider`, `crawl`, `+http`) carry most of the recall, and
+a name is listed only when it is reported through its own constant or is too
+quiet to carry a generic token.
+
+A marker must be one **no real device can carry**. This is the whole discipline
+of the file, and it is easy to get wrong: `java/` looks like a server-side stack
+and is what J2ME feature phones announce; `whatsapp/` is the messenger as often
+as the link fetcher; `dalvik`, `cfnetwork` and `okhttp` carry real ad requests
+from real apps. `bot` needs its word check or the phone brand CUBOT matches.
+
+A marker that must be found in a browser-shaped agent also has to trip
+`botSuspect`, the cheap gate deciding who pays for the full scan; otherwise it is
+only ever reached through `parseBrowserName`'s default arm.
+
 ## Performance
 
 - **Avoid allocating where you reasonably can.** A parse currently costs one
@@ -79,6 +98,11 @@ receiver because it is exported and the API is frozen.
 
 ## Tests
 
+- **New non-trivial code ships with a test.** A branch, a loop, a table, a
+  parser, a boundary rule: if it can be wrong, something has to fail when it is.
+  Trivial one-liners and pure renames do not need one. This is not negotiable
+  per-change — it is the reason a twenty year old parser can still be refactored
+  at all.
 - A test lives in the `_test.go` file mirroring the implementation file it
   covers. `device.go` → `device_test.go`. Never create catch-all test files.
 - Non-trivial logic leaves a runnable check behind. When hand rolling a
@@ -86,7 +110,27 @@ receiver because it is exported and the API is frozen.
   compare differentially — see `TestIsAmazonFire` against the regexp it replaced.
 - When correctness depends on an invariant, assert the invariant, not just the
   behaviour: `TestIPadScreenSizesAreLandscape` guards the table ordering that
-  `isiPad` relies on.
+  `isiPad` relies on, and `TestBotMarkersAreIndexed` guards the index `botName`
+  reads, where a mis-bucketed marker is simply never tried.
+- Anything that walks untrusted input by index belongs in `FuzzParse`'s
+  properties rather than in another table of hand-picked strings. CI fuzzes for a
+  minute per run; a crash found there is written to `testdata/fuzz` and becomes a
+  permanent seed.
+
+### Fixtures
+
+Fixture sets of real agents live in `testdata/` and are documented in
+[doc/fixtures.md](doc/fixtures.md). Two rules matter when touching them:
+
+- A row is a claim about what an agent *means*, not a snapshot of current output.
+  When a change makes one fail, work out which of the two is wrong first. Test
+  suites that were regenerated to match a bug are how parsers rot.
+- Sources must be permissively licensed (MIT, BSD, Apache-2.0) and credited in
+  `testdata/NOTICE.md`. Take agent strings, never another parser's labels: those
+  are its judgement in its categories, and copying them imports both.
+- `botRecallFloor` in `bot_test.go` is the share of the bot fixture set detected.
+  Raise it when detection improves; lowering it to make a change pass is how a
+  detector rots.
 
 ### Enum terminators
 
@@ -103,6 +147,13 @@ not that they match a golden list. Uniqueness is what makes that sufficient:
 `String()` has no numeric fallback, so a constant with no `case` falls into the
 default arm and repeats the Unknown name, and the duplicate gives it away. The
 same check catches two cases returning the same name by copy-paste.
+
+## Documentation
+
+`README.md` stays short: what the package is, the API, the honest caveats, and
+links out. Lists and special topics live in `doc/<topic>.md` — the constant
+lists, bot detection, connected TV, fixtures. A new constant goes in the relevant
+`doc/` file, not the README.
 
 ## Tooling
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/LumenResearch/uasurfer.svg?branch=master)](https://travis-ci.org/LumenResearch/uasurfer)  [![GoDoc](https://godoc.org/github.com/LumenResearch/uasurfer?status.svg)](https://godoc.org/github.com/LumenResearch/uasurfer)  [![Go Report Card](https://goreportcard.com/badge/github.com/LumenResearch/uasurfer)](https://goreportcard.com/report/github.com/LumenResearch/uasurfer)
+[![Go](https://github.com/LumenResearch/uasurfer/actions/workflows/test.yaml/badge.svg)](https://github.com/LumenResearch/uasurfer/actions/workflows/test.yaml) [![Go Reference](https://pkg.go.dev/badge/github.com/LumenResearch/uasurfer.svg)](https://pkg.go.dev/github.com/LumenResearch/uasurfer)  [![Go Report Card](https://goreportcard.com/badge/github.com/LumenResearch/uasurfer)](https://goreportcard.com/report/github.com/LumenResearch/uasurfer)
 
 # uasurfer
 
@@ -8,32 +8,49 @@
 
 The following information is returned by uasurfer from a raw HTTP User-Agent string:
 
-| Name           | Example | Coverage in 192,792 parses |
-|----------------|---------|--------------------------------|
-| Browser name    | `chrome` | 99.85%                         |
-| Browser version | `53` | 99.17%                         |
-| Platform       | `ipad`  | 99.97%                         |
-| OS name         | `ios`  | 99.96%                         |
-| OS version      | `10`   | 98.81%                         |
-| Device type    |  `tablet` | 99.98%                         |
+| Name | Example |
+|---|---|
+| Browser name | `chrome` |
+| Browser version | `53` |
+| Platform | `ipad` |
+| OS name | `ios` |
+| OS version | `10` |
+| Device type | `tablet` |
+| Bot | `false` |
 
-Layout engine, browser language, and other esoteric attributes are not parsed.
+Layout engine, browser language, device brand and device model are not parsed.
 
-Coverage is estimated from a random sample of real UA strings collected across thousands of sources in US and EU mid-2016.
+Mainstream desktop and mobile are effectively solved. Two caveats are worth
+knowing before relying on a field:
+
+* **Android phone versus tablet** is not always decidable, because vendors ship
+  tablets that announce `Mobile`. An Android agent with no tablet indicator
+  defaults to a phone.
+* **Bot detection** trades the long tail for a name table nobody has to
+  maintain: it catches 83% of a 1,975 agent crawler fixture set with no false
+  positive across 2,906 real device agents. See [doc/bots.md](doc/bots.md).
+* **Chrome's user agent reduction** hollowed out several fields at the source.
+  Chromium browsers report a frozen `10.15.7` for macOS, NT 10.0 for both
+  Windows 10 and 11, `Android 10` on every Android device, and `0` for every
+  version component below the major. No parser can recover these from the agent.
 
 ## Usage
 
 ### Parse(ua string) Function
 
-The `Parse()` function accepts a user agent `string` and returns UserAgent struct with named constants and integers for versions (minor, major and patch separately), and the full UA string that was parsed (lowercase). A string can be retrieved by adding `.String()` to a variable, such as `uasurfer.BrowserName.String()`.
+The `Parse()` function accepts a user agent `string` and returns a `*UserAgent`, with named constants for the browser, OS, platform and device, and integers for versions (major, minor and patch separately). A string can be retrieved by adding `.String()` to a variable, such as `uasurfer.BrowserName.String()`, or `.StringTrimPrefix()` to drop the type name.
 
-```
+```go
 // Define a user agent string
 myUA := "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.85 Safari/537.36"
 
-// Parse() returns all attributes, including returning the full UA string last
-ua, uaString := uasurfer.Parse(myUA)
+ua := uasurfer.Parse(myUA)
 ```
+
+For a request loop, `ParseUserAgent(ua string, dest *UserAgent)` fills a
+`UserAgent` the caller owns; call `Reset()` before reusing one. `ParseWithHints`
+takes a `Hints` struct carrying what the agent cannot say for itself - today the
+screen size, which is how an iPad in desktop mode is told apart from a Mac.
 
 where example UserAgent is:
 ```
@@ -61,60 +78,37 @@ where example UserAgent is:
 
 **Usage note:** There are some OSes that do not return a version, see docs below. Linux is typically not reported with a specific Linux distro name or version.
 
-#### Browser Name
-* `BrowserChrome` - Google [Chrome](https://en.wikipedia.org/wiki/Google_Chrome), [Chromium](https://en.wikipedia.org/wiki/Chromium_(web_browser))
-* `BrowserSafari` - Apple [Safari](https://en.wikipedia.org/wiki/Safari_(web_browser)), Google Search ([GSA](https://itunes.apple.com/us/app/google/id284815942))
-* `BrowserIE` - Microsoft [Internet Explorer](https://en.wikipedia.org/wiki/Internet_Explorer), [Edge](https://en.wikipedia.org/wiki/Microsoft_Edge)
-* `BrowserFirefox` - Mozilla [Firefox](https://en.wikipedia.org/wiki/Firefox), GNU [IceCat](https://en.wikipedia.org/wiki/GNU_IceCat), [Iceweasel](https://en.wikipedia.org/wiki/Mozilla_Corporation_software_rebranded_by_the_Debian_project#Iceweasel), [Seamonkey](https://en.wikipedia.org/wiki/SeaMonkey)
-* `BrowserAndroid` - Android [WebView](https://developer.chrome.com/multidevice/webview/overview) (Android OS <4.4 only)
-* `BrowserOpera` - [Opera](https://en.wikipedia.org/wiki/Opera_(web_browser))
-* `BrowserUCBrowser` - [UC Browser](https://en.wikipedia.org/wiki/UC_Browser)
-* `BrowserSilk` - Amazon [Silk](https://en.wikipedia.org/wiki/Amazon_Silk)
-* `BrowserQQ` - Tencent [QQ](https://en.wikipedia.org/wiki/Tencent_QQ)
-* `BrowserSpotify` - [Spotify](https://en.wikipedia.org/wiki/Spotify#Clients) desktop client
-* `BrowserBlackberry` - RIM [BlackBerry](https://en.wikipedia.org/wiki/BlackBerry)
-* `BrowserYandex` - [Yandex](https://en.wikipedia.org/wiki/Yandex_Browser)
-* `BrowserNintendo` - [Nintendo DS(i) Browser](https://en.wikipedia.org/wiki/Nintendo_DS_%26_DSi_Browser)
-* `BrowserSamsung` - [Samsung Internet](https://en.wikipedia.org/wiki/Samsung_Internet_for_Android)
-* `BrowserCocCoc`- [Cốc Cốc](https://en.wikipedia.org/wiki/C%E1%BB%91c_C%E1%BB%91c)
-* `BrowserUnknown` - Unknown
+#### Constants
+
+The full lists of `BrowserName`, `OSName`, `Platform` and `DeviceType` constants
+live in the package reference:
+[`BrowserName`](https://pkg.go.dev/github.com/LumenResearch/uasurfer#BrowserName),
+[`OSName`](https://pkg.go.dev/github.com/LumenResearch/uasurfer#OSName),
+[`Platform`](https://pkg.go.dev/github.com/LumenResearch/uasurfer#Platform),
+[`DeviceType`](https://pkg.go.dev/github.com/LumenResearch/uasurfer#DeviceType).
+Grouping worth knowing about:
+
+* `BrowserChrome` covers Chromium and Android WebView 4.4 or newer.
+* `BrowserIE` covers Edge as well, including Chromium Edge; version >= 79 is how
+  you tell them apart.
+* `BrowserFirefox` covers IceCat, Iceweasel and SeaMonkey.
+* `BrowserSafari` covers the Google Search app on iOS, which is Safari in
+  disguise.
+* Crawlers have their own constants and their own document: see
+  [doc/bots.md](doc/bots.md).
 
 #### Browser Version
 
-Browser version returns an `unint8` of the major version attribute of the User-Agent String. For example Chrome 45.0.23423 would return `45`. The intention is to support math operators with versions, such as "do XYZ for Chrome version >23".
+Browser version is a `Version{Major, Minor, Patch}` of ints. For example Chrome
+45.0.23423 gives `{45, 0, 23423}`, so `ua.Browser.Version.Major > 23` is the
+usual test. Versions compare with `Less`: `if ver1.Less(ver2) {}`.
 
-Unknown version is returned as `0`.
-
-#### Platform
-* `PlatformWindows` - Microsoft Windows
-* `PlatformMac` - Apple Macintosh
-* `PlatformLinux` - Linux, including Android and other OSes
-* `PlatformiPad` - Apple iPad
-* `PlatformiPhone` - Apple iPhone
-* `PlatformBlackberry` - RIM Blackberry
-* `PlatformWindowsPhone` Microsoft Windows Phone & Mobile
-* `PlatformKindle` - Amazon Kindle & Kindle Fire
-* `PlatformPlaystation` - Sony Playstation, Vita, PSP
-* `PlatformXbox` - Microsoft Xbox
-* `PlatformNintendo` - Nintendo DS, Wii, etc.
-* `PlatformUnknown` - Unknown
-
-#### OS Name
-* `OSWindows`
-* `OSMacOSX` - includes "macOS Sierra"
-* `OSiOS`
-* `OSAndroid`
-* `OSChromeOS`
-* `OSWebOS`
-* `OSLinux`
-* `OSPlaystation`
-* `OSXbox`
-* `OSNintendo`
-* `OSUnknown`
+An unknown version is `{0, 0, 0}`. Chromium browsers now report `0` for
+everything below the major version, whatever they are actually running.
 
 #### OS Version
 
-OS X major version is always 10 for releases prior to Big Sur with consecutive minor versions indicating release releases (10 - Yosemite, 11 - El Capitain, 12 Sierra, etc). macOS Big Sur is indicated as `{11, 1, 0}`. Windows version is NT version. `Version{0, 0, 0}` indicated version is unknown or not evaluated.
+OS X major version is always 10 for releases prior to Big Sur with consecutive minor versions indicating releases (10 - Yosemite, 11 - El Capitan, 12 Sierra, etc). macOS Big Sur is indicated as `{11, 1, 0}`, though Chrome and Firefox freeze what they report at `10.15.7` whatever the machine runs. Windows version is the NT version. `Version{0, 0, 0}` means the version is unknown or not evaluated.
 Versions can be compared using `Less` function: `if ver1.Less(ver2) {}`
 
 Here are some examples across the platform, os.name, and os.version:
@@ -137,45 +131,35 @@ Here are some examples across the platform, os.name, and os.version:
 Windows 95, 98, and ME represent 0.01% of traffic worldwide and are not available through this package at this time.
 
 #### DeviceType
-DeviceType is typically quite accurate, though determining between phones and tablets on Android is not always possible due to how some vendors design their UA strings. A mobile Android device without tablet indicator defaults to being classified as a phone. DeviceTV supports major brands such as Philips, Sharp, Vizio and steaming boxes such as Apple, Google, Roku, Amazon.
+DeviceType is typically quite accurate, though determining between phones and tablets on Android is not always possible due to how some vendors design their UA strings. A mobile Android device without a tablet indicator defaults to being classified as a phone.
 
-* `DeviceComputer`
-* `DevicePhone`
-* `DeviceTablet`
-* `DeviceTV`
-* `DeviceConsole`
-* `DeviceWearable`
-* `DeviceUnknown`
+`DeviceTV` covers the major TV brands and the streaming sticks and boxes from
+Apple, Google, Roku and Amazon, most of which also report an OS of their own:
+see [doc/tv.md](doc/tv.md).
 
 ## Example Combinations of Attributes
 * Surface RT -> `OSWindows8`, `DeviceTablet`, OSVersion >= `6`
 * Android Tablet -> `OSAndroid`, `DeviceTablet`
 * Microsoft Edge -> `BrowserIE`, BrowserVersion >= `12.0.0`
 
-## To do
+## Deliberately not supported
 
-* Remove compiled regexp in favor of string.Contains wherever possible (lowers mem/alloc)
-* Better version support on Firefox derivatives (e.g. SeaMonkey)
-* Potential additional browser support:
- * "NetFront" (1% share in India)
- * "Sogou Explorer" (5% share in China)
- * "Maxthon" (1.5% share in China)
- * "Nokia"
-* Potential additional OS support:
- * "Nokia" (5% share in India)
- * "Series 40" (5.5% share in India)
- * Windows 2003 Server
-* iOS safari browser identification based on iOS version
-* Add android version to browser identification
-* old Macs
- * "opera/9.64 (macintosh; ppc mac os x; u; en) presto/2.1.1"
-* old Windows
- * "mozilla/5.0 (windows nt 4.0; wow64) applewebkit/537.36 (khtml, like gecko) chrome/37.0.2049.0 safari/537.36"
+Device brand and model, layout engine, CPU architecture and browser language.
+Naming every Chromium skin (Vivaldi, Whale, MIUI, Huawei) and every in-app
+webview (Facebook, Instagram, WeChat) is not done either: those report as the
+engine they are. Client hints beyond the screen size are not read yet, which is
+what the frozen version fields above would need.
 
 ## Adding new user agents
 
 1. Source user agent strings which identify a device type, system or a browser you want to add
 2. Identify a unique part of the user agent string which identifies a device
 3. Add a condition to a switch statement inside `browser.go`, `device.go` or `system.go`
+4. Add rows to the fixture sets in `testdata/` that fail without the change
 
 For example, to identify a Google TV user agent as device type TV, we identify that all user agents contain "googletv" string and we add `strings.Contains(ua, "googletv")` to the `device.go` switch condition for identifying TVs.
+
+Before opening a PR: `gofmt -l .`, `go vet ./...`, `golangci-lint run ./...`,
+`go test ./...`, and for anything on the parse path, before-and-after medians
+from `go test -run=XXX -bench=Parse -benchmem -count=6`. `CLAUDE.md` has the
+conventions in full.

--- a/bot.go
+++ b/bot.go
@@ -1,0 +1,347 @@
+package uasurfer
+
+import (
+	"slices"
+	"strings"
+)
+
+// botMarker is a substring that identifies a bot, and the name to report for
+// it. A named crawler keeps its own constant; everything else reports as the
+// generic BrowserBot.
+type botMarker struct {
+	s    string
+	name BrowserName
+
+	// word requires s to stand as a word of its own rather than as letters
+	// inside a longer one; see isBotWord.
+	word bool
+}
+
+// botMarkers is deliberately not a list of crawler names. Keeping one entry per
+// crawler is how the other parsers end up shipping (and having to maintain) a
+// thousand of them; the generic tokens below - "bot" as a word, "spider",
+// "crawl", "+http" - carry most of the recall on their own, and a name is only
+// listed when it is either reported through its own constant or too quiet to
+// carry a generic token.
+//
+// A marker is only added when it cannot plausibly appear in a real browser's
+// agent. That rules out the tokens of non-browser clients that are still real
+// devices with a real person behind them: dalvik, cfnetwork, okhttp and friends
+// are app HTTP stacks, not crawlers.
+var botMarkers = []botMarker{
+	// generic. These carry roughly nine of every ten bots we detect.
+	{s: "bot", word: true},
+	{s: "spider"},
+	{s: "crawl"},
+	{s: "+http"}, // the contact URL convention, near universal among crawlers
+
+	// named crawlers, reported through their own constant
+	{s: "applebot", name: BrowserAppleBot},
+	{s: "baiduspider", name: BrowserBaiduBot},
+	{s: "adidxbot", name: BrowserBingBot},
+	{s: "bingbot", name: BrowserBingBot},
+	{s: "bingpreview", name: BrowserBingBot},
+	{s: "msnbot", name: BrowserMsnBot},
+	{s: "duckduckbot", name: BrowserDuckDuckGoBot},
+	{s: "facebookexternalhit", name: BrowserFacebookBot},
+	{s: "facebot", name: BrowserFacebookBot},
+	{s: "linkedinbot", name: BrowserLinkedInBot},
+	{s: "twitterbot", name: BrowserTwitterBot},
+	{s: "pingdom", name: BrowserPingdomBot}, // also PingdomTMS
+	{s: "coccocbot", name: BrowserCocCocBot},
+	{s: "yandexbot", name: BrowserYandexBot},
+	{s: "yadirectfetcher", name: BrowserYandexBot},
+
+	// Yahoo, by token rather than by the bare vendor name: "yahoo" on its own
+	// also appears in Yahoo Japan's apps and in the portal agents of Japanese
+	// TVs, 46 of which read as a crawler in the corpus before this.
+	{s: "slurp", name: BrowserYahooBot},
+	{s: "y!j", name: BrowserYahooBot}, // Yahoo Japan's crawler fleet
+	{s: "yahoocachesystem", name: BrowserYahooBot},
+	{s: "yahoomailproxy", name: BrowserYahooBot},
+	{s: "yahoo ad monitoring", name: BrowserYahooBot},
+	{s: "yahoo link preview", name: BrowserYahooBot},
+
+	// Google runs a fleet: the crawler, the ads crawlers, the inspection and
+	// verification agents. Only "googlebot" carries the generic token.
+	{s: "googlebot", name: BrowserGoogleBot},
+	{s: "adsbot-google", name: BrowserGoogleBot},
+	{s: "mediapartners-google", name: BrowserGoogleBot},
+	{s: "googleother", name: BrowserGoogleBot},
+	{s: "google-inspectiontool", name: BrowserGoogleBot},
+	{s: "feedfetcher-google", name: BrowserGoogleBot},
+	{s: "apis-google", name: BrowserGoogleBot},
+	{s: "google-read-aloud", name: BrowserGoogleBot},
+	{s: "google-safety", name: BrowserGoogleBot},
+
+	// AI crawlers. Named because they are the fastest growing share of crawl
+	// traffic and callers ask about them by name; the smaller ones (ai2bot,
+	// timpibot, youbot, imagesiftbot, ...) stay generic.
+	{s: "gptbot", name: BrowserOpenAIBot},
+	{s: "chatgpt-user", name: BrowserOpenAIBot},
+	{s: "oai-searchbot", name: BrowserOpenAIBot},
+	{s: "claudebot", name: BrowserAnthropicBot},
+	{s: "claude-web", name: BrowserAnthropicBot},
+	{s: "claude-user", name: BrowserAnthropicBot},
+	{s: "claude-searchbot", name: BrowserAnthropicBot},
+	{s: "anthropic-ai", name: BrowserAnthropicBot},
+	{s: "perplexitybot", name: BrowserPerplexityBot},
+	{s: "perplexity-user", name: BrowserPerplexityBot},
+	{s: "amazonbot", name: BrowserAmazonBot},
+	{s: "bytespider", name: BrowserBytedanceBot},
+	{s: "ccbot", name: BrowserCommonCrawlBot},
+
+	// Meta's AI crawler and its link preview fetcher are one company, so they
+	// share the constant that facebookexternalhit already uses.
+	{s: "meta-externalagent", name: BrowserFacebookBot},
+	{s: "meta-externalfetcher", name: BrowserFacebookBot},
+
+	// SEO and market intelligence crawlers. High volume: on many sites these
+	// two alone outweigh every AI crawler put together.
+	{s: "ahrefsbot", name: BrowserAhrefsBot},
+	{s: "semrushbot", name: BrowserSemrushBot},
+	{s: "petalbot", name: BrowserPetalBot}, // Huawei's crawler, PetalSearch
+
+	// generic AI and aggregator agents that carry no token of their own
+	{s: "cohere-ai"},
+	{s: "omgili"},
+	{s: "webzio-extended"},
+
+	// automation and headless browsers: a real engine, but nobody is watching
+	{s: "headless"},
+	{s: "puppeteer"},
+	{s: "playwright"},
+	{s: "selenium"},
+	{s: "webdriver"},
+	{s: "phantomjs"},
+	{s: "lighthouse"},
+	{s: "pagespeed"},
+	{s: "gtmetrix"},
+
+	// HTTP clients and scripting stacks. Server side only: an agent that names
+	// one of these is a script, never a browser.
+	//
+	// Deliberately absent: java/, which J2ME feature phones announce
+	// ("Java/HWJa/1.0"), and the app HTTP stacks - dalvik, cfnetwork, okhttp -
+	// which carry ad requests from real apps on real devices.
+	{s: "curl/"},
+	{s: "wget"},
+	{s: "python-requests"},
+	{s: "urllib"},
+	{s: "aiohttp"},
+	{s: "httpx/"},
+	{s: "scrapy"},
+	{s: "go-http-client"},
+	{s: "axios/"},
+	{s: "node-fetch"},
+	{s: "guzzle"},
+	{s: "libwww-perl"},
+	{s: "lwp::"},
+	{s: "apache-httpclient"},
+	{s: "httpclient"},
+	{s: "restsharp"},
+	{s: "postmanruntime"},
+	{s: "insomnia/"},
+	{s: "powershell"},
+	{s: "winhttp"},
+	{s: "wordpress/"},
+
+	// What a tool calls itself. These are the -er and -ing forms on purpose: an
+	// agent naming itself a scanner or a checker is describing a job, where the
+	// bare verb is a word a device or an app can carry - "scan" is a document
+	// scanner app, "check" could be anything, and "reader/" is BaconReader on a
+	// Nexus 4.
+	{s: "checker"},
+	{s: "checklink"},
+	{s: "sitecheck"},
+	{s: "linkcheck"},
+	{s: "deadlink"},
+	{s: "monitoring"},
+	{s: "uptime"},
+	{s: "scanner"},
+	{s: "scraper"},
+	{s: "scrape"},
+	{s: "analyzer"},
+	{s: "auditor"},
+	{s: "verifier"},
+	{s: "inspector"},
+	{s: "extractor"},
+	{s: "harvester"},
+	{s: "collector"},
+	{s: "indexer"},
+	{s: "downloader"},
+	{s: "parser"},
+	{s: "preview"},
+	{s: "robot"},
+	{s: "synthetic"},
+	{s: "seo"},
+
+	// Named tools and services whose agents carry nothing else to go on, each
+	// seen repeatedly in the fixture set rather than guessed at.
+	{s: "ptst"},      // WebPageTest
+	{s: "ips-agent"}, // Trustwave
+	{s: "statuscake"},
+	{s: "binlar"},
+	{s: "siteimprove"},
+	{s: "hatena"},
+	{s: "newspaper"}, // the Python article scraper
+	{s: "feedparser"},
+	{s: "nutch"},
+	{s: "heritrix"},
+
+	// link expanders, feed readers, monitors and validators
+	{s: "fetcher"},
+	{s: "archiver"},
+	{s: "validator"},
+	{s: "skypeuripreview"},
+	// whatsapp/ is absent: the link preview fetcher and the messenger app on a
+	// real handset both announce "WhatsApp/<version>".
+	{s: "embedly"},
+	{s: "vkshare"},
+	{s: "datadog"},
+}
+
+// botBuckets indexes botMarkers by first byte, longest marker first, so that a
+// named crawler wins over the generic token inside it.
+//
+// botDigrams is the gate in front of that: a bitmap of the 65536 possible byte
+// pairs, with a bit set for each pair that starts a marker. One pair test per
+// position rejects almost every byte of a real agent outright, which is what
+// makes a single pass over the agent affordable on every parse - indexing by
+// first byte alone was not, because the first bytes of a hundred markers cover
+// most of the alphabet and every other byte then walked a bucket.
+var botBuckets, botDigrams = func() (buckets [256][]botMarker, digrams [1024]uint64) {
+	for _, m := range botMarkers {
+		buckets[m.s[0]] = append(buckets[m.s[0]], m)
+		if len(m.s) >= 2 {
+			k := uint16(m.s[0])<<8 | uint16(m.s[1])
+			digrams[k>>6] |= 1 << (k & 63)
+		}
+	}
+	for c := range buckets {
+		slices.SortFunc(buckets[c], func(a, b botMarker) int { return len(b.s) - len(a.s) })
+	}
+	return
+}()
+
+// isBotWord reports whether ua[start:end] is a name in its own right rather than
+// letters inside a longer word. It exists for the "bot" marker, where the
+// difference decides whether a phone is a crawler.
+//
+// Punctuation, a digit or the end of the agent after it is where a crawler puts
+// its version or contact URL: "googlebot/2.1", "PetalBot;", "Discordbot". A
+// space after it only counts when the token also starts a word, which is what
+// separates the crawler writing its name as two words - "ContextAd Bot 1.0" -
+// from the phone brand "CUBOT GT99". A letter after it is never a match, or the
+// Italian bank "Banca Caboto" in an old IE agent reads as a crawler.
+func isBotWord(ua string, start, end int) bool {
+	if end == len(ua) {
+		return true
+	}
+	if c := ua[end]; c != ' ' {
+		return !isLower(c)
+	}
+	return start == 0 || !isLower(ua[start-1])
+}
+
+// hasContactURL reports whether ua publishes a URL as a field of its own.
+//
+// Consulted only for agents that named no browser at all, where it is the
+// crawler convention of pointing at a page that explains the crawl. A browser
+// has no reason to carry one, and neither does an app SDK; a crawler that has
+// bothered with a contact URL is announcing itself as clearly as one calling
+// itself a bot.
+//
+// The URL has to follow a field edge. A proxy that rewrites the agent can leave
+// the whole string starting with one, and that agent still belongs to whatever
+// device sat behind the proxy.
+func hasContactURL(ua string) bool {
+	for _, m := range [...]string{"http://", "https://", "www."} {
+		for i := 0; i < len(ua); {
+			j := strings.Index(ua[i:], m)
+			if j < 0 {
+				break
+			}
+			at := i + j
+			if at > 0 && isURLEdge(ua[at-1]) {
+				return true
+			}
+			i = at + len(m)
+		}
+	}
+	return false
+}
+
+// isURLEdge reports whether c can precede a contact URL: whitespace, or the
+// punctuation an agent uses to open a field.
+func isURLEdge(c byte) bool {
+	switch c {
+	case '(', ';', ',', '+', '[', '<', '"', '\'':
+		return true
+	}
+	return isSpace(c)
+}
+
+// botSuspect reports whether ua is worth a full botName pass.
+//
+// botName walks the agent, and at roughly a nanosecond and a half per byte that
+// is more than the browser matching it precedes - paid on every parse, for
+// something almost no agent is. These five checks are each a single SIMD scan,
+// an order of magnitude cheaper per byte, and every crawler that disguises
+// itself as a browser trips at least one:
+//
+//   - '+' and "http", the contact URL conventions: "+http://example.com/bot.html"
+//     and the bare URL or mailto a crawler leaves in its agent
+//   - "bot", "spider", "crawl", the three names crawlers give themselves
+//   - "headless", for the automation stacks, which claim none of the above
+//
+// A crawler wearing no browser token needs no gate: nothing below matches it
+// either, so parseBrowserName's default arm runs the full pass instead. What
+// this does give up is the crawler that both wears a full browser agent and
+// names itself something quieter still - Chrome-Lighthouse, PTST, ips-agent.
+// See doc/bots.md.
+func botSuspect(ua string) bool {
+	return strings.IndexByte(ua, '+') >= 0 ||
+		strings.Contains(ua, "http") ||
+		strings.Contains(ua, "bot") ||
+		strings.Contains(ua, "spider") ||
+		strings.Contains(ua, "crawl") ||
+		strings.Contains(ua, "headless")
+}
+
+// botName returns the name to report for ua and whether it is a bot at all. It
+// runs before any browser matching, because crawlers copy whole browser agents
+// and append themselves: ClaudeBot carries a Chrome token and would otherwise
+// read as a person using Chrome.
+func botName(ua string) (BrowserName, bool) {
+	// A named crawler wins wherever it sits, so a generic hit is remembered
+	// rather than returned: "Mozilla/5.0 (seoanalyzer; compatible; bingbot/2.0)"
+	// is BingBot, not an anonymous bot that happened to say "seo" first. Only
+	// the generic case reads the whole agent, and only bots get that far.
+	generic := false
+	for i := 0; i+1 < len(ua); i++ {
+		k := uint16(ua[i])<<8 | uint16(ua[i+1])
+		if botDigrams[k>>6]&(1<<(k&63)) == 0 {
+			continue
+		}
+		for _, m := range botBuckets[ua[i]] {
+			if !strings.HasPrefix(ua[i:], m.s) {
+				continue
+			}
+			if m.word && !isBotWord(ua, i, i+len(m.s)) {
+				continue
+			}
+			// "like FeedFetcher-Google" is Feedly claiming a resemblance, the
+			// same move as "like Gecko". It is still a bot, just not that one.
+			if m.name != BrowserUnknown && !strings.HasSuffix(ua[:i], "like ") {
+				return m.name, true
+			}
+			generic = true
+			break
+		}
+	}
+	if generic {
+		return BrowserBot, true
+	}
+	return BrowserUnknown, false
+}

--- a/bot_test.go
+++ b/bot_test.go
@@ -1,0 +1,284 @@
+package uasurfer
+
+import (
+	"embed"
+	"strings"
+	"testing"
+)
+
+//go:embed testdata/bots.tsv testdata/devices.tsv testdata/tv.tsv
+var fixtures embed.FS
+
+// readFixtures returns the rows of a testdata file, "#" comments and blank
+// lines dropped, each row split on tabs.
+func readFixtures(t *testing.T, name string, fields int) [][]string {
+	t.Helper()
+
+	b, err := fixtures.ReadFile("testdata/" + name)
+	if err != nil {
+		t.Fatalf("reading %s: %v", name, err)
+	}
+
+	var rows [][]string
+	for i, line := range strings.Split(string(b), "\n") {
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		row := strings.Split(line, "\t")
+		if len(row) != fields {
+			t.Fatalf("%s line %d: got %d fields, want %d: %q", name, i+1, len(row), fields, line)
+		}
+		rows = append(rows, row)
+	}
+	if len(rows) == 0 {
+		t.Fatalf("%s: no fixtures", name)
+	}
+	return rows
+}
+
+// botRecallFloor is the share of testdata/bots.tsv we detect. It is a floor, not
+// a target: raise it when detection improves, and treat a change that pushes
+// recall below it as a regression to explain rather than a number to lower.
+const botRecallFloor = 0.82
+
+func TestBotFixtures(t *testing.T) {
+	rows := readFixtures(t, "bots.tsv", 2)
+
+	var detected int
+	for _, row := range rows {
+		want, agent := row[0], row[1]
+		ua := Parse(agent)
+		if ua.IsBot() {
+			detected++
+		}
+
+		if want == "!" {
+			// A known miss. Not asserted: catching one is an improvement, and
+			// the row should then be relabelled rather than left to fail.
+			if ua.IsBot() {
+				t.Logf("now detected, relabel this row from %q to %q: %s",
+					"!", ua.Browser.Name.StringTrimPrefix(), agent)
+			}
+			continue
+		}
+
+		if !ua.IsBot() {
+			t.Errorf("IsBot() = false, want true: %s", agent)
+			continue
+		}
+		if got := ua.Browser.Name.StringTrimPrefix(); got != want {
+			t.Errorf("browser = %s, want %s: %s", got, want, agent)
+		}
+		// A bot's OS and device are overwritten wholesale, so they are part of
+		// the claim: a caller filtering on either must not see a real device.
+		if ua.OS.Name != OSBot || ua.OS.Platform != PlatformBot || ua.DeviceType != DeviceComputer {
+			t.Errorf("bot defaults = %v/%v/%v, want bot/bot/computer: %s",
+				ua.OS.Platform, ua.OS.Name, ua.DeviceType, agent)
+		}
+	}
+
+	if recall := float64(detected) / float64(len(rows)); recall < botRecallFloor {
+		t.Errorf("bot recall = %.3f (%d/%d), below the floor of %.2f",
+			recall, detected, len(rows), botRecallFloor)
+	} else {
+		t.Logf("bot recall %.3f (%d/%d), floor %.2f", recall, detected, len(rows), botRecallFloor)
+	}
+}
+
+// The precision half of the bargain: generic tokens buy the recall above, and
+// this is what stops them costing a real device.
+func TestDeviceFixturesAreNotBots(t *testing.T) {
+	for _, row := range readFixtures(t, "devices.tsv", 2) {
+		want, agent := row[0], row[1]
+		ua := Parse(agent)
+		if ua.IsBot() {
+			t.Errorf("IsBot() = true, want false (%s): %s", ua.Browser.Name.StringTrimPrefix(), agent)
+			continue
+		}
+		if got := ua.DeviceType.StringTrimPrefix(); got != want {
+			t.Errorf("device = %s, want %s: %s", got, want, agent)
+		}
+	}
+}
+
+func TestBotName(t *testing.T) {
+	tests := []struct {
+		agent string
+		want  BrowserName
+	}{
+		// generic tokens
+		{"Mozilla/5.0 (compatible; SomeNewBot/1.0)", BrowserBot},
+		{"Mozilla/5.0 (compatible; Whatever/1.0; +http://example.com/robot)", BrowserBot},
+		{"SomeSpider/2.0", BrowserBot},
+		{"NewCrawler", BrowserBot},
+		{"curl/8.6.0", BrowserBot},
+		{"python-requests/2.32.3", BrowserBot},
+		{"Go-http-client/1.1", BrowserBot},
+
+		// a named crawler beats the generic token it contains
+		{"Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)", BrowserGoogleBot},
+		{"Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)", BrowserAhrefsBot},
+		{"Mozilla/5.0 (compatible; GPTBot/1.2; +https://openai.com/gptbot)", BrowserOpenAIBot},
+		{"AdsBot-Google (+http://www.google.com/adsbot.html)", BrowserGoogleBot},
+
+		// crawlers wearing a whole browser agent: the token can sit anywhere
+		{"Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; ClaudeBot/1.0; " +
+			"+claudebot@anthropic.com) Chrome/W.X.Y.Z Safari/537.36", BrowserAnthropicBot},
+		{"Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 " +
+			"(KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36 (compatible; " +
+			"Googlebot/2.1; +http://www.google.com/bot.html)", BrowserGoogleBot},
+		{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) " +
+			"HeadlessChrome/126.0.6478.61 Safari/537.36", BrowserBot},
+
+		// the "bot" word boundary
+		{"Mozilla/5.0 (Linux; Android 4.2.1; CUBOT ONE Build/JOP40D) AppleWebKit/537.36 " +
+			"(KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36", BrowserUnknown},
+		{"Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; Banca Caboto s.p.a.; rv:11.0) like Gecko",
+			BrowserUnknown},
+
+		// a name claimed by resemblance is not that crawler
+		{"TelegramBot (like TwitterBot)", BrowserBot},
+		{"Feedly/1.0 (+http://www.feedly.com/fetcher.html; like FeedFetcher-Google)", BrowserBot},
+		{"FreshRSS/1.11.2 (Linux; https://freshrss.org) like Googlebot", BrowserBot},
+
+		// a named crawler wins wherever in the agent it sits
+		{"Mozilla/5.0 (seoanalyzer; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)", BrowserBingBot},
+
+		// vendor tokens that belong to apps rather than crawlers
+		{"YahooJMobileApp/1.1 (Android emg; 1.3.4) (samsung; SC-02E; samsung; SC-02E; 4.1.1/JRO03C)",
+			BrowserUnknown},
+		{"WhatsApp/2.11.102 Android/2.3.3 Device/HTC-HTC_Wildfire", BrowserUnknown},
+		{"HuaweiU3100/B000 Browser/Obigo-Browser/Q05A Java/HWJa/2.0 Profile/MIDP-2.0", BrowserUnknown},
+		{"BaconReader/3.3.1(Android 4.4.2; LGE Nexus 4)", BrowserUnknown},
+
+		// and a plain browser, which must never pay a bot's price
+		{"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) " +
+			"Chrome/126.0.0.0 Safari/537.36", BrowserUnknown},
+	}
+
+	for _, tt := range tests {
+		ua := normalise(tt.agent)
+		got, ok := botName(ua)
+		if tt.want == BrowserUnknown {
+			if ok {
+				t.Errorf("botName(%.60q) = %v, want no match", tt.agent, got)
+			}
+			continue
+		}
+		if !ok {
+			t.Errorf("botName(%.60q) = no match, want %v", tt.agent, tt.want)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("botName(%.60q) = %v, want %v", tt.agent, got, tt.want)
+		}
+	}
+}
+
+func TestIsBotWord(t *testing.T) {
+	// A crawler's name, in the four shapes it takes.
+	for _, agent := range []string{
+		"googlebot/2.1", "petalbot;", "discordbot", "semrushbot/7~bl", "adsbot-google",
+		"contextad bot 1.0", "better uptime bot mozilla/5.0", "df bot 1.0",
+	} {
+		i := strings.Index(agent, "bot")
+		if !isBotWord(agent, i, i+3) {
+			t.Errorf("isBotWord(%q) = false, want true", agent)
+		}
+	}
+
+	// Letters inside a longer word: a phone brand, an Italian bank, a plural.
+	for _, agent := range []string{
+		"cubot one build/jop40d", "banca caboto s.p.a.", "robots welcome",
+	} {
+		i := strings.Index(agent, "bot")
+		if isBotWord(agent, i, i+3) {
+			t.Errorf("isBotWord(%q) = true, want false", agent)
+		}
+	}
+}
+
+func TestHasContactURL(t *testing.T) {
+	for _, agent := range []string{
+		"wordpress/4.3.27; http://afterice.se",
+		"y!j-asr/0.1 crawler (http://www.yahoo-help.jp/)",
+		"someagent/1.0 (+https://example.com/policy)",
+		"linkanalyser [www.example.org]",
+		"tool/1.0 www.example.com",
+	} {
+		if !hasContactURL(agent) {
+			t.Errorf("hasContactURL(%q) = false, want true", agent)
+		}
+	}
+
+	for _, agent := range []string{
+		"",
+		"mozilla/5.0 (windows nt 10.0; win64; x64) applewebkit/537.36",
+		// a proxy rewrote the agent and left its own URL at the front: the
+		// device behind it is not a crawler
+		"http://atamg.wup.ru/samsung-gt-s5233t/s5233txejf1 shp/vpp/r5 jasmine/0.8",
+		// and a URL glued to a word is not a field of its own
+		"someapp/1.0 seehttp://example.com",
+	} {
+		if hasContactURL(agent) {
+			t.Errorf("hasContactURL(%q) = true, want false", agent)
+		}
+	}
+}
+
+// The buckets are the index botName reads, and a marker landing in the wrong one
+// is invisible: the scan simply never tries it.
+func TestBotMarkersAreIndexed(t *testing.T) {
+	for _, m := range botMarkers {
+		if m.s == "" {
+			t.Error("empty bot marker")
+			continue
+		}
+		if m.s != strings.ToLower(m.s) {
+			t.Errorf("marker %q is not lowercase, so the normalised agent can never match it", m.s)
+		}
+		if len(m.s) < 2 {
+			t.Errorf("marker %q is shorter than the digram gate, so it is never tried", m.s)
+			continue
+		}
+		k := uint16(m.s[0])<<8 | uint16(m.s[1])
+		if botDigrams[k>>6]&(1<<(k&63)) == 0 {
+			t.Errorf("marker %q: opening pair missing from botDigrams, so it is never tried", m.s)
+		}
+		c := m.s[0]
+		found := false
+		for _, b := range botBuckets[c] {
+			found = found || b.s == m.s
+		}
+		if !found {
+			t.Errorf("marker %q missing from its bucket", m.s)
+		}
+	}
+
+	// Longest first, which is what makes a named crawler win over the generic
+	// token inside it.
+	for c, bucket := range botBuckets {
+		for i := 1; i < len(bucket); i++ {
+			if len(bucket[i-1].s) < len(bucket[i].s) {
+				t.Errorf("bucket %q is not ordered longest first: %q before %q",
+					byte(c), bucket[i-1].s, bucket[i].s)
+			}
+		}
+	}
+}
+
+func BenchmarkBotName(b *testing.B) {
+	agent := normalise("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)")
+	for b.Loop() {
+		botName(agent)
+	}
+}
+
+// The pass every parse pays for: a browser agent that matches nothing.
+func BenchmarkBotNameMiss(b *testing.B) {
+	agent := normalise("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+		"(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36")
+	for b.Loop() {
+		botName(agent)
+	}
+}

--- a/browser.go
+++ b/browser.go
@@ -4,7 +4,17 @@ import "strings"
 
 // Retrieve browser name from UA strings
 func (u *UserAgent) parseBrowserName(ua string) bool {
-	// Blackberry goes first because it reads as MSIE & Safari
+	// Bots go first: a crawler copies a whole browser agent and appends itself,
+	// so every check below would match one before we got to it. Only agents
+	// carrying a hint of one pay for the full pass.
+	if botSuspect(ua) {
+		if name, ok := botName(ua); ok {
+			u.Browser.Name = name
+			return u.applyBotDefaults()
+		}
+	}
+
+	// Blackberry goes next because it reads as MSIE & Safari
 	if strings.Contains(ua, "blackberry") || strings.Contains(ua, "playbook") || strings.Contains(ua, "bb10") || strings.Contains(ua, "rim ") {
 		u.Browser.Name = BrowserBlackberry
 		return u.applyBotDefaults()
@@ -12,9 +22,6 @@ func (u *UserAgent) parseBrowserName(ua string) bool {
 
 	if strings.Contains(ua, "applewebkit") {
 		switch {
-		case strings.Contains(ua, "googlebot"):
-			u.Browser.Name = BrowserGoogleBot
-
 		case strings.Contains(ua, "qq/") || strings.Contains(ua, "qqbrowser/"):
 			u.Browser.Name = BrowserQQ
 
@@ -56,10 +63,6 @@ func (u *UserAgent) parseBrowserName(ua string) bool {
 		case strings.Contains(ua, " spotify/"):
 			u.Browser.Name = BrowserSpotify
 
-		// AppleBot uses webkit signature as well
-		case strings.Contains(ua, "applebot"):
-			u.Browser.Name = BrowserAppleBot
-
 		// presume it's safari unless an esoteric browser is being specified (webOSBrowser, SamsungBrowser, etc.)
 		case strings.Contains(ua, "like gecko") && strings.Contains(ua, "mozilla/") && strings.Contains(ua, "safari/") && !strings.Contains(ua, "linux") && !strings.Contains(ua, "android") && !strings.Contains(ua, "browser/") && !strings.Contains(ua, "os/") && !strings.Contains(ua, "yabrowser/"):
 			u.Browser.Name = BrowserSafari
@@ -96,51 +99,27 @@ notwebkit:
 	case strings.Contains(ua, "ucbrowser"):
 		u.Browser.Name = BrowserUCBrowser
 
-	case strings.Contains(ua, "applebot"):
-		u.Browser.Name = BrowserAppleBot
-
-	case strings.Contains(ua, "baiduspider"):
-		u.Browser.Name = BrowserBaiduBot
-
-	case strings.Contains(ua, "adidxbot") || strings.Contains(ua, "bingbot") || strings.Contains(ua, "bingpreview"):
-		u.Browser.Name = BrowserBingBot
-
-	case strings.Contains(ua, "duckduckbot"):
-		u.Browser.Name = BrowserDuckDuckGoBot
-
-	case strings.Contains(ua, "facebot") || strings.Contains(ua, "facebookexternalhit"):
-		u.Browser.Name = BrowserFacebookBot
-
-	case strings.Contains(ua, "googlebot"):
-		u.Browser.Name = BrowserGoogleBot
-
-	case strings.Contains(ua, "linkedinbot"):
-		u.Browser.Name = BrowserLinkedInBot
-
-	case strings.Contains(ua, "msnbot"):
-		u.Browser.Name = BrowserMsnBot
-
-	case strings.Contains(ua, "pingdom.com_bot"):
-		u.Browser.Name = BrowserPingdomBot
-
-	case strings.Contains(ua, "twitterbot"):
-		u.Browser.Name = BrowserTwitterBot
-
-	case strings.Contains(ua, "yandex") || strings.Contains(ua, "yadirectfetcher"):
+	// Yandex names every one of its crawlers "Yandex<something>" and its own
+	// browser is matched above, so the bare vendor name is safe here. Yahoo's is
+	// not, and is handled by token in botMarkers instead.
+	case strings.Contains(ua, "yandex"):
 		u.Browser.Name = BrowserYandexBot
 
-	case strings.Contains(ua, "yahoo"):
-		u.Browser.Name = BrowserYahooBot
-
-	case strings.Contains(ua, "coccocbot"):
-		u.Browser.Name = BrowserCocCocBot
-
-	case strings.Contains(ua, "phantomjs"):
-		u.Browser.Name = BrowserBot
-
 	default:
-		u.Browser.Name = BrowserUnknown
-
+		// No browser token at all: the shape of a script, an HTTP library or a
+		// crawler that never pretended to be a browser. None of those trip
+		// botSuspect, so they get the full pass here, where it costs nothing -
+		// the alternative for these agents is reporting Unknown. It is also the
+		// one place a bare contact URL can be trusted, nothing here being a
+		// browser.
+		switch name, ok := botName(ua); {
+		case ok:
+			u.Browser.Name = name
+		case hasContactURL(ua):
+			u.Browser.Name = BrowserBot
+		default:
+			u.Browser.Name = BrowserUnknown
+		}
 	}
 
 	return u.applyBotDefaults()

--- a/device.go
+++ b/device.go
@@ -5,12 +5,11 @@ import (
 )
 
 // Markers that are a substring of another marker are omitted: "tv" already
-// subsumes googletv/appletv/smarttv/smart-tv/hbbtv/dtv/"tv box", "aftss"
-// subsumes "aftsss", and "aftka" subsumes "aftkauk".
+// subsumes googletv/appletv/smarttv/smart-tv/hbbtv/dtv/"tv box". Amazon's Fire
+// TV models are not listed at all; isFireTV matches the whole family.
 var tvMarkers = []string{
 	"tv", "roku", "crkey", "chromecast", "stb", "tuner", "vizio", "viera", "aquos", "bravia",
 	"netcast", "youview", "adt-", "swisscom-ip", "mibox", "ott-g1", "ottera",
-	"aftb", "aftt", "aftm", "aftr", "aftss", "aftka", "aftkrt", "aftgazl", "aftanna",
 	"tpm191e", "tpm171e", "nokia streaming box", "stableavb_telly", "lxbox51",
 	"x96max", "x96q_max_pro", "canal plus box", "vectra 4k box",
 	"diw377", "diw380", "dv8555", "dctiw362", "gd1 4k", "ai pont", "b-stream",
@@ -36,8 +35,47 @@ func isTV(ua string) bool {
 		}
 	}
 
-	return strings.Contains(ua, "mbox") && !strings.Contains(ua, "xbox")
+	if strings.Contains(ua, "mbox") && !strings.Contains(ua, "xbox") {
+		return true
+	}
+
+	// Last, because it is the only check that has to look at where in the agent
+	// the match sits: every other marker here is distinctive enough to match
+	// anywhere.
+	return isFireTV(platformGroup(ua))
 }
+
+// isFireTV reports whether specs carries an Amazon Fire TV model token: "aft"
+// and up to ten more letters or digits, as its own field.
+//
+// Amazon has shipped dozens of these - aftb, aftmm, aftka, aftkm, aftdck,
+// aftkmst12, aftbamr311 - and enumerating them meant every new stick read as a
+// phone until someone noticed. The family prefix is stable, so match on that.
+//
+// Only the platform group is searched, never the whole agent: unanchored, "aft"
+// also begins "after", which turns any agent quoting a URL like
+// "afterice.se" into a television.
+func isFireTV(specs string) bool {
+	for i := 0; i+3 <= len(specs); i++ {
+		if i > 0 && !isFieldEdge(specs[i-1]) {
+			continue
+		}
+		if specs[i] != 'a' || specs[i+1] != 'f' || specs[i+2] != 't' {
+			continue
+		}
+		n := i + 3
+		for n < len(specs) && n-i <= 12 && (isLower(specs[n]) || isDigit(specs[n])) {
+			n++
+		}
+		if n > i+3 && (n == len(specs) || isFieldEdge(specs[n])) {
+			return true
+		}
+	}
+	return false
+}
+
+// isFieldEdge reports whether c separates two fields of a platform group.
+func isFieldEdge(c byte) bool { return isSpace(c) || c == ';' || c == ',' }
 
 func (u *UserAgent) parseDevice(ua string) {
 	switch {

--- a/device_test.go
+++ b/device_test.go
@@ -48,3 +48,82 @@ func TestIsTVMarkers(t *testing.T) {
 		}
 	}
 }
+
+// TestTVFixtures runs the connected TV fixture set. Device type and OS are
+// asserted together on purpose: a stick that reports the right OS and the wrong
+// device type is no more useful to a caller than one that reports neither.
+func TestTVFixtures(t *testing.T) {
+	for _, row := range readFixtures(t, "tv.tsv", 3) {
+		wantDevice, wantOS, agent := row[0], row[1], row[2]
+		ua := Parse(agent)
+		if got := ua.DeviceType.StringTrimPrefix(); got != wantDevice {
+			t.Errorf("device = %s, want %s: %s", got, wantDevice, agent)
+		}
+		if got := ua.OS.Name.StringTrimPrefix(); got != wantOS {
+			t.Errorf("os = %s, want %s: %s", got, wantOS, agent)
+		}
+	}
+}
+
+func TestIsFireTV(t *testing.T) {
+	// Real model tokens, as they appear in the platform group. Amazon has shipped
+	// dozens; the point of the rule is that it does not need to know them.
+	for _, specs := range []string{
+		"linux; android 9; aftb", "linux; android 11; aftkm", "linux; android 9; aftmm",
+		"linux; android 7.1.2; aftsss", "linux; android 9; aftka build/ps7233.3244n",
+		"linux; android 11; aftkmst12", "linux; android 9; aftbamr311", "linux; android 5.1; aftt",
+		"linux; android 9; aftdck", "aftb", "linux, aftgazl",
+	} {
+		if !isFireTV(specs) {
+			t.Errorf("isFireTV(%q) = false, want true", specs)
+		}
+	}
+
+	// "aft" also starts ordinary words, which is why the match is anchored to a
+	// field of the platform group and never run over the whole agent.
+	for _, specs := range []string{
+		"", "aft", "linux; android 9; craft",
+		"macintosh; intel mac os x 10_15_7", "linux; android 13; sm-s918b",
+		"compatible; wordpress/5.3.3; https://belasting-aftrekken.nl",
+		"linux; android 9; kfmuwi", // a Fire tablet, not a Fire TV
+	} {
+		if isFireTV(specs) {
+			t.Errorf("isFireTV(%q) = true, want false", specs)
+		}
+	}
+
+	// A bare "after" as its own field does match, and is left matching: a
+	// platform group carries OS, model and build fields, never prose. The trap
+	// worth guarding is the whole-agent one below.
+	if !isFireTV("windows nt 10.0; after") {
+		t.Error("isFireTV: expected the documented false positive on a bare \"after\" field")
+	}
+
+	// The whole-agent form of the same trap: a URL in the tail must not promote
+	// a desktop browser to a television.
+	notTV := "mozilla/5.0 (windows nt 10.0; win64; x64) applewebkit/537.36 " +
+		"(khtml, like gecko) chrome/126.0.0.0 safari/537.36 http://afterice.se"
+	if isTV(notTV) {
+		t.Error("isTV: a URL containing \"after\" reads as a television")
+	}
+}
+
+func TestPlatformGroup(t *testing.T) {
+	tests := []struct{ ua, want string }{
+		{"mozilla/5.0 (macintosh; intel mac os x 10_15_7) applewebkit/605", "macintosh; intel mac os x 10_15_7"},
+		{"roku/dvp-12.5 (12.5.5.4405-46)", "12.5.5.4405-46"},
+		// no parens, so the group is the whole agent
+		{"curl/8.6.0", "curl/8.6.0"},
+		// unterminated, and reversed: both run to the end rather than panicking
+		{"mozilla/5.0 (macintosh", "macintosh"},
+		// the parens are in the wrong order, so the group starts after the "("
+		// and runs to the end, which here is nothing at all
+		{"mozilla/5.0 ) macintosh (", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := platformGroup(tt.ua); got != tt.want {
+			t.Errorf("platformGroup(%q) = %q, want %q", tt.ua, got, tt.want)
+		}
+	}
+}

--- a/doc/bots.md
+++ b/doc/bots.md
@@ -1,0 +1,55 @@
+# Bot detection
+
+`IsBot()` reports whether an agent belongs to a crawler, a script or an
+automation stack rather than to a person. When it does, the OS, platform and
+device fields are set to `OSBot`, `PlatformBot` and `DeviceComputer`, so a caller
+filtering on any one of them sees the same answer.
+
+```go
+ua := uasurfer.Parse(agent)
+if ua.IsBot() {
+    return // not a person
+}
+```
+
+## What it catches
+
+Crawlers announce themselves conventionally, and detection is built on those
+conventions rather than on a list of names: anything calling itself `…bot`,
+`…spider` or `…crawler`, anything publishing a contact URL as `+http…`, the
+HTTP client libraries (curl, python-requests, Go-http-client, Scrapy, …), the
+headless and automation browsers, and the link preview fetchers.
+
+The crawlers with the volume to be worth naming get their own constant -
+`BrowserGoogleBot`, `BrowserBingBot`, `BrowserOpenAIBot`, `BrowserAnthropicBot`,
+`BrowserPerplexityBot`, `BrowserAmazonBot`, `BrowserBytedanceBot`,
+`BrowserAhrefsBot`, `BrowserSemrushBot` and the rest of the block in
+[`BrowserName`](https://pkg.go.dev/github.com/LumenResearch/uasurfer#BrowserName).
+Everything else reports as `BrowserBot`. A named constant covers the whole fleet
+behind it: `BrowserGoogleBot` is AdsBot, Mediapartners, GoogleOther and
+Google-InspectionTool as well as Googlebot itself.
+
+An agent that names no browser at all but publishes a contact URL is also taken
+as a crawler. Nothing that reaches that point is a browser, and a crawler that
+has bothered to link a page explaining itself is announcing itself as clearly as
+one calling itself a bot.
+
+## What it does not catch
+
+Roughly one crawler in six, by count of distinct agents: the ones that wear a
+complete browser agent and then name themselves something unguessable, with no
+URL and no generic token - `Datanyze`, `Rigor`, `Scope3/2.0`, `binlar`. Catching
+those means shipping a list of every crawler name in existence and keeping it
+current, which this package deliberately does not.
+
+Measured against 1,975 real crawler agents, detection sits at **83%**, with no
+false positive across the 2,906 real device agents in the device fixture set (nor
+across the 17k agents it was sampled from). Both fixture sets are in `testdata/`.
+
+Impostors are named by what they are, not what they claim: `TelegramBot (like
+TwitterBot)` and `Feedly/1.0 (… like FeedFetcher-Google)` are `BrowserBot`, since
+"like X" is a claim of resemblance rather than identity.
+
+Some agents are non-browser but not bots, and are reported as the devices they
+are: app HTTP stacks such as Dalvik, CFNetwork and OkHttp carry requests from
+real apps on real phones, and `Java/…` is what a J2ME feature phone announces.

--- a/doc/tv.md
+++ b/doc/tv.md
@@ -1,0 +1,30 @@
+# Connected TV
+
+Televisions, sticks and set top boxes report `DeviceTV`. Where the platform
+states an OS of its own, that is reported too.
+
+| platform | OS name | platform value | OS version |
+|---|---|---|---|
+| Samsung smart TVs | `OSTizen` | `PlatformLinux` | yes |
+| LG smart TVs | `OSWebOS` | `PlatformLinux` | not stated by the device |
+| Roku players | `OSRoku` | `PlatformLinux` | yes |
+| Apple TV | `OSTvOS` | `PlatformAppleTV` | yes |
+| Amazon Fire TV | `OSAndroid` | `PlatformLinux` | the Android version |
+| Android TV, Google TV, Chromecast | `OSAndroid` | `PlatformLinux` | the Android version |
+| Vizio, Hisense VIDAA, HbbTV boxes, RDK, NetCast, Viera, Bravia | `OSLinux` or `OSUnknown` | `PlatformLinux` | not stated by the device |
+
+The last row is not an omission: those platforms are Linux and state no version
+of their own, so a constant per brand would buy a name and nothing else. Use
+`DeviceTV` to know it is a television, and the browser and its version for what
+the device can actually render.
+
+Amazon's Fire TV models are recognised as a family, so a stick released after
+this version of the library still reports `DeviceTV`. Fire tablets remain
+`DeviceTablet`.
+
+Two notes that look like bugs and are not:
+
+* LG spells its own OS **`Web0S`**, with a zero, on everything since webOS 3.
+  All three spellings map to `OSWebOS`.
+* The Roku and Apple TV **remote control apps** run on a phone, and report as
+  one. Only the players and the boxes report `DeviceTV`.

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,109 @@
+package uasurfer
+
+import (
+	"strings"
+	"testing"
+)
+
+// The parser walks untrusted input by index throughout - platformGroup slices on
+// the parentheses it finds, Version.parse and the marker scans step through
+// bytes - so the property worth fuzzing is that no agent, however malformed,
+// gets it to step outside a string or to disagree with itself.
+//
+// Run longer than the seed corpus with:
+//
+//	go test -run=XXX -fuzz=FuzzParse -fuzztime=2m
+func FuzzParse(f *testing.F) {
+	// Seeds: the shapes that have historically broken index arithmetic here,
+	// rather than a sample of well formed agents.
+	seeds := []string{
+		"",
+		"(",
+		")",
+		")(",
+		"()",
+		"mozilla/5.0 (",
+		"mozilla/5.0 )",
+		"mozilla/5.0 ) macintosh (",
+		"(;;;;;;)",
+		";",
+		"/",
+		"+",
+		"aft",
+		"bot",
+		"cpu os ",
+		"android ",
+		"windows nt ",
+		"version/",
+		"appletv/",
+		"appletv6,2/",
+		"roku/dvp-",
+		"tizen ",
+		"trident/",
+		"cfnetwork/ darwin/",
+		"mozilla/5.0 (iphone; cpu iphone os 17_5 like mac os x) applewebkit/605.1.15",
+		"mozilla/5.0 (windows nt 10.0; win64; x64) applewebkit/537.36 chrome/126.0.0.0 safari/537.36",
+		"mozilla/5.0 (linux; android 10; k) applewebkit/537.36 chrome/126.0.0.0 mobile safari/537.36",
+		"mozilla/5.0 (compatible; googlebot/2.1; +http://www.google.com/bot.html)",
+		"roku/dvp-12.5 (12.5.5.4405-46)",
+		"mozilla/5.0 (smart-tv; linux; tizen 6.0) applewebkit/537.36 version/6.0 tv safari/537.36",
+		"mozilla/5.0 (web0s; linux/smarttv) applewebkit/537.36",
+		"mozilla/5.0 (linux; android 11; aftkm) applewebkit/537.36 silk/122.4.2 like chrome/122.0",
+		// non ASCII, which sends normalise down its fallback path
+		"mozilla/5.0 (Ünicode ÅÄÖ)",
+		// and an agent past the stack buffer, the other fallback
+		strings.Repeat("a", 1100),
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, agent string) {
+		ua := Parse(agent)
+
+		// Every field has to be a constant the package defines. A value outside
+		// the list means the parser invented one, and String() would then report
+		// it as Unknown while a caller's switch fell through.
+		if ua.Browser.Name < 0 || ua.Browser.Name >= _browserNameFinal {
+			t.Fatalf("browser name %d out of range", ua.Browser.Name)
+		}
+		if ua.OS.Name < 0 || ua.OS.Name >= _osNameFinal {
+			t.Fatalf("os name %d out of range", ua.OS.Name)
+		}
+		if ua.OS.Platform < 0 || ua.OS.Platform >= _platformFinal {
+			t.Fatalf("platform %d out of range", ua.OS.Platform)
+		}
+		if ua.DeviceType < 0 || ua.DeviceType >= _deviceTypeFinal {
+			t.Fatalf("device type %d out of range", ua.DeviceType)
+		}
+
+		// Versions are parsed by hand out of arbitrary text; negatives would
+		// break Less and any caller comparing against a release number.
+		for _, v := range []Version{ua.Browser.Version, ua.OS.Version} {
+			if v.Major < 0 || v.Minor < 0 || v.Patch < 0 {
+				t.Fatalf("negative version %v", v)
+			}
+		}
+
+		// A bot is reported consistently across all four fields, because callers
+		// filter on whichever one they happen to hold.
+		if ua.IsBot() && (ua.OS.Name != OSBot || ua.OS.Platform != PlatformBot || ua.DeviceType != DeviceComputer) {
+			t.Fatalf("bot reported inconsistently: %+v", ua)
+		}
+
+		// Parsing is a pure function of the agent, and normalisation is the only
+		// thing that may differ between two spellings of one agent: an upper
+		// case agent has to land on the same answer as its lowercase twin.
+		if lower := Parse(strings.ToLower(agent)); *lower != *ua {
+			t.Fatalf("case changed the result:\n lower %+v\n orig  %+v", lower, ua)
+		}
+
+		// And the reuse path has to agree with the allocating one, or a caller
+		// pooling UserAgents gets different answers from the same input.
+		var reused UserAgent
+		ParseUserAgent(agent, &reused)
+		if reused != *ua {
+			t.Fatalf("ParseUserAgent disagrees with Parse:\n reused %+v\n parse  %+v", reused, ua)
+		}
+	})
+}

--- a/system.go
+++ b/system.go
@@ -55,19 +55,22 @@ func isSpace(c byte) bool { return c == ' ' || c == '\t' || c == '\n' || c == '\
 func isLower(c byte) bool { return c >= 'a' && c <= 'z' }
 func isDigit(c byte) bool { return c >= '0' && c <= '9' }
 
-func (u *UserAgent) parseOS(ua string, hints *Hints) bool {
-	// The platform group is the text between the first parentheses. When the
-	// closing paren is missing or precedes the opening one, the group runs to
-	// the end of the agent instead. Only e moves: s still points at the opening
-	// paren (or -1 when there is none), so the s+1 below skips that paren rather
-	// than the agent's first byte.
+// platformGroup returns the text between the first parentheses. When the closing
+// paren is missing or precedes the opening one, the group runs to the end of the
+// agent instead. Only e moves: s still points at the opening paren (or -1 when
+// there is none), so the s+1 below skips that paren rather than the agent's
+// first byte.
+func platformGroup(ua string) string {
 	s := strings.IndexByte(ua, '(')
 	e := strings.IndexByte(ua, ')')
 	if e == -1 || s > e {
 		e = len(ua)
 	}
+	return ua[s+1 : e]
+}
 
-	agentPlatform := ua[s+1 : e]
+func (u *UserAgent) parseOS(ua string, hints *Hints) bool {
+	agentPlatform := platformGroup(ua)
 	// Cut returns the whole string when there is no ";", which is what we want.
 	specs, _, _ := strings.Cut(agentPlatform, ";")
 
@@ -114,7 +117,7 @@ func (u *UserAgent) parseOS(ua string, hints *Hints) bool {
 			u.parseLinux(ua, agentPlatform)
 
 		// WebOS (non-linux flagged)
-		case strings.Contains(ua, "webos") || strings.Contains(ua, "hpwos"):
+		case isWebOS(ua):
 			u.OS.Platform = PlatformLinux
 			u.OS.Name = OSWebOS
 
@@ -132,9 +135,27 @@ func (u *UserAgent) parseOS(ua string, hints *Hints) bool {
 		case strings.Contains(ua, "android"):
 			u.parseLinux(ua, agentPlatform)
 
+		// Apple TV, ahead of the CFNetwork case below: its native apps carry the
+		// same Darwin signature as an iPhone's, and the model is what separates
+		// them. The version follows the model generation ("AppleTV6,2/11.1") or,
+		// for the media player agents, sits in the iOS style "CPU OS" field.
+		case strings.Contains(ua, "appletv") || strings.Contains(ua, "apple tv"):
+			u.OS.Platform = PlatformAppleTV
+			u.OS.Name = OSTvOS
+			u.parseTvOSVersion(ua)
+
 		// Apple CFNetwork
 		case strings.Contains(ua, "cfnetwork") && strings.Contains(ua, "darwin"):
 			u.parseAppleNative(ua, hints)
+
+		// Roku, after CFNetwork: the players state their OS version after the
+		// model ("Roku/DVP-12.5", "Roku4640X/DVP-7.70") and never carry Darwin,
+		// while "Roku" on its own is also the remote control app, which runs on
+		// a phone and is caught above.
+		case strings.Contains(ua, "roku"):
+			u.OS.Platform = PlatformLinux
+			u.OS.Name = OSRoku
+			u.OS.Version.parseAfter(ua, "/dvp-", "roku/")
 
 		default:
 			u.OS.Platform = PlatformUnknown
@@ -181,8 +202,15 @@ func (u *UserAgent) parseLinux(ua, agentPlatform string) {
 		u.OS.Platform = PlatformLinux
 		u.OS.Name = OSChromeOS
 
+	// Tizen: Samsung's smart TVs, which report "SMART-TV; LINUX; Tizen 6.0",
+	// and the few Tizen phones, which report "Linux; Tizen 2.3".
+	case strings.Contains(ua, "tizen"):
+		u.OS.Platform = PlatformLinux
+		u.OS.Name = OSTizen
+		u.OS.Version.parseAfter(ua, "tizen ", "tizen/")
+
 	// WebOS
-	case strings.Contains(ua, "webos") || strings.Contains(ua, "hpwos"):
+	case isWebOS(ua):
 		u.OS.Platform = PlatformLinux
 		u.OS.Name = OSWebOS
 
@@ -224,6 +252,27 @@ func (u *UserAgent) parseiOS(specs, agentPlatform string) {
 		u.OS.Platform = PlatformiPad
 		u.OS.Name = OSUnknown
 	}
+}
+
+// isWebOS covers the three spellings in the wild: Palm and HP's original
+// "webOS" and "hpwOS", and the "Web0S" - with a zero - that LG ships on its
+// smart TVs.
+func isWebOS(ua string) bool {
+	return strings.Contains(ua, "webos") ||
+		strings.Contains(ua, "web0s") ||
+		strings.Contains(ua, "hpwos")
+}
+
+// parseTvOSVersion reads the tvOS version, which sits after the slash that
+// follows the hardware generation: "AppleTV6,2/11.1", "AppleTV/1.1". The media
+// player agents carry no model and state the version the iOS way instead.
+func (u *UserAgent) parseTvOSVersion(ua string) {
+	if _, after, ok := strings.Cut(ua, "appletv"); ok {
+		if _, version, ok := strings.Cut(after, "/"); ok && u.OS.Version.parse(version) {
+			return
+		}
+	}
+	u.OS.Version.parseAfter(ua, "cpu os ", "os x ")
 }
 
 func (u *UserAgent) parseWindowsPhone(agentPlatform string) {
@@ -306,6 +355,15 @@ func (o *OS) parseiOSVersion(agentPlatform string) {
 	}
 }
 
+// maxVersionPart caps each component of a version.
+//
+// Nothing has ever shipped a version number this large, and accumulating one
+// unchecked overflows: FuzzParse found "roku/10000000000000000000", which gave a
+// negative major that then compares as older than every release there has been.
+// The cap is also small enough that the multiply below cannot overflow an int on
+// a 32 bit platform.
+const maxVersionPart = 1 << 24
+
 // strToVer accepts a string and returns a Version,
 // with {0, 0, 0} being default.
 func (v *Version) parse(str string) bool {
@@ -339,7 +397,9 @@ func (v *Version) parse(str string) bool {
 					break
 				}
 
-				val = 10*val + int(c) - 48
+				if val <= maxVersionPart {
+					val = 10*val + int(c) - 48
+				}
 				if k == l {
 					str = str[:0]
 				}

--- a/system_test.go
+++ b/system_test.go
@@ -130,3 +130,73 @@ func TestParseWindowsVersions(t *testing.T) {
 		}
 	}
 }
+
+func TestIsWebOS(t *testing.T) {
+	// LG ships "Web0S" with a zero, Palm and HP shipped the other two.
+	for _, ua := range []string{
+		"mozilla/5.0 (web0s; linux/smarttv) applewebkit/537.36",
+		"mozilla/5.0 (webos; linux/smarttv) applewebkit/538.2",
+		"mozilla/5.0 (hpwos/3.0.5; u; en-us) applewebkit/534.6",
+	} {
+		if !isWebOS(ua) {
+			t.Errorf("isWebOS(%q) = false, want true", ua)
+		}
+	}
+	for _, ua := range []string{"", "mozilla/5.0 (windows nt 10.0)", "web0", "webo"} {
+		if isWebOS(ua) {
+			t.Errorf("isWebOS(%q) = true, want false", ua)
+		}
+	}
+}
+
+func TestParseTvOSVersion(t *testing.T) {
+	tests := []struct {
+		ua   string
+		want Version
+	}{
+		// the version follows the slash after the hardware generation
+		{"appletv6,2/11.1", Version{11, 1, 0}},
+		{"appletv11,1/15.5.1", Version{15, 5, 1}},
+		{"appletv/1.1", Version{1, 1, 0}},
+		// the media player agents carry no model and state it the iOS way
+		{"applecoremedia/1.0.0.12f69 (apple tv; u; cpu os 8_3 like mac os x; en_us)", Version{8, 3, 0}},
+		// nothing parseable: the caller still gets a usable zero value
+		{"appletv", Version{}},
+		{"apple tv", Version{}},
+	}
+	for _, tt := range tests {
+		var u UserAgent
+		u.parseTvOSVersion(tt.ua)
+		if u.OS.Version != tt.want {
+			t.Errorf("parseTvOSVersion(%q) = %v, want %v", tt.ua, u.OS.Version, tt.want)
+		}
+	}
+}
+
+// A version component that cannot fit is nonsense, but it must not come back
+// negative: Less would then sort it before every real release. FuzzParse found
+// this one, and testdata/fuzz keeps it as a seed.
+func TestVersionParseOverflow(t *testing.T) {
+	for _, agent := range []string{
+		"roku/10000000000000000000",
+		"chrome/99999999999999999999.99999999999999999999",
+		"mozilla/5.0 (windows nt 184467440737095516151) applewebkit/537.36",
+	} {
+		ua := Parse(agent)
+		for _, v := range []Version{ua.Browser.Version, ua.OS.Version} {
+			if v.Major < 0 || v.Minor < 0 || v.Patch < 0 {
+				t.Errorf("Parse(%q) = %v, want no negative component", agent, v)
+			}
+			if v.Major > maxVersionPart*10 {
+				t.Errorf("Parse(%q) = %v, want each component capped", agent, v)
+			}
+		}
+	}
+
+	// and the cap must not disturb versions anyone actually ships
+	var v Version
+	v.parse("126.0.6478.126")
+	if v != (Version{126, 0, 6478}) {
+		t.Errorf("parse(%q) = %v, want {126 0 6478}", "126.0.6478.126", v)
+	}
+}

--- a/testdata/NOTICE.md
+++ b/testdata/NOTICE.md
@@ -1,0 +1,11 @@
+# Third party notices for testdata
+
+The agent strings in this directory were collected from the projects below and
+are redistributed under their licences. The expectations beside them are this
+project's own work, under the same Apache-2.0 licence as the rest of uasurfer.
+
+| project                                                                 | licence                                                                     | notice                              |
+| ----------------------------------------------------------------------- | --------------------------------------------------------------------------- | ----------------------------------- |
+| [crawler-user-agents](https://github.com/monperrus/crawler-user-agents) | [MIT](https://github.com/monperrus/crawler-user-agents/blob/master/LICENSE) | Copyright (c) 2017 Martin Monperrus |
+| [go-useragent](https://github.com/medama-io/go-useragent)               | [MIT](https://github.com/medama-io/go-useragent/blob/main/LICENSE)          | Copyright (c) 2023 medama-io        |
+| [uap-core](https://github.com/ua-parser/uap-core)                       | [Apache-2.0](https://github.com/ua-parser/uap-core/blob/master/LICENSE)     | Copyright 2009 Google Inc.          |

--- a/testdata/bots.tsv
+++ b/testdata/bots.tsv
@@ -1,0 +1,1988 @@
+# Bot detection fixture set: <expected browser>\t<agent>.
+#
+# The expected browser is a BrowserName constant without its "Browser" prefix.
+# "!" marks an agent we knowingly do not detect: it carries no generic token and
+# no name of its own, so catching it would mean shipping a crawler-name table.
+# Those rows are not asserted individually - they set the recall floor in
+# TestBotFixtures, which is what stops the detector quietly getting worse.
+#
+# Agent strings collected from the sources credited in testdata/NOTICE.md and
+# redistributed under their licences. The expectations beside them are this
+# project's own: a row is a claim about what the agent means, not a snapshot of
+# whatever the parser said the day it was written.
+
+Bot	A6-Indexer/1.0 (http://www.a6corp.com/a6-web-scraping-policy/)
+Bot	AASA-Bot/1.0.0
+Bot	ADmantX Platform Semantic Analyzer - ADmantX Inc. - www.admantx.com - support@admantx.com
+!	ALittle Client
+GoogleBot	APIs-Google (+https://developers.google.com/webmasters/APIs-Google.html)
+Bot	Aboundex/0.2 (http://www.aboundex.com/crawler/)
+Bot	Aboundex/0.3 (http://www.aboundex.com/crawler/)
+Bot	AcademicBotRTU (https://academicbot.rtu.lv; mailto:caps@rtu.lv)
+Bot	Accessible Web Bot
+!	Acquia optimize (Monsido)
+Bot	AddThis.com robot tech.support@clearspring.com
+GoogleBot	AdsBot-Google (+http://www.google.com/adsbot.html)
+GoogleBot	AdsBot-Google-Mobile (+http://www.google.com/mobile/adsbot.html) Mozilla (iPhone; U; CPU iPhone OS 3 0 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile Safari
+Bot	AdsTxtCrawler/1.0
+Bot	Algolia Crawler
+Bot	AliyunSecBot/Aliyun AliyunSecBot@service.alibaba.com
+!	Amazon CloudFront
+Bot	Anomura/1.2 (+https://www.direqt.ai)
+Bot	Apache-HttpClient/4.2.3 (java 1.5)
+Bot	Apache-HttpClient/4.2.5 (java 1.5)
+Bot	Apache-HttpClient/4.3.1 (java 1.5)
+Bot	Apache-HttpClient/4.3.3 (java 1.5)
+Bot	Apache-HttpClient/4.3.5 (java 1.5)
+Bot	Apache-HttpClient/4.4.1 (Java/1.8.0_65)
+Bot	Apache-HttpClient/4.5.10 (Java/1.8.0_201)
+Bot	Apache-HttpClient/4.5.2 (Java/1.8.0_151)
+Bot	Apache-HttpClient/4.5.2 (Java/1.8.0_161)
+Bot	Apache-HttpClient/4.5.2 (Java/1.8.0_181)
+Bot	Apache-HttpClient/4.5.2 (Java/1.8.0_65)
+Bot	Apache-HttpClient/4.5.3 (Java/1.8.0_121)
+Bot	Apache-HttpClient/4.5.3-SNAPSHOT (Java/1.8.0_152)
+Bot	Apache-HttpClient/4.5.7 (Java/11.0.3)
+Bot	ApifyWebsiteContentCrawler/1.0 (+https://apify.com/apify/website-content-crawler)
+Bot	Aragog/1.0 (+https://wordads.co)
+Bot	Aranea Web-Crawled Corpora Project (+http://unesco.uniba.sk/guest (Hebrew 2024 Spring Crawl))
+Bot	ArchiveTeam ArchiveBot/20170106.02 (wpull 2.0.2)
+Bot	ArenaUnfurlBot/1.0 (Link preview bot for AI model comparison platform; +https://arena.ai) Mozilla/5.0 (compatible)
+Bot	Arquivo-web-crawler (compatible; +https://arquivo.pt/robot)
+!	Asana/1.4.0 WebsiteMetadataRetriever
+Bot	Audisto Crawler (desktop; +https://audisto.com/bot)
+Bot	Audisto Crawler (desktop; essential; +https://audisto.com/bot)
+Bot	Audisto Crawler (mobile; +https://audisto.com/bot)
+Bot	Audisto Crawler (mobile; essential; +https://audisto.com/bot)
+Bot	AwarioRendererBot/1.0 (+https://awario.com/bots.html; bots@awario.com)
+Bot	AwarioRssBot/1.0 (+https://awario.com/bots.html; bots@awario.com)
+Bot	AwarioSmartBot/1.0 (+https://awario.com/bots.html; bots@awario.com)
+Bot	BDBot/1.0
+!	BIGLOTRON (Beta 2;GNU/Linux)
+Bot	BLP_bbot/0.1
+!	BTWebClient/180B(9704)
+Bot	BUbiNG (+http://law.di.unimi.it/BUbiNG.html)
+!	BW/1.1; bit.ly/3eZNDnO
+!	BW/1.1; rb.gy/oupwis
+Bot	Bad Neighborhood Header Detector (http://www.bad-neighborhood.com/header_detector.php)
+Bot	Baidu-YunGuanCe-Bot(ce.baidu.com)
+Bot	Baidu-YunGuanCe-PerfBot(ce.baidu.com)
+Bot	Baidu-YunGuanCe-SLABot(ce.baidu.com)
+Bot	Baidu-YunGuanCe-ScanBot(ce.baidu.com)
+Bot	Baidu-YunGuanCe-VSBot(ce.baidu.com)
+Bot	BarkRowler/0.7 (+http://www.exensa.com/crawling)
+Bot	Barkrowler/0.5.1 (experimenting / debugging - sorry for your logs ) http://www.exensa.com/crawl - admin@exensa.com -- based on BuBiNG
+Bot	Barkrowler/0.7 (+http://www.exensa.com/crawl)
+Bot	Barkrowler/0.9 (+http://www.exensa.com/crawl)
+Bot	BeeperBot/0 Matrix-Media-Repo/1
+Bot	Better Uptime Bot Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36
+Bot	Bibliotheque Nacional de France Crawler
+Bot	BinaryCanary/1.0 (+https://www.binarycanary.com)
+!	Bitbucket-Webhooks/2.0
+!	BlackBerry9000/4.6.0.167 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/102 ips-agent
+!	Blackboard Safeassign
+!	Blackbox Exporter/0.20.0-rc.0
+!	Bling ERP
+Bot	BlogBridge 6.7 (http://www.blogbridge.com/) 1.6.0_18
+Bot	BlogVault/1.0 (+https://blogvault.net)
+Bot	Bloglines/3.1 (http://www.bloglines.com)
+!	Blogtrottr/2.0
+!	Bluesky/
+Bot	BlueskyPreviewBot/1.0
+Bot	Bot.AraTurka.com/0.0.1
+Bot	BrandONbot (http://brandonmedia.net)
+!	Brandwatch/1.0 (varies)
+Bot	BraveBot / Mozilla/5.0 (compatible; BraveBot/1.0)
+Bot	BrightEdge Crawler/1.0 (crawler@brightedge.com)
+!	Brightbot 1.0
+Bot	BrowserBot-Observer (+https://siteobserver.co)
+Bot	BublupBot (+https://www.bublup.com/bublup-bot.html)
+Bot	Buck/2.2; (+https://app.hypefactors.com/media-monitoring/about.html)
+Bot	BufferLinkPreviewBot/1.0 (+https://scraper.buffer.com/about/bots/link-preview-bot)
+Bot	Bugsnag script fetcher (support@bugsnag.com)
+!	Bushbaby (reported in logs)
+Bot	Buttondown RSS-Feed-Parser/1.0 (https://buttondown.com)
+Bot	Buzzbot/1.0 (Buzzbot; http://www.buzzstream.com; buzzbot@buzzstream.com)
+Bot	CC Metadata Scaper http://wiki.creativecommons.org/Metadata_Scraper
+CommonCrawlBot	CCBot/2.0 (http://commoncrawl.org/faq/)
+CommonCrawlBot	CCBot/2.0 (https://commoncrawl.org/faq/)
+Bot	CDSCbot/2024.08.08 https://wiki.communitydata.science/CommunityData:Fediverse_research
+Bot	CISPA Webcrawler (https://vuln-notify-checker.cispa.saarland)
+Bot	CXK/5.0 (linux; 43A1AAD0; ARMv9) assistenC5/v6.5.6 (KHTML, lcxk) CXK_Bot/2.3.1
+!	CaliberBot (varies)
+Bot	Caliperbot/1.0 (+http://www.conductor.com/caliperbot)
+!	CapitalOneShopping/1.0 (example)
+Bot	CapsuleChecker (http://www.capsulink.com/)
+Bot	Centro Ads.txt Crawler/1.0
+Bot	Chatwork LinkPreview v1
+Bot	CheckHost (https://check-host.net/)
+Bot	CheckMarkNetwork/1.0 (+http://www.checkmarknetwork.com/spider.html)
+!	Chrome Privacy Preserving Prefetch Proxy
+Bot	Chrome/54.0.2840.71 (compatible; RevvimGort/5.0; +http://www.revvim.com; webmaster@revvim.com)
+Bot	CiBra Data Collector (http://cibra.de/)
+Bot	CipaCrawler/3.0 (info@domaincrawler.com; http://www.domaincrawler.com/www.example.com)
+Bot	CirrusExplorer/2 (https://cseu.ro/explorer.php)
+Bot	Citoid (Wikimedia tool; learn more at https://www.mediawiki.org/wiki/Citoid)
+AnthropicBot	Claude-User (claude-code/2.1.86; +https://support.anthropic.com/)
+AnthropicBot	Claude-Web/1.0 (web crawler; +https://www.anthropic.com/; bots@anthropic.com)
+Bot	ClickUpLinkUnfurler/1.0 (+https://clickup.com)
+Bot	Clickagy Intelligence Bot v2
+Bot	Cliqzbot/0.1 (+http://cliqz.com +cliqzbot@cliqz.com)
+Bot	Cliqzbot/0.1 (+http://cliqz.com/company/cliqzbot)
+Bot	Cloudflare-AutoRAG (https://developers.cloudflare.com/autorag; autorag@cloudflare.com)
+Bot	Cloudflare-Validator/1.0
+Bot	CodaBot/1.0
+Bot	CommaFeed/4.4.0 (https://github.com/Athou/commafeed)
+Bot	Commonly seen variations include: Mozilla/5.0 (X11; U; Linux i686 (x86_64); en-US; rv:1.8.1.11) Gecko/20080109 (Charlotte/0.9t; http://www.searchme.com/support/)
+Bot	Companybook-Crawler (+https://www.companybooknetworking.com/)
+Bot	ContextAd Bot 1.0
+Bot	ConveraCrawler/0.9e (+http://ews.converasearch.com/crawl.htm)
+Bot	Convermax/1.0 (+https://docs.convermax.com/indexer)
+Bot	CookieHub Bot
+!	Corporama matcher 1.2
+Bot	CriteoBot/0.1 (+https://www.criteo.com/criteo-crawler/)
+Bot	Critical CSS Bot
+Bot	Cronless/2.0 (+http://cronless.com)
+Bot	CrunchBot/1.0 (+http://www.leadcrunch.com/crunchbot)
+Bot	Curebot/1.0
+Bot	CyberPatrol SiteCat Webbot (http://www.cyberpatrol.com/cyberpatrolcrawler.asp)
+!	CyotekWebCopy/1.9 CyotekHTTP/6.4
+Bot	DF Bot 1.0
+!	DMBrowser/
+Bot	DaspeedBot/1.0 (+https://daspeed.io/bot-info)
+Bot	Datadog Agent/7.69.2
+Bot	Datadog Synthetic
+!	Datafeedwatch/2.1.x
+Bot	Dazzle BlueSky Bot/1.1
+Bot	Deskyobot/1.0 (+https://www.deskyo.com/bot)
+Bot	Digg Deeper/v1 (http://digg.com/about)
+!	DigiCert DCV/1.1
+Bot	DingTalkBot-LinkService/1.0 (+https://open-doc.dingtalk.com/microapp/faquestions/ftpfeu)
+Bot	DirBuster-1.0-RC1 (http://www.owasp.org/index.php/Category:OWASP_DirBuster_Project)
+!	Discourse Forum Onebox v3.3.0.beta1-dev
+!	Disqus/1.0
+GoogleBot	DoCoMo/2.0 N905i(c100;TB;W24H16) (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)
+Bot	DoCoMo/2.0 P900i(c100;TB;W24H11) (compatible; ichiro/mobile goo; +http://help.goo.ne.jp/help/article/1142/)
+Bot	DoCoMo/2.0 P900i(c100;TB;W24H11) (compatible; ichiro/mobile goo; +http://search.goo.ne.jp/option/use/sub4/sub4-1/)
+Bot	DoCoMo/2.0 P900i(c100;TB;W24H11) (compatible; ichiro/mobile goo;+http://search.goo.ne.jp/option/use/sub4/sub4-1/)
+Bot	DoCoMo/2.0 P900i(c100;TB;W24H11)(compatible; ichiro/mobile goo;+http://help.goo.ne.jp/door/crawler.html)
+Bot	DoCoMo/2.0 P901i(c100;TB;W24H11) (compatible; ichiro/mobile goo; +http://help.goo.ne.jp/door/crawler.html)
+Bot	DomCopBot (https://www.domcop.com/bot)
+Bot	Domain Re-Animator Bot (http://domainreanimator.com) - support@domainreanimator.com
+Bot	DomainStatsBot/1.0 (http://domainstats.io/our-bot)
+Bot	DominicBot/1.0 (+https://vanylla.org/bot)
+!	Download Ninja/4.0
+Bot	DowntimeDetector/4.0 (+https://downforeveryoneorjustme.com)
+Bot	Dratabot (+https://dratabot.com)
+Bot	DreamHost Data Team (+http://www.dreamhost.com/support/)
+Bot	DuckAssistBot/1.2; (+http://duckduckgo.com/duckassistbot.html)
+DuckDuckGoBot	DuckDuckBot/1.0; (+http://duckduckgo.com/duckduckbot.html)
+DuckDuckGoBot	DuckDuckBot/1.1; (+http://duckduckgo.com/duckduckbot.html)
+Bot	E. Orliac, G. Fourestey/2.3 (A Patent Crawler; http://scitas.epfl.ch/; etienne.orliac@epfl.ch, gilles.fourestey@epfl.ch)
+Bot	EZID (EZID link checker; https://ezid.cdlib.org/)
+Bot	EasyBib AutoCite (http://autocite-info.citation-api.com/)
+Bot	EasyCron/1.0 (https://www.easycron.com/)
+Bot	Electronic Frontier Foundation's Do Not Track Verifier (for questions or concerns email dnt-policy@eff.org)
+!	EmailWolf 1.00
+Bot	Embedly +support@embed.ly
+Bot	EpivozCrawler/1.7
+Bot	EvernoteRichLinkBot/1.0 (+https://evernote.com)
+Bot	EvoUptimeBot/1.0
+!	ExodusMovement/1.0 GlobalCoinHeight/1.0
+Bot	Experibot-v2 http://goo.gl/ZAr8wX
+Bot	Experibot-v3 http://goo.gl/ZAr8wX
+Bot	FAST Enterprise Crawler 6 / Scirus scirus-crawler@fast.no; http://www.scirus.com/srsapp/contactus/
+Bot	FAST Enterprise Crawler 6 used by Schibsted (webcrawl@schibstedsok.no)
+Bot	FAST-WebCrawler/3.6/FirstPage (atw-crawler at fast dot no;http://fast.no/support/crawler.asp)
+Bot	FAST-WebCrawler/3.7 (atw-crawler at fast dot no; http://fast.no/support/crawler.asp)
+Bot	FAST-WebCrawler/3.7/FirstPage (atw-crawler at fast dot no;http://fast.no/support/crawler.asp)
+Bot	FAST-WebCrawler/3.8
+Bot	FDL Stats Bot
+FacebookBot	Facebot/1.0
+!	FastmailUA/1.0
+Bot	FedReporter Bot for FFIEC
+Bot	FedReporterDataBot/1.0 (+https://fedreporter.net/FedReporterBotDocumentation;)
+Bot	FediDB/0.5.0; +https://fedidb.org/crawler.html
+Bot	FediIndex/1.0 (+https://fedi.wrm.sr/about)
+Bot	FediList Agent/3 (https://fedilist.com/)
+!	Fedicabot / FedicaApp
+Bot	Fedineko (crabo/0.3.1; +https://fedineko.org/about)
+!	Feed Image Audit -- App
+Bot	FeedBurner/1.0 (http://www.FeedBurner.com)
+!	FeedBurner/1.0 (http://www.FeedBurner.com) Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36 Specificfeeds
+!	FeedFlow/1.0
+Bot	FeedValidator/1.3
+!	Feedbin feed-id:2005098 - 2 subscribers
+!	Feeder / 1.10.8(88)
+Bot	Feedly/1.0 (+http://www.feedly.com/fetcher.html; like FeedFetcher-Google)
+Bot	FeedlyBot/1.0 (http://feedly.com)
+Bot	Feedpresso Content Index Bot
+Bot	Fetch/2.0a (CMS Detection/Web/SEO analysis tool, see http://guess.scritch.org)
+Bot	Fever/1.38 (Feed Parser; http://feedafever.com; Allow like Gecko)
+Bot	FindFiles.net-FaviconFetcher/1.0 (+https://findfiles.net/bot)
+Bot	FirmoGraph (+https://firmograph.io)
+Bot	Flamingo_SearchEngine (+http://www.flamingosearch.com/bot)
+Bot	FreeWebMonitoring SiteChecker/0.2 (+https://www.freewebmonitoring.com/bot.html)
+Bot	FreshRSS/1.11.2 (Linux; https://freshrss.org) like Googlebot
+Bot	FreshpingBot/1.0 (+https://freshping.io/)
+Bot	Friendica 'The Tazmans Flax-lily' 2019.01-1293; https://hoyer.xyz
+Bot	Friendly testing bot
+Bot	FullStoryBot/1.0
+Bot	FuseonBot/1.1 (+http://linkaffinity.io)
+Bot	FyndSearchEngine-Crawler (by fynd.bot; https://fynd.bot)
+Bot	FyndSearchEngine-ReCrawler (by fynd.bot; https://fynd.bot)
+Bot	Fyrebot/1.0
+Bot	G2 Web Services/1.0 (built with StormCrawler Archetype 1.8; https://www.g2webservices.com/; developers@g2llc.com)
+Bot	GG PeekBot 2.0 ( https://www.gg.pl/ https://www.gg.pl/info/praca/ )
+!	GIFTEDVISITOR SCAN
+Bot	Gabanzabot/1.1 (Gabanza Search Engine; https://www.gabanza.com)
+Bot	Gaisbot/3.0 (robot@gais.cs.ccu.edu.tw; http://gais.cs.ccu.edu.tw/robot.php)
+Bot	GarlikCrawler/1.2 (http://garlik.com/, crawler@garlik.com)
+!	GigablastOpenSource/1.0
+Bot	Gigabot/1.0
+Bot	Gigabot/2.0 (http://www.gigablast.com/spider.html)
+Bot	GingerCrawler/1.0 (Language Assistant for Dyslexics; www.gingersoftware.com/crawler_agent.htm; support at ginger software dot com)
+Bot	Go-http-client/1.1
+Bot	Go-http-client/2.0
+!	Google Trust Services (DCV Check)
+Bot	Google Web Preview
+Bot	Google-Adwords-Instant (+http://www.google.com/adsbot.html)
+!	GoogleAssociationService/
+Bot	GoogleStackdriverMonitoring-UptimeChecks(https://cloud.google.com/monitoring)
+GoogleBot	Googlebot-IA/2.1
+GoogleBot	Googlebot-Image/1.0
+GoogleBot	Googlebot-Video/1.0
+GoogleBot	Googlebot/2.1 (+http://www.google.com/bot.html)
+Bot	Grammarly/1.0 (http://www.grammarly.com)
+Bot	GroupMeBot/1.0
+Bot	Grover/Grover-1.18 (Web Crawler)
+Bot	Gulper Web Bot 0.2.4 (www.ecsl.cs.sunysb.edu/~maxim/cgi-bin/Link/GulperBot)
+GoogleBot	Gwene/1.0 (The gwene.org rss-to-news gateway) Googlebot
+Bot	HTTP Banner Detection (https://security.ipip.net)
+!	HTTPie/3.2.2
+!	HanaleiBot runid=beta-stage-integration-test
+Bot	Hatena Antenna/0.3
+Bot	Hatena-Favicon/2 (http://www.hatena.ne.jp/faq/)
+Bot	Hatena::Fetcher/0.01 (master) Furl/3.13
+Bot	Hatena::Russia::Crawler/0.01
+Bot	Hatena::Scissors/0.01
+Bot	HatenaBookmark/4.0 (Hatena::Bookmark; Analyzer)
+!	Hello World
+Bot	HelloworkJobPostingBot/1.0
+Bot	HetrixTools Uptime Monitoring Bot. https://hetrix.tools/uptime-monitoring-bot.html
+Bot	Hlidam.to robot
+Bot	Honeybadger Uptime Check
+Bot	HubSpot Connect 2.0 (http://dev.hubspot.com/) - BizOpsCompanies-Tq2-BizCoDomainValidationAudit
+!	Hydrozen.io/1.0
+!	Hype Machine/4.0 hypem.com (anthony@hypem.com)
+Bot	IAS crawler (ias_crawler; http://integralads.com/site-indexing-policy/)
+Bot	IBM Crawler
+Bot	ICC-Crawler/2.0 (Mozilla-compatible; ; http://kc.nict.go.jp/project1/crawl.html; zurukko1552995316;)
+Bot	ICC-Crawler/2.0 (Mozilla-compatible; ; http://ucri.nict.go.jp/en/icccrawler.html)
+Bot	IDG/EU (http://spaziodati.eu/)
+Bot	IFTTT/1.0 (https://ifttt.com/support)
+Bot	INETDEX-BOT/1.5 (Mozilla/5.0; https://inetdex.com/bot.html)
+Bot	IRLbot/3.0 (compatible; MSIE 6.0; http://irl.cs.tamu.edu/crawler)
+Bot	Iframely/1.3.1 (+https://iframely.com/docs/about) Atlassian
+Bot	IlTrovatore-Setaccio ( http://www.iltrovatore.it)
+Bot	Innguma/1.0 (+https://factory.innguma.com/fetcher/)
+Bot	Innovazion Crawler/Nutch-1.7
+Bot	Instapaper/4.0Instaparser/1.0
+!	Integromat/production
+Bot	IonCrawl (https://www.ionos.de/terms-gtc/faq-crawler-en/)
+Bot	Irokez.cz monitoring v1.2 - (http://www.irokez.cz, Irokez.cz, crawl)
+!	Jersey/2.25.1 (HttpUrlConnection 1.8.0_141)
+!	Jetty/9.3.z-SNAPSHOT
+Bot	Jigsaw/2.3.0 W3C_CSS_Validator_JFouffa/2.0
+Bot	K7MLWCBot/1.0 (+http://www.k7computing.com)
+Bot	KDDI-CA31 UP.Browser/6.2.0.7.3.129 (GUI) MMP/2.0 (compatible; ichiro/mobile goo; +http://help.goo.ne.jp/help/article/1142/)
+Bot	KDDI-CA31 UP.Browser/6.2.0.7.3.129 (GUI) MMP/2.0 (compatible; ichiro/mobile goo; +http://search.goo.ne.jp/option/use/sub4/sub4-1/)
+Bot	KDDI-CA31 UP.Browser/6.2.0.7.3.129 (GUI) MMP/2.0 (compatible; ichiro/mobile goo;+http://search.goo.ne.jp/option/use/sub4/sub4-1/)
+Bot	Kemvibot/1.0 (http://kemvi.com, marco@kemvi.com)
+!	Klaviyo/1.0
+Bot	LCC (+http://corpora.informatik.uni-leipzig.de/crawler_faq.html)
+Bot	LMArenaUnfurlBot/1.0 (Link preview bot for AI model comparison platform; +https://lmarena.ai) Mozilla/5.0 (compatible)
+Bot	Landau-Media-Spider/1.0(http://bots.landaumedia.de/bot.html)
+Bot	Lemmy/0.19.8; +https://leminal.space
+!	Library Of Congress Web Archiving
+Bot	LightspeedSystemsCrawler Mozilla/5.0 (Windows; U; MSIE 9.0; Windows NT 9.0; en-US
+!	Likely BoardGamePricesBot or similar (not officially published)
+Bot	Linguee Bot (http://www.linguee.com/bot)
+Bot	Linguee Bot (http://www.linguee.com/bot; bot@linguee.com)
+Bot	LinkAce/1 (https://github.com/Kovah/LinkAce)
+LinkedInBot	LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com)
+LinkedInBot	LinkedInBot/1.0 (compatible; Mozilla/5.0; Jakarta Commons-HttpClient/3.1 +http://www.linkedin.com)
+LinkedInBot	LinkedInBot/1.0 (compatible; Mozilla/5.0; Jakarta Commons-HttpClient/4.3 +http://www.linkedin.com)
+Bot	LinkupBot/1.0 (LinkupBot for web indexing; https://linkup.so/bot; bot@linkup.so)
+Bot	LivelapBot/0.2 (http://site.livelap.com/crawler)
+Bot	Livelapbot/0.1
+!	LogicMonitor SiteMonitor/1.0
+Bot	MADBbot/0.1 (Gathering webpages for data analytics; https://madb.zapto.org/bot.html; ma-db-crawl@googlegroups.com)
+Bot	MBCrawler/1.0 (https://monitorbacklinks.com)
+Bot	MJ12bot/v1.2.0 (http://majestic12.co.uk/bot.php?+)
+Bot	MLBot (www.metadatalabs.com/mlbot)
+Bot	MTRobot/0.2 (Metrics Tools Analytics Crawler; https://metrics-tools.de/robot.html; crawler@metrics-tools.de)
+Bot	Magnet.me-web/1.0 (+https://magnet.me/bot.html)
+Bot	MagpieRSS/0.7 ( http://magpierss.sf.net)
+Bot	Magus Bot 1.0
+!	Make/production
+Bot	Mattermost-Bot/1.1
+Bot	MauiBot (crawler.feedback+wc@gmail.com)
+Bot	Mavifinds Bot
+Bot	Mechanize/2.9.1 Ruby/3.1.2 (http://github.com/sparklemotion/mechanize/)
+Bot	MediaMonitoringBot/1.1 (+https://mediamonitoringbot.com/crawler; crawler@mediamonitoringbot.com)
+!	Mediatoolkitbot (complaints@mediatoolkit.com)
+Bot	MediavineMetadataParser/7.7.3
+Bot	Mediumbot-MetaTagFetcher/0.3 (+https://medium.com/)
+Bot	MeltwaterNews www.meltwater.com
+Bot	MergadoBot (+http://mergado.cz)
+Bot	MetaInspector/5.6.0 (+https://github.com/jaimeiniesta/metainspector)
+!	MetaURI API/2.0 +metauri.com
+!	Metorik API Client/2.0.1
+!	MgidBot 1.0
+Bot	MicrosoftPreview/2.0; +https://aka.ms/MicrosoftPreview
+Bot	MixnodeCache/1.8(+https://cache.mixnode.com/)
+Bot	ModernizeBot/0.1 (+https://modernizeyourwebsite.com/bot)
+!	ModularConnector/1.0 (Linux)
+Bot	MojeekBot/0.2 (archi; http://www.mojeek.com/bot.html)
+!	Mollie HTTP client/1.0
+Bot	MoodleBot/1.0
+GoogleBot	Mozilla (Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html))
+Bot	Mozilla / 5.0(Windows NT 10.0; Win64; x64) AppleWebKit / 537.36(KHTML, like Gecko; compatible; URLSuMaBot / 1.0; +https://www.urlsuma.de/bot.aspx) Chrome / 70.0.3538.77 Safari / 537.36
+Bot	Mozilla/2.0 (compatible; Ask Jeeves/Teoma; +http://about.ask.com/en/docs/about/webmasters.shtml)
+Bot	Mozilla/2.0 (compatible; Ask Jeeves/Teoma; +http://sp.ask.com/docs/about/tech_crawling.html)
+Bot	Mozilla/3.0 (Vagabondo/2.0 MT; webcrawler@NOSPAMexperimental.net; http://aanmelden.ilse.nl/?aanmeld_mode=webhints)
+!	Mozilla/3.0 (compatible; Indy Library)
+!	Mozilla/3.0 (compatible; WebCapture 2.0; Auto; Windows)
+!	Mozilla/4.0 (compatible;  MSIE 5.01; GomezAgent 2.0; Windows NT)
+Bot	Mozilla/4.0 (compatible; MSIE 4.01; Windows CE; PPC; 240x320; SPV M700; OpVer 19.123.2.733) OrangeBot-Mobile 2008.0 (mobilesearch.support@orange-ftgroup.com)
+Bot	Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0; Offline Explorer; MSIECrawler)
+Bot	Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0;.NET CLR 1.0.3705; ContextAd Bot 1.0)
+!	Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; Netcraft SSL Server Survey - contact info@netcraft.com)
+Bot	Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1;  http://www.changedetection.com/bot.html )
+!	Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.0) LinkCheck by Siteimprove.com
+!	Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.0) Match by Siteimprove.com
+Bot	Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; RetrevoPageAnalyzer; +http://www.retrevo.com/content/about-us)
+!	Mozilla/4.0 (compatible; MSIE 7.0; Windows NT) NewsNow/1.0
+!	Mozilla/4.0 (compatible; Netcraft Web Server Survey)
+Bot	Mozilla/4.0 (compatible; Vagabondo/2.2; webcrawler at wise-guys dot nl)
+Bot	Mozilla/4.0 (compatible; Vagabondo/4.0Beta; webcrawler at wise-guys dot nl; http://webagent.wise-guys.nl/; http://www.wise-guys.nl/)
+!	Mozilla/4.0 (compatible; Zealbot 1.0)
+Bot	Mozilla/4.0 (compatible; grub-client-0.3.0; Crawl your own stuff with http://grub.org)
+Bot	Mozilla/4.0 (compatible; grub-client-1.0.4; Crawl your own stuff with http://grub.org)
+Bot	Mozilla/4.0 (compatible; grub-client-1.0.5; Crawl your own stuff with http://grub.org)
+Bot	Mozilla/4.0 (compatible; grub-client-1.0.6; Crawl your own stuff with http://grub.org)
+Bot	Mozilla/4.0 (compatible; grub-client-1.0.7; Crawl your own stuff with http://grub.org)
+Bot	Mozilla/4.0 (compatible; grub-client-1.1.1; Crawl your own stuff with http://grub.org)
+Bot	Mozilla/4.0 (compatible; grub-client-1.2.1; Crawl your own stuff with http://grub.org)
+Bot	Mozilla/4.0 (compatible; grub-client-1.3.1; Crawl your own stuff with http://grub.org)
+Bot	Mozilla/4.0 (compatible; grub-client-1.3.7; Crawl your own stuff with http://grub.org)
+Bot	Mozilla/4.0 (compatible; grub-client-1.4.3; Crawl your own stuff with http://grub.org)
+Bot	Mozilla/4.0 (compatible; grub-client-1.5.3; Crawl your own stuff with http://grub.org)
+Bot	Mozilla/4.0 compatible ZyBorg/1.0 (wn-14.zyborg@looksmart.net; http://www.WISEnutbot.com)
+!	Mozilla/4.5 (compatible; HTTrack 3.0x; Windows 98)
+Bot	Mozilla/5.0 (Compatible; Feedsearch Bot; +https://feedearch.dev)
+!	Mozilla/5.0 (Google-PhysicalWeb)
+Bot	Mozilla/5.0 (HeadOnlyScraper)
+Bot	Mozilla/5.0 (HeadOnlyScraperV2)
+!	Mozilla/5.0 (Java) outbrain
+Bot	Mozilla/5.0 (Linux) (compatible; AlexandriaOrgBot/1.0; +https://www.alexandria.org/bot.html)
+!	Mozilla/5.0 (Linux; Android 15; CPH2557 Build/AP3A.240617.008; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/142.0.7444.142 Mobile Safari/537.36 Instagram 406.0.0.58.159 Android (35/15; 480dpi; 1080x2400; OPPO; CPH2557; OP573DL1; mt6833; en_MY; 822918295; IABMV/1) NV/1
+!	Mozilla/5.0 (Linux; Android 15; GEC77) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36 Nitro-Optimizer-Agent
+!	Mozilla/5.0 (Linux; Android 16; Pixel 10 Pro XL Build/CP1A.260305.018; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/146.0.7680.174 Mobile Safari/537.36 MetaIAB Facebook
+Bot	Mozilla/5.0 (Linux; Android 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; TikTokSpider; ttspider-feedback@tiktok.com)
+BytedanceBot	Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.5267.1259 Mobile Safari/537.36; Bytespider
+BytedanceBot	Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.7990.1979 Mobile Safari/537.36; Bytespider
+BytedanceBot	Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.2268.1523 Mobile Safari/537.36; Bytespider
+GoogleBot	Mozilla/5.0 (Linux; Android 5.0; SM-G920A) AppleWebKit (KHTML, like Gecko) Chrome Mobile Safari (compatible; AdsBot-Google-Mobile; +http://www.google.com/mobile/adsbot.html)
+!	Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4) Build/MPJ24.139-64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.81 Mobile Safari/537.36 PTST/391
+!	Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4) Build/MPJ24.139-64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.146 Mobile Safari/537.36 PTST/180521.140508
+!	Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3694.0 Mobile Safari/537.36 Chrome-Lighthouse
+!	Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36(KHTML, like Gecko) Chrome/69.0.3464.0 Mobile Safari/537.36 Chrome-Lighthouse
+GoogleBot	Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.5735.179 Mobile Safari/537.36 (compatible; Google-Safety; +http://www.google.com/bot.html)
+!	Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.201 Mobile Safari/537.36 (compatible; Google-InspectionTool/1.0;)
+Bot	Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6439.0 Mobile Safari/537.36 +https://sitebulb.com
+GoogleBot	Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+GoogleBot	Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+Bot	Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Huckabot/0.0; +https://huckabuy.com/)
+Bot	Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Google-CloudVertexBot; +https://cloud.google.com/enterprise-search)
+!	Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Google-InspectionTool/1.0)
+Bot	Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36(compatible; MarketingMiner v2.0; +https://www.marketingminer.com)
+BytedanceBot	Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2576.1836 Mobile Safari/537.36; Bytespider
+BytedanceBot	Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.9681.1227 Mobile Safari/537.36; Bytespider
+BytedanceBot	Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.6023.1635 Mobile Safari/537.36; Bytespider
+BytedanceBot	Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.4944.1981 Mobile Safari/537.36; Bytespider
+BytedanceBot	Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.3613.1739 Mobile Safari/537.36; Bytespider
+BytedanceBot	Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.4022.1033 Mobile Safari/537.36; Bytespider
+BytedanceBot	Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.3248.1547 Mobile Safari/537.36; Bytespider
+BytedanceBot	Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.5527.1507 Mobile Safari/537.36; Bytespider
+!	Mozilla/5.0 (Linux; Android 7.0; Moto G (4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4695.0 Mobile Safari/537.36 Chrome-Lighthouse
+GoogleBot	Mozilla/5.0 (Linux; Android 7.0; SM-G930V Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36 (compatible; Google-Read-Aloud; +https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers)
+Bot	Mozilla/5.0 (Linux; Android 7.0;) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; AspiegelBot)
+PetalBot	Mozilla/5.0 (Linux; Android 7.0;) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; PetalBot;+https://webmaster.petalsearch.com/site/petalbot)
+BytedanceBot	Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.5216.1326 Mobile Safari/537.36; Bytespider
+BytedanceBot	Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.9038.1080 Mobile Safari/537.36; Bytespider
+Bot	Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36 (compatible; EzoicBot-Nicheiq; +http://www.ezoic.com/bot)
+Bot	Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36 (compatible; EzoicBot-UptimeOwl; +http://www.ezoic.com/bot)
+Bot	Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012; Storebot-Google/1.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
+Bot	Mozilla/5.0 (Linux; CentOS; compatible; semantic-visions-discovery; HTTPClient 4.5)
+!	Mozilla/5.0 (Linux; U; Android 1.6; ja-jp; SonyEricssonSO-01B Build/R1EA018) AppleWebKit/528.5 (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 (compatible; ichiro/mobile goo; http://help.goo.ne.jp/help/article/1142)
+!	Mozilla/5.0 (Linux; U; Android 2.3.4; generic) AppleWebKit/537.36 (KHTML, like Gecko; Google Web Preview) Version/4.0 Mobile Safari/537.36
+!	Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/55.0 BrandVerity/1.0 (http://www.brandverity.com/why-is-brandverity-visiting-me)
+Bot	Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:49.0) Gecko/20100101 Firefox/49.0 (FlipboardProxy/1.2; +http://flipboard.com/browserproxy)
+!	Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:103.0) Gecko/20100101 Firefox/103.0 abuse.xmco.fr
+Bot	Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:28.0) Gecko/20100101 Firefox/28.0 (FlipboardProxy/1.1; +http://flipboard.com/browserproxy)
+!	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10; rv:60.0) Gecko/20100101 Firefox/60.0 Collapsify
+Bot	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.111 Safari/537.36 moatbot
+AmazonBot	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Amazonbot/0.1; +https://developer.amazon.com/support/amazonbot)
+AppleBot	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Applebot/0.1)
+AppleBot	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Applebot/0.1; +http://www.apple.com/go/applebot)
+Bot	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.125 Safari/537.36 (compatible; KosmioBot/1.0; +http://kosm.io/bot.html)
+Bot	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.101 Safari/537.36 SWIMGBot
+Bot	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36 AppEngine-Google; (+http://code.google.com/appengine; appid: s~feedly-nikon3)
+!	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36 Hardenize
+!	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36 (ThousandEyes Agent)
+!	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) YLT Chrome/85.0.4183.121 Safari/537.36
+!	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36 ZoteroTranslationServer/WMF (mailto:noc@wikimedia.org)
+Bot	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36 ArchiveBox/0.7.2 (+https://github.com/ArchiveBox/ArchiveBox/)
+!	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36 SQWatcher/202312 (sqcompliance.com/sqwatcher.html)
+!	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36; Manus-User/1.0
+!	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 newsai/1.0 Safari/537.36
+Bot	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.107 Safari/537.36 (compatible; +https://developers.cloudflare.com/security-center/)
+!	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36 Silktide
+Bot	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko; compatible; PulsePoint-Crawler) Chrome/120.0.0.0 Safari/537.36
+!	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7; TSM-turingos-1253296984) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36
+Bot	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7; TSMbot) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36
+Bot	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.13 (KHTML, like Gecko) Chrome/30.0.1599.66 Safari/537.13 Luminator-robots/2.0
+!	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/600.1.17 (KHTML, like Gecko) Version/7.1 Safari/537.85.10 MarketGoo/2.1
+Bot	Mozilla/5.0 (Macintosh; Intel Mac OS X 13_0_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36 ISSCyberRiskCrawler/1.1.4
+Bot	Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2) Gecko/20100115 Firefox/3.6 (FlipboardProxy/1.1; +http://flipboard.com/browserproxy)
+!	Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_6; en-us) AppleWebKit/528.16 (KHTML, like Gecko) Fluid/0.9.6 Safari/528.16
+Bot	Mozilla/5.0 (Supabase Paired Crawler HTTP/2)
+Bot	Mozilla/5.0 (TweetmemeBot/4.0; +http://datasift.com/bot.html) Gecko/20100101 Firefox/31.0
+PingdomBot	Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) PingdomTMS/0.8.5 Safari/534.34
+Bot	Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.1.1 Safari/538.1 bl.uk_lddc_renderbot/2.0.0 (+ http://www.bl.uk/aboutus/legaldeposit/websites/websites/faqswebmaster/index.html)
+Bot	Mozilla/5.0 (WhatsMyIP.org Text_to_Code_Ratio_Tool) http://whatsmyip.org/ua
+!	Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36 (Dotcom-Monitor)
+Bot	Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko; compatible; Cookiebot/1.0; +http://cookiebot.com/) Chrome/97.0.4692.71 Safari/537.36
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36 Dlc/2.0.1
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 SecurityHeaders
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36 nyt_scraping/scraping@nytimes.com
+GoogleBot	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.5735.179 Safari/537.36 (compatible; Google-Safety; +http://www.google.com/bot.html)
+Bot	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36 (compatible; CrawlyProjectCrawler/0.1.3; crawlyproject@digitaldragon.dev +https://crawlyproject.digitaldragon.dev/)
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Playwright/1.40.0
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36; Selenium
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 CookieHubScan/3.0
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 CookieHubVerify/3.0
+Bot	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 CybaaBot
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36 Readable/1.1.4
+Bot	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36 (+https://whatis.contentkingapp.com)
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/17.17134 www.uptimedoctor.com (username slowmail)
+Bot	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.75 Safari/537.36 (compatible; SMTBot/1.0; +http://www.similartech.com/smtbot)
+Bot	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.75 Safari/537.36 (compatible; SMTBot/1.0; http://www.similartech.com/smtbot)
+Bot	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Safari/537.36 https://linko.app/crawler
+Bot	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.97 Safari/537.36 (+https://www.loc.gov/programs/web-archiving/for-site-owners/)
+Bot	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.97 Safari/537.36 +https://www.mirrorweb.com
+Bot	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Flyriverbot/1.1 (+https://www.flyriver.com/; AI Content Source Check)
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36 Edg/96.0.1054.57 PWABuilderHttpAgent
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36 (Autoconfig Test from USTC, Quit please contact: mailservertest2023@gmail.com)
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.115.0 Chrome/142.0.7444.265 Electron/39.8.5 Safari/537.36
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Trae/1.107.1 Chrome/142.0.7444.235 Electron/39.2.7 Safari/537.36
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) browser/2020.2.0 Chrome/78.0.3904.130 Electron/7.1.7 Safari/537.36 PingdomTMS/2020.2
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) browser/2020.2.1 Chrome/78.0.3904.130 Electron/7.3.2 Safari/537.36 PingdomTMS/2020.2
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) browser/2020.2.5 Chrome/78.0.3904.130 Electron/7.3.15 Safari/537.36 PingdomTMS/2020.2
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) renderer/2020.2.0 Chrome/78.0.3904.130 Electron/7.1.7 Safari/537.36 PingdomTMS/2020.2
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko, Foregenix) Chrome/91.0.4472.77 Safari/537.36
+Bot	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko; CookieYesbot/1.0; +http://www.cookieyes.com/documentation/cookieyesbot) Chrome/131.0.6778.0 Safari/537.36
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko; compatible; BW/1.2; rb.gy/oupwis) Chrome/124.0.0.0 Safari/537.36
+Bot	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/605.1.15 (KHTML, like Gecko; compatible; FriendlyCrawler/1.0) Chrome/120.0.6099.216 Safari/605.1.15
+Bot	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/605.1.16 (KHTML, like Gecko; compatible; Friendly_Crawler/2.0) Chrome/120.0.6099.217 Safari/605.1.15/Nutch-1.20-SNAPSHOT
+Bot	Mozilla/5.0 (Windows NT 10.0; Win64; x64; BDCbot/1.0; +http://bigweb.bigdatacorp.com.br/faq.aspx) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36
+!	Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0 MonitoRSS/1.0
+Bot	Mozilla/5.0 (Windows NT 10.0; Win64; x64; trendictionbot0.5.0; trendiction search; http://www.trendiction.de/bot; please let us know of any problems; web at trendiction.com) Gecko/20170101 Firefox/67.0
+Bot	Mozilla/5.0 (Windows NT 10.0; cludo.com bot) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36
+Bot	Mozilla/5.0 (Windows NT 5.1) brokenlinkcheck.com/1.2
+Bot	Mozilla/5.0 (Windows NT 5.1; U; Win64; fr; rv:1.8.1) VoilaBot BETA 1.2 (support.voilabot@orange-ftgroup.com)
+!	Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)
+Bot	Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.1 (KHTML, like Gecko) Chrome/21.0.1180.89 Safari/537.1; 360Spider
+Bot	Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.1 (KHTML, like Gecko) Chrome/21.0.1180.89 Safari/537.1; 360Spider(compatible; HaosouSpider; http://www.haosou.com/help/help_3_2.html)
+BingBot	Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534+ (KHTML, like Gecko) BingPreview/1.0b
+MsnBot	Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534+ (KHTML, like Gecko) MsnBot-Media /1.0b
+!	Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.64 Safari/537.11 GotSiteMonitor.com
+Bot	Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36; 360Spider
+Bot	Mozilla/5.0 (Windows NT 6.1; WOW64) SkypeUriPreview Preview/0.5
+Bot	Mozilla/5.0 (Windows NT 6.1; WOW64) acunetix-product/wvs (Acunetix Web Vulnerability Scanner - Free Edition)
+Bot	Mozilla/5.0 (Windows NT 6.1; WOW64; https://top.mail.ru/passremind) AppleWebKit/537.22 (KHTML, like Gecko)
+Bot	Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.81 YisouSpider/5.0 Safari/537.36
+Bot	Mozilla/5.0 (Windows NT 6.1; Win64; x64; +http://url-classification.io/wiki/index.php?title=URL_server_crawler) KStandBot/1.0
+Bot	Mozilla/5.0 (Windows NT 6.1; Win64; x64; +http://www.komodia.com/newwiki/index.php/URL_server_crawler) KomodiaBot/1.0
+Bot	Mozilla/5.0 (Windows NT 6.1; Win64; x64; +https://www.ubtsupport.com/legal/Streamline3Bot.php) Streamline3Bot/1.0
+Bot	Mozilla/5.0 (Windows NT 6.1; compatible; BDCbot/1.0; +http://bigweb.bigdatacorp.com.br/faq.aspx) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36
+Bot	Mozilla/5.0 (Windows NT 6.1; rv:34.0) Gecko/20100101 Firefox/34.0; Dragonbot; http://www.dragonmetrics.com
+!	Mozilla/5.0 (Windows NT 6.1; rv:38.0) Gecko/20100101 Firefox/38.0 (IndeedBot 1.1)
+Bot	Mozilla/5.0 (Windows NT 6.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.63 Safari/537.36 QIHU 360SE; 360Spider
+Bot	Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.5 Safari/537.22 +awesomecrawler
+!	Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.0 Safari/537.36 PTST/1.0
+!	Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.4 (KHTML, like Gecko) Chrome/98 Safari/537.4 (StatusCake)
+Bot	Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv 11.0) like Gecko (compatible; Zombiebot/2.1; +http://www.zombiedomain.net/robot/)
+!	Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko PTST/1.0
+!	Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0; BingPreview/1.0b) like Gecko
+Bot	Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Safari/537.36 (compatible; PagePeeker/3.0; +https://pagepeeker.com/robots/)
+Bot	Mozilla/5.0 (Windows NT 6.3;compatible; DVbot/1.0; +http://www.doubleverify.com)
+Bot	Mozilla/5.0 (Windows NT 6.3;compatible; Leikibot/1.0; +http://www.leiki.com)
+BingBot	Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 530) like Gecko (compatible; adidxbot/2.0; +http://www.bing.com/bingbot.htm)
+!	Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 530) like Gecko BingPreview/1.0b
+Bot	Mozilla/5.0 (Windows; U; MSIE 9.0; Windows NT 9.0; en-US) AppEngine-Google; (+http://code.google.com/appengine; appid: s~virustotalcloud)
+Bot	Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.7.10) Gecko/20050716 Thunderbird/1.0.6 - WebCrawler http://cognitiveseo.com/bot.html
+Bot	Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.116 Safari/537.36 HubSpot Webcrawler - web-crawlers@hubspot.com
+Bot	Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) Speedy Spider (http://www.entireweb.com/about/search_tech/speedy_spider/)
+Bot	Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) Speedy Spider for SpeedyAds (http://www.entireweb.com/about/search_tech/speedy_spider/)
+Bot	Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.6) Gecko/20070725 Firefox/2.0.0.6 - James BOT - WebCrawler http://cognitiveseo.com/bot.html
+Bot	Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.1.2) Gecko/20090729 Firefox/3.5.2 (.NET CLR 3.5.30729; Diffbot/0.1; +http://www.diffbot.com)
+Bot	Mozilla/5.0 (Windows; U; Windows NT 5.1; en; rv:1.9.0.13) Gecko/2009073022 Firefox/3.5.2 (.NET CLR 3.5.30729) SurveyBot/2.3 (DomainTools)
+Bot	Mozilla/5.0 (Windows; U; Windows NT 5.1; fr; rv:1.8.1) VoilaBot BETA 1.2 (support.voilabot@orange-ftgroup.com)
+Bot	Mozilla/5.0 (Windows; U; Windows NT 5.1; zh-CN; )  Firefox/1.5.0.11; 360Spider
+Bot	Mozilla/5.0 (Windows; U; Windows NT 5.1; zh-CN; rv:1.8.0.11)  Firefox/1.5.0.11; 360Spider
+Bot	Mozilla/5.0 (Windows; U; Windows NT 5.1; zh-CN; rv:1.8.0.11) Firefox/1.5.0.11 360Spider;
+Bot	Mozilla/5.0 (Windows; U; Windows NT 5.1; zh-CN; rv:1.8.0.11) Gecko/20070312 Firefox/1.5.0.11; 360Spider
+Bot	Mozilla/5.0 (Windows; U; Windows NT 6.0; en-GB; rv:1.0; trendictionbot0.5.0; trendiction search; http://www.trendiction.de/bot; please let us know of any problems; web at trendiction.com) Gecko/20071127 Firefox/3.0.0.11
+!	Mozilla/5.0 (Windows; U; Windows NT 6.1; en-GB; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 (NetShelter ContentScan)
+!	Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.2) Gecko/20100115 Firefox/3.6 MSIE 7.0; Sucuri Integrity Monitor/2.4
+!	Mozilla/5.0 (X11; Datanyze; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36
+!	Mozilla/5.0 (X11; Linux i586; rv:31.0) Gecko/20100101 Firefox/31.0 PrintFriendly.com
+Bot	Mozilla/5.0 (X11; Linux i686; rv:6.0) Gecko/20100101 Firefox/6.0 (Freshbot/1.0/EU; http://webagent.wise-guys.nl/)
+Bot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) (dbot)
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.60 Safari/537.36 NewRelicSynthetics/1.0
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0 Safari/537.36 Ghost Inspector (63c85ddbde52d6697f57c623)
+Bot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36 (compatible; AmazonProductDiscovery/1.0; https://vendorcentral.amazon.com/support/amazonproductbot)
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36 GTmetrix
+Bot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 (compatible; AmazonSellerInitiatedListing/1.0; https://vendorcentral.amazon.com/support/amazonproductbot)
+Bot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 (compatible; harsilbot/1.1; +http://www.harsil.com/bot)
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.6422.26 Safari/537.36 TestLocally/1.0
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6478.182 Safari/537.36 PlayStore-Google
+Bot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36 (compatible; XY-Archive-Compliance-Archiver; +https://archive.xyplanningnetwork.com/)
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36 Scope3/2.0 (scope3.com)
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.6998.35 Safari/537.36 (Checkly, https://www.checklyhq.com)
+Bot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36; Devin/1.0; +https://devin.ai
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Sindup/1.0.0
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.7204.168 Safari/537.36 DatadogSynthetics
+Bot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.7339.16 Safari/537.36 (compatible; ActiveComply/2.0; +https://app.activecomply.com/bot)
+Bot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36 (compatible; YandexScreenshotBot/3.0; +http://yandex.com/bots)
+GoogleBot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36 (compatible; Google-Read-Aloud; +https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers)
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36 Google Favicon
+Bot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36 Google (+https://developers.google.com/+/web/snippet/
+Bot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36 Google-PageRenderer Google (+https://developers.google.com/+/web/snippet/)
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.75 Safari/537.36 DareBoost
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3694.0 Safari/537.36 Chrome-Lighthouse
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.87 Safari/537.36 LinkTiger
+Bot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36 SeoSiteCheckup (https://seositecheckup.com)
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.0 Safari/537.36 Criticalcss.com/2.0.0
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36 PTST/211202.211915
+Bot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/120.0.0.0 Safari/537.36 Puppeteer
+Bot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/69.0.3494.0 Safari/537.36
+Bot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/74.0.3729.169 Safari/537.36
+Bot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/76.0.3803.0 Safari/537.36
+Bot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/87.0.4280.88 YextBot/Java Safari/537.36
+PingdomBot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/59.0.3071.109 Chrome/59.0.3071.109 Safari/537.36 PingdomPageSpeed/1.0 (pingbot/2.0; +http://www.pingdom.com/)
+PingdomBot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/61.0.3163.100 Chrome/61.0.3163.100 Safari/537.36 PingdomPageSpeed/1.0 (pingbot/2.0; +http://www.pingdom.com/)
+PingdomBot	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/61.0.3163.100 Chrome/61.0.3163.100 Safari/537.36 PingdomPageSpeed/1.0 (pingbot/2.0; http://www.pingdom.com/)
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko; GeedoShopProductFinder) Chrome/142.0.0.0 Safari/537.36
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko; Google Web Preview) Chrome/27.0 .1453 Safari/537.36.
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko; Google Web Preview) Chrome/27.0.1453 Safari/537.36
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko; compatible; Google-Agent)
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko; compatible; GoogleAgent-Mariner) Chrome/142.0.7444.162 Safari/537.36
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36(KHTML, like Gecko) Chrome/69.0.3464.0 Safari/537.36 Chrome-Lighthouse
+!	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/602.1 (KHTML, like Gecko) splash Version/10.0 Safari/602.1
+!	Mozilla/5.0 (X11; Linux x86_64) Miniature.io/6.0 AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.12.4 Chrome/69.0.3497.128 Safari/537.36
+!	Mozilla/5.0 (X11; Linux x86_64) Nikto/2.5.0 (Evasions:None) (Test:Port Check)
+Bot	Mozilla/5.0 (X11; Linux x86_64; HubSpot Single Page link check; web-crawlers+links@hubspot.com) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36
+!	Mozilla/5.0 (X11; Linux x86_64; Rigor) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Safari/537.36
+Bot	Mozilla/5.0 (X11; Linux x86_64; Storebot-Google/1.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36
+Bot	Mozilla/5.0 (X11; Linux x86_64; WanscannerBot/1.2; +https://abuse.pend.re) Gecko/20100101 Firefox/10.0
+Bot	Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0 (compatible; AmazonProductDiscovery/1.0; https://vendorcentral.amazon.com/support/amazonproductbot)
+Bot	Mozilla/5.0 (X11; U; Linux Core i7-4980HQ; de; rv:32.0; compatible; JobboerseBot; http://www.jobboerse.com/bot.htm) Gecko/20100101 Firefox/38.0
+!	Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.7.12; ips-agent) Gecko/20050922 Fedora/1.0.7-1.1.fc4 Firefox/1.0.7
+!	Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.3; ips-agent) Gecko/20090824 Fedora/1.0.7-1.1.fc4  Firefox/3.5.3
+!	Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.24; ips-agent) Gecko/20111107 Ubuntu/10.04 (lucid) Firefox/3.6.24
+!	Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:14.0; ips-agent) Gecko/20100101 Firefox/14.0.1
+Bot	Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Xing Bot
+!	Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:49.0) Gecko/20100101 Firefox/49.0 / GnowitNewsbot / Contact information at http://www.gnowit.com
+Bot	Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:72.0) Gecko/20100101 Firefox/72.0 (compatible; img2dataset; +https://github.com/rom1504/img2dataset)
+!	Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0 PTST/211202.211915
+Bot	Mozilla/5.0 (X11; compatible; semantic-visions.com crawler; HTTPClient 4.5)
+Bot	Mozilla/5.0 (compatibl$; Miniflux/2.0.x-dev; +https://miniflux.app)
+!	Mozilla/5.0 (compatible) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.73 Safari/537.36 collection@infegy.com
+Bot	Mozilla/5.0 (compatible) SemanticScholarBot (+https://www.semanticscholar.org/crawler)
+Bot	Mozilla/5.0 (compatible;  Page2RSS/0.7; +http://page2rss.com/)
+!	Mozilla/5.0 (compatible; +centuryb.o.t9[at]gmail.com)
+Bot	Mozilla/5.0 (compatible; +http://tweetedtimes.com)
+Bot	Mozilla/5.0 (compatible; +https://probely.com/sos) ProbelySPDR/0.1.0
+Bot	Mozilla/5.0 (compatible; 007ac9 Crawler; http://crawler.007ac9.net/)
+Bot	Mozilla/5.0 (compatible; A360-Search; +https://area360.uk/)
+Bot	Mozilla/5.0 (compatible; AccessStatus/1.0; +https://www.accesslink.fr/page/a-propos-de-accessstatus/)
+Bot	Mozilla/5.0 (compatible; ActiveComply; +https://www.activecomply.com/)
+Bot	Mozilla/5.0 (compatible; AddSearchBot/0.9; +http://www.addsearch.com/bot; info@addsearch.com)
+Bot	Mozilla/5.0 (compatible; AdkernelTopicCrawler/1.0; +http://adkernel.com/robot/)
+Bot	Mozilla/5.0 (compatible; Adsbot/3.1; +https://seostar.co/robot/)
+Bot	Mozilla/5.0 (compatible; AdvBot/2.0; +http://advbot.net/bot.html)
+AhrefsBot	Mozilla/5.0 (compatible; AhrefsBot/5.2; +http://ahrefs.com/robot/)
+AhrefsBot	Mozilla/5.0 (compatible; AhrefsBot/5.2; News; +http://ahrefs.com/robot/)
+AhrefsBot	Mozilla/5.0 (compatible; AhrefsBot/6.1; +http://ahrefs.com/robot/)
+AhrefsBot	Mozilla/5.0 (compatible; AhrefsBot/6.1; News; +http://ahrefs.com/robot/)
+AhrefsBot	Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)
+Bot	Mozilla/5.0 (compatible; AhrefsSiteAudit/5.2; +http://ahrefs.com/robot/)
+Bot	Mozilla/5.0 (compatible; AhrefsSiteAudit/6.1; +http://ahrefs.com/robot/)
+Bot	Mozilla/5.0 (compatible; AlertSite; +https://www.alertsite.com/)
+Bot	Mozilla/5.0 (compatible; Alexabot/1.0; +http://www.alexa.com/help/certifyscan; certifyscan@alexa.com)
+Bot	Mozilla/5.0 (compatible; AllAfrica NewsBot; +https://allafrica.com/)
+Bot	Mozilla/5.0 (compatible; AllAfrica; +https://allafrica.com/)
+Bot	Mozilla/5.0 (compatible; AlphaBot/3.2; +http://alphaseobot.com/bot.html)
+Bot	Mozilla/5.0 (compatible; Amazon-Bedrock-AgentCore-Browser; +https://aws.amazon.com/bedrock/)
+Bot	Mozilla/5.0 (compatible; AmazonBuyForMe; +https://www.amazon.com/)
+Bot	Mozilla/5.0 (compatible; Amzn-User; +https://developer.amazon.com/)
+Bot	Mozilla/5.0 (compatible; Anchor Browser; +https://anchorbrowser.io/)
+Bot	Mozilla/5.0 (compatible; AndersPinkBot/1.0; +http://anderspink.com/bot.html)
+Bot	Mozilla/5.0 (compatible; Apercite; +http://www.apercite.fr/robot/index.html)
+Bot	Mozilla/5.0 (compatible; ApifyBot/1.0)
+AppleBot	Mozilla/5.0 (compatible; Applebot/0.3; +http://www.apple.com/go/applebot)
+Bot	Mozilla/5.0 (compatible; Artemis; CERT PL; +https://cert.pl/skanowanie)
+!	Mozilla/5.0 (compatible; Attracta)
+Bot	Mozilla/5.0 (compatible; Authory/1.0; +https://authory.com/)
+Bot	Mozilla/5.0 (compatible; AwarioBot/1.0; +https://awario.com/bots.html)
+Bot	Mozilla/5.0 (compatible; BLEXBot/1.0; +http://webmeup-crawler.com/)
+BaiduBot	Mozilla/5.0 (compatible; Baiduspider-render/2.0; +http://www.baidu.com/search/spider.html)
+BaiduBot	Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)
+Bot	Mozilla/5.0 (compatible; BazQux/2.4; +https://bazqux.com/fetcher; 1 subscribers)
+Bot	Mozilla/5.0 (compatible; BehloolBot/beta; +http://www.webeaver.com/bot)
+Bot	Mozilla/5.0 (compatible; BestChange Bot; +https://bestchange.com/)
+Bot	Mozilla/5.0 (compatible; BestChange; +https://bestchange.com/)
+Bot	Mozilla/5.0 (compatible; BitBot/v1.19.0; +https://bitbot.dev)
+Bot	Mozilla/5.0 (compatible; BitSightBot/1.0)
+Bot	Mozilla/5.0 (compatible; BlingERP; +https://www.bling.com.br/)
+Bot	Mozilla/5.0 (compatible; Blockaid; +https://www.blockaid.io/)
+Bot	Mozilla/5.0 (compatible; BlogTraffic/1.4 Feed-Fetcher; +http://www.blogtraffic.de/rss-bot.html)
+Bot	Mozilla/5.0 (compatible; BomboraBot/1.0; +http://www.bombora.com/bot)
+Bot	Mozilla/5.0 (compatible; BoxcarBot/1.1; +awesome@boxcar.io)
+Bot	Mozilla/5.0 (compatible; Bugsnag; +https://www.bugsnag.com/)
+Bot	Mozilla/5.0 (compatible; Butterfly/1.0; +http://labs.topsy.com/butterfly/) Gecko/2009032608 Firefox/3.0.8
+Bot	Mozilla/5.0 (compatible; CLASSLA-web; +https://www.clarin.si/info/classla-web-crawler/)
+Bot	Mozilla/5.0 (compatible; CMSChecker/1.0; +https://cmschecker.net)
+Bot	Mozilla/5.0 (compatible; CapitalOneBot; +https://www.capitalone.com/)
+Bot	Mozilla/5.0 (compatible; CapterraBot/1.0; +https://www.capterra.com)
+Bot	Mozilla/5.0 (compatible; CensysInspect/1.1; +https://about.censys.io/)
+Bot	Mozilla/5.0 (compatible; CentComBot/
+Bot	Mozilla/5.0 (compatible; CertChief; +https://www.certchief.com/)
+Bot	Mozilla/5.0 (compatible; Channel3Bot/1.0; +https://trychannel3.com/channel3bot)
+Bot	Mozilla/5.0 (compatible; ChatGLM-Spider/1.0; +https://chatglm.cn/)
+Bot	Mozilla/5.0 (compatible; Cincraw/1.0; +http://cincrawdata.net/bot/)
+Bot	Mozilla/5.0 (compatible; ClarityBot/9.0; +https://www.seoclarity.net/bot.html)
+Bot	Mozilla/5.0 (compatible; Cliqzbot/0.1 +http://cliqz.com/company/cliqzbot)
+Bot	Mozilla/5.0 (compatible; Cliqzbot/1.0 +http://cliqz.com/company/cliqzbot)
+Bot	Mozilla/5.0 (compatible; Cliqzbot/2.0; +http://cliqz.com/company/cliqzbot)
+Bot	Mozilla/5.0 (compatible; CloudFlare-AlwaysOnline/1.0; +http://www.cloudflare.com/always-online) AppleWebKit/534.34
+Bot	Mozilla/5.0 (compatible; CloudFlare-AlwaysOnline/1.0; +https://www.cloudflare.com/always-online) AppleWebKit/534.34
+Bot	Mozilla/5.0 (compatible; CloudFlare-Prefetch/0.1; +http://www.cloudflare.com/)
+Bot	Mozilla/5.0 (compatible; Cloudflare-Custom-Hostname-Verification; +https://www.cloudflare.com/)
+Bot	Mozilla/5.0 (compatible; Cloudflare-Healthchecks/1.0; +https://www.cloudflare.com/; healthcheck-id: AAAAAAAAAAAAAAAA)
+Bot	Mozilla/5.0 (compatible; Cloudflare-Stream-Webhook; +https://www.cloudflare.com/)
+Bot	Mozilla/5.0 (compatible; Cloudflare-Traffic-Manager/1.0; +https://www.cloudflare.com/traffic-manager/; pool-id: AAAAAAAAAAAAAAAA)
+Bot	Mozilla/5.0 (compatible; CloudflareRadarURLScanner; +https://radar.cloudflare.com/)
+Bot	Mozilla/5.0 (compatible; Cloudtrellis; +https://www.cloudtrellis.com/)
+Bot	Mozilla/5.0 (compatible; Cludo; +https://www.cludo.com/)
+Bot	Mozilla/5.0 (compatible; Cocolyzebot/1.0; https://cocolyze.com/bot)
+Bot	Mozilla/5.0 (compatible; ContextualBot/1.0; +http://outcomes.net)
+Bot	Mozilla/5.0 (compatible; Cotoyogi/4.0; +https://ds.rois.ac.jp/center8/crawler/)
+Bot	Mozilla/5.0 (compatible; Crawlson/1.0; +https://www.crawlson.com/domain)
+Bot	Mozilla/5.0 (compatible; Crazy Egg; +https://www.crazyegg.com/)
+Bot	Mozilla/5.0 (compatible; Current/1.0; +https://currentreader.app; RSS Reader)
+Bot	Mozilla/5.0 (compatible; Dark Visitor/1.0; +https://darkvisitors.com)
+Bot	Mozilla/5.0 (compatible; DataForSeoBot/1.0; +https://dataforseo.com/dataforseo-bot)
+!	Mozilla/5.0 (compatible; Dataprovider.com)
+Bot	Mozilla/5.0 (compatible; Daum/4.1; +http://cs.daum.net/faq/15/4118.html?faqId=28966)
+Bot	Mozilla/5.0 (compatible; Dead Link Checker; http://www.dead-link-checker.com/)
+Bot	Mozilla/5.0 (compatible; DeepSeekBot/1.0; +https://www.deepseek.com/bot)
+Bot	Mozilla/5.0 (compatible; Detectify) +https://detectify.com/bot/
+Bot	Mozilla/5.0 (compatible; DeuSu/0.1.0; +https://deusu.org)
+Bot	Mozilla/5.0 (compatible; DeuSu/5.0.2; +https://deusu.de/robot.html)
+Bot	Mozilla/5.0 (compatible; Digincore bot; https://www.digincore.com/crawler.html for rules and instructions.)
+Bot	Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)
+Bot	Mozilla/5.0 (compatible; Dmbot/1.1)
+Bot	Mozilla/5.0 (compatible; DnyzBot/1.0)
+Bot	Mozilla/5.0 (compatible; Domains Project/1.0.3; +https://github.com/tb0hdan/domains)
+Bot	Mozilla/5.0 (compatible; DotBot/1.1; http://www.opensiteexplorer.org/dotbot, help@moz.com)
+Bot	Mozilla/5.0 (compatible; Dow Jones Searchbot)
+Bot	Mozilla/5.0 (compatible; DrataAutopilot; +https://drata.com/)
+Bot	Mozilla/5.0 (compatible; Drupalbot; +https://www.drupal.org)
+Bot	Mozilla/5.0 (compatible; Dubbotbot/0.2; +http://dubbot.com)
+DuckDuckGoBot	Mozilla/5.0 (compatible; DuckDuckBot-Https/1.1; https://duckduckgo.com/duckduckbot)
+Bot	Mozilla/5.0 (compatible; DuckDuckGo-Favicons-Bot/1.0; +http://duckduckgo.com)
+Bot	Mozilla/5.0 (compatible; EchoboxBot/1.0; hash/w4mwnpbXf3MFAbxOkJRw; +http://www.echobox.com)
+Bot	Mozilla/5.0 (compatible; EcoVadisSustainabilityBot/1.0; +https://www.ecovadis.com; Crawling on behalf of one of your business partners.)
+Bot	Mozilla/5.0 (compatible; EdgeWatch/1.1; https://about.edgewatch.com/)
+Bot	Mozilla/5.0 (compatible; Embedly/0.2; +http://support.embed.ly/)
+Bot	Mozilla/5.0 (compatible; Embedly/0.2; snap; +http://support.embed.ly/)
+Bot	Mozilla/5.0 (compatible; EtaoSpider/1.0; http://open.etao.com/dev/EtaoSpider)
+Bot	Mozilla/5.0 (compatible; EveryoneSocialBot/1.0; support@everyonesocial.com http://everyonesocial.com/)
+Bot	Mozilla/5.0 (compatible; Exabot PyExalead/3.0; +http://www.exabot.com/go/robot)
+Bot	Mozilla/5.0 (compatible; Exabot-Images/3.0; +http://www.exabot.com/go/robot)
+Bot	Mozilla/5.0 (compatible; Exabot/3.0 (BiggerBetter); +http://www.exabot.com/go/robot)
+Bot	Mozilla/5.0 (compatible; Exabot/3.0;  http://www.exabot.com/go/robot)
+Bot	Mozilla/5.0 (compatible; Exabot/3.0; +http://www.exabot.com/go/robot)
+Bot	Mozilla/5.0 (compatible; ExtLinksBot/1.5 +https://extlinks.com/Bot.html)
+Bot	Mozilla/5.0 (compatible; ExteContextCrawl/1.0; +http://crawl001.exte.ai)
+Bot	Mozilla/5.0 (compatible; Eyeotabot/1.0; +http://www.eyeota.com)
+Bot	Mozilla/5.0 (compatible; Ezgif/69.420; +https://ezgif.com/about)
+Bot	Mozilla/5.0 (compatible; Ezooms/1.0; ezooms.bot@gmail.com)
+Bot	Mozilla/5.0 (compatible; FacebookBot/1.0; +https://developers.facebook.com/docs/sharing/webmasters/facebookbot/)
+Bot	Mozilla/5.0 (compatible; FastDAST; +https://www.blackduck.com/)
+Bot	Mozilla/5.0 (compatible; Feedsearch-Crawler; +https://pypi.org/project/feedsearch-crawler)
+Bot	Mozilla/5.0 (compatible; Feedspot/1.0 (+https://www.feedspot.com/fs/fetcher; like FeedFetcher-Google)
+Bot	Mozilla/5.0 (compatible; Feedspotbot/1.0; +http://www.feedspot.com/fs/bot)
+Bot	Mozilla/5.0 (compatible; Feedwind/3.0; +http://feed.mikle.com/support/description/)
+Bot	Mozilla/5.0 (compatible; FemtosearchBot/1.0; http://femtosearch.com)
+Bot	Mozilla/5.0 (compatible; Findxbot/1.0; +http://www.findxbot.com)
+Bot	Mozilla/5.0 (compatible; FirecrawlAgent; +https://firecrawl.dev/)
+Bot	Mozilla/5.0 (compatible; FleebsBot/1~w; +https://fleebs.com/bot)
+Bot	Mozilla/5.0 (compatible; FlipboardProxy/1.1; +http://flipboard.com/browserproxy)
+Bot	Mozilla/5.0 (compatible; FlipboardProxy/1.2; +http://flipboard.com/browserproxy)
+Bot	Mozilla/5.0 (compatible; FlipboardRSS/1.2; +http://flipboard.com/browserproxy)
+Bot	Mozilla/5.0 (compatible; Freespoke/2.0; +https://crawler.freespoke.com)
+Bot	Mozilla/5.0 (compatible; GeedoBot; +http://www.geedo.com/bot.html)
+Bot	Mozilla/5.0 (compatible; Genieo/1.0 http://www.genieo.com/webfilter.html)
+Bot	Mozilla/5.0 (compatible; GenomeCrawlerd/1.0; +https://www.nokia.com/genomecrawler)
+Bot	Mozilla/5.0 (compatible; Gluten Free Crawler/1.0; +http://glutenfreepleasure.com/)
+Bot	Mozilla/5.0 (compatible; Go-http-client/1.1; +centurybot9@gmail.com)
+Bot	Mozilla/5.0 (compatible; GoParserBot/1.0)
+Bot	Mozilla/5.0 (compatible; Goodreads; +https://www.goodreads.com)
+Bot	Mozilla/5.0 (compatible; Goodzer/1.0) and Mozilla/5.0 (compatible; Goodzer/2.0; crawler@goodzer.com)
+Bot	Mozilla/5.0 (compatible; Google-Apps-Script; beanserver; +https://script.google.com; id: UAEmdDd_XLoqpGxtGfu5uvUaQlW77VLYz-w)
+Bot	Mozilla/5.0 (compatible; Google-Extended/1.0; +http://www.google.com/bot.html)
+Bot	Mozilla/5.0 (compatible; Google-Gemini-CLI/1.0; +https://github.com/google-gemini/gemini-cli)
+GoogleBot	Mozilla/5.0 (compatible; Google-InspectionTool/1.0)
+GoogleBot	Mozilla/5.0 (compatible; Google-InspectionTool/1.0;)
+Bot	Mozilla/5.0 (compatible; Google-NotebookLM; +https://notebooklm.google.com/)
+!	Mozilla/5.0 (compatible; Google-Site-Verification/1.0)
+Bot	Mozilla/5.0 (compatible; Google-Structured-Data-Testing-Tool +http://developers.google.com/structured-data/testing-tool/)
+Bot	Mozilla/5.0 (compatible; Google-Structured-Data-Testing-Tool +https://search.google.com/structured-data/testing-tool)
+Bot	Mozilla/5.0 (compatible; Google-Trust-Services/2.0; http://pki.goog/)
+Bot	Mozilla/5.0 (compatible; GoogleDocs; apps-spreadsheets; +http://docs.google.com)
+GoogleBot	Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+Bot	Mozilla/5.0 (compatible; Gowikibot/1.0; +http://www.gowikibot.com)
+Bot	Mozilla/5.0 (compatible; GrapeshotCrawler/2.0; +http://www.grapeshot.co.uk/crawler.php)
+Bot	Mozilla/5.0 (compatible; Greppr Web Crawler/0.12.0 (https://greppr.org/))
+Bot	Mozilla/5.0 (compatible; Grobbot/2.2; +https://grob.it)
+Bot	Mozilla/5.0 (compatible; GroovinaAdsbot/1.0; +https://www.groovinads.com/en/#bot)
+Bot	Mozilla/5.0 (compatible; GroupHigh/1.0; +http://www.grouphigh.com/
+Bot	Mozilla/5.0 (compatible; GuestpostsBot/2.0; +https://guestposts.com.br/blog/robot/)
+Bot	Mozilla/5.0 (compatible; HIFIBot/1; +https://hi.fi)
+Bot	Mozilla/5.0 (compatible; HaloBot/1.0)
+Bot	Mozilla/5.0 (compatible; HenkBot/1.0; +https://valyu.ai/crawler)
+Bot	Mozilla/5.0 (compatible; HoneybadgerBot; +https://www.honeybadger.io/)
+Bot	Mozilla/5.0 (compatible; HubSpot Crawler; web-crawlers@hubspot.com)
+Bot	Mozilla/5.0 (compatible; ICBot/0.1; +https://ideasandcode.xyz
+Bot	Mozilla/5.0 (compatible; IbouBot/1.0; +bot@ibou.io; +https://ibou.io/iboubot.html)
+Bot	Mozilla/5.0 (compatible; ImageFetcher/9.0; +http://wsrv.nl/)
+Bot	Mozilla/5.0 (compatible; ImagesiftBot; +imagesift.com)
+Bot	Mozilla/5.0 (compatible; Innologica; +https://www.innologica.com/)
+Bot	Mozilla/5.0 (compatible; InternetMeasurement/1.0; +https://internet-measurement.com/)
+Bot	Mozilla/5.0 (compatible; IsDownBot/1.0;)
+Bot	Mozilla/5.0 (compatible; IstellaBot/1.23.15 +http://www.tiscali.it/)
+Bot	Mozilla/5.0 (compatible; Jetslide; +http://jetsli.de/crawler)
+Bot	Mozilla/5.0 (compatible; Jooblebot/2.0; Windows NT 6.1; WOW64; +http://jooble.org/jooble-bot) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36
+Bot	Mozilla/5.0 (compatible; Kagibot/1.0; +https://kagi.com/bot)
+Bot	Mozilla/5.0 (compatible; Kangaroo Bot/1.0; +http://www.kangaroo.com)
+Bot	Mozilla/5.0 (compatible; KangarooBot/1.0; +https://kangaroobot.com)
+Bot	Mozilla/5.0 (compatible; KeybaseBot; +https://keybase.io)
+Bot	Mozilla/5.0 (compatible; Known Agent/1.0; +https://knownagents.com)
+Bot	Mozilla/5.0 (compatible; Known Agents Browser/1.0; +https://knownagents.com)
+Bot	Mozilla/5.0 (compatible; Konturbot/1.2; +http://kontur.ru; cargo@kontur.ru)
+Bot	Mozilla/5.0 (compatible; KrawlerBot; +https://www.krawler.com/)
+Bot	Mozilla/5.0 (compatible; Kukei.eu-Bot/0.2; +https://kukei.eu)
+Bot	Mozilla/5.0 (compatible; KunatoCrawler/1.0; +http://kunato.ai/bot.html)
+Bot	Mozilla/5.0 (compatible; LAC_IAHarvester/3.3.0; +https://library-archives.canada.ca/eng/services/government-canada/web-social-media-preservation-program/Pages/web-archive.aspx)
+Bot	Mozilla/5.0 (compatible; LastModBot/0.1; +https://last-modified.com/en)
+Bot	Mozilla/5.0 (compatible; Let's Encrypt validation server; +https://www.letsencrypt.org)
+Bot	Mozilla/5.0 (compatible; Level9SearchBot/2-1.5)
+Bot	Mozilla/5.0 (compatible; Linespider/1.1; +https://lin.ee/4dwXkTH)
+Bot	Mozilla/5.0 (compatible; LinkCheckerBot/2.0; +https://linkchecker.pro/robot/)
+Bot	Mozilla/5.0 (compatible; LinkWalker/2.0; +http://www.seventwentyfour.com)
+Bot	Mozilla/5.0 (compatible; LinkisBot/1.0; bot@linkis.com) (iPhone; CPU iPhone OS 8_4_1 like Mac OS X) Mobile/12H321
+Bot	Mozilla/5.0 (compatible; LinkpadBot/2.4; +https://linkpad.org/robot/)
+Bot	Mozilla/5.0 (compatible; LinksIndexerBot/1.0; +http://linksindexer.com/bot)
+Bot	Mozilla/5.0 (compatible; Linux x86_64; Mail.RU_Bot/2.0; +http://go.mail.ru/
+Bot	Mozilla/5.0 (compatible; Linux x86_64; Mail.RU_Bot/2.0; +http://go.mail.ru/help/robots)
+Bot	Mozilla/5.0 (compatible; Linux x86_64; Mail.RU_Bot/Robots/2.0; +http://go.mail.ru/help/robots)
+Bot	Mozilla/5.0 (compatible; Linux x86_64; python-requests/2.32.3; RecipeRadar/0.1; +https://www.reciperadar.com)
+Bot	Mozilla/5.0 (compatible; Linux; AGAKIDSBOT/3.1 +agakids.ru/project) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
+Bot	Mozilla/5.0 (compatible; Lipperhey Link Explorer; http://www.lipperhey.com/)
+Bot	Mozilla/5.0 (compatible; Lipperhey SEO Service; http://www.lipperhey.com/)
+Bot	Mozilla/5.0 (compatible; Lipperhey Site Explorer; http://www.lipperhey.com/)
+Bot	Mozilla/5.0 (compatible; Lipperhey-Kaus-Australis/5.0; +https://www.lipperhey.com/en/about/)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.2.1; http://www.majestic12.co.uk/bot.php?+)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.2.3; http://www.majestic12.co.uk/bot.php?+)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.2.4; http://www.majestic12.co.uk/bot.php?+)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.2.5; http://www.majestic12.co.uk/bot.php?+)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.3.0; http://www.majestic12.co.uk/bot.php?+)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.3.1; http://www.majestic12.co.uk/bot.php?+)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.3.2; http://www.majestic12.co.uk/bot.php?+)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.3.3; http://www.majestic12.co.uk/bot.php?+)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.4.0; http://www.majestic12.co.uk/bot.php?+)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.4.1; http://www.majestic12.co.uk/bot.php?+)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.4.2; http://www.majestic12.co.uk/bot.php?+)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.4.3; http://www.majestic12.co.uk/bot.php?+)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.4.4 (domain ownership verifier); http://www.majestic12.co.uk/bot.php?+)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.4.4; http://www.majestic12.co.uk/bot.php?+)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.4.5; http://www.majestic12.co.uk/bot.php?+)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.4.6; http://mj12bot.com/)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.4.7; http://mj12bot.com/)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.4.7; http://www.majestic12.co.uk/bot.php?+)
+Bot	Mozilla/5.0 (compatible; MJ12bot/v1.4.8; http://mj12bot.com/)
+Bot	Mozilla/5.0 (compatible; MRGbot/1.0; +https://www.mrg.ro/bot.html)
+!	Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0) LinkCheck by Siteimprove.com
+Bot	Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0) SiteCheck-sitecrawl
+Bot	Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0) SiteCheck-sitecrawl by Siteimprove.com
+!	Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0;  WOW64;  Trident/6.0;  BingPreview/1.0b)
+Bot	Mozilla/5.0 (compatible; MSIE 7.0 +http://www.europarchive.org)
+Bot	Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.1) Streamline3Bot/1.0
+Bot	Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Multiviewbot
+Bot	Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0); 360Spider
+Bot	Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0); 360Spider(compatible; HaosouSpider; http://www.haosou.com/help/help_3_2.html)
+!	Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0;  WOW64;  Trident/5.0;  BingPreview/1.0b)
+!	Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; AppInsights)
+!	Mozilla/5.0 (compatible; MSIE or Firefox mutant; not on Windows server; + http://tab.search.daum.net/aboutWebSearch.html) Daumoa/3.0
+!	Mozilla/5.0 (compatible; MSIE or Firefox mutant; not on Windows server;) Daumoa/4.0 (Following Mediapartners-Google)
+Bot	Mozilla/5.0 (compatible; MaCoCu; +https://www.clarin.si/info/macocu-massive-collection-and-curation-of-monolingual-and-bilingual-data/)
+Bot	Mozilla/5.0 (compatible; Macrobondbot +http://redir.macrobond.com/go/bot/)
+Bot	Mozilla/5.0 (compatible; MagiBot; +https://www.magi.com/)
+Bot	Mozilla/5.0 (compatible; Mail.RU_Bot/2.0; +http://go.mail.ru/
+Bot	Mozilla/5.0 (compatible; MailChimp; +https://mailchimp.com/)
+Bot	Mozilla/5.0 (compatible; MainWP/4.2.7.1; +http://mainwp.com)
+Bot	Mozilla/5.0 (compatible; Mappy/1.0; +http://mappydata.net/bot/)
+Bot	Mozilla/5.0 (compatible; MatchorySearch/1.3; +https://www.matchory.com)
+Bot	Mozilla/5.0 (compatible; McontextualBot/0.1; +http://mcontextual.net/mcontextual-bot)
+Bot	Mozilla/5.0 (compatible; MedialogiaBot; +http://home.prod.mlg.ru/bots.txt)
+Bot	Mozilla/5.0 (compatible; MegaIndex.ru/2.0; +http://megaindex.com/crawler)
+Bot	Mozilla/5.0 (compatible; MegaIndex.ru/2.0; +https://www.megaindex.ru/?tab=linkAnalyze)
+Bot	Mozilla/5.0 (compatible; MentalHealthLeadBot/DeepCrawl/1.0; +https://aiinstall.co)
+Bot	Mozilla/5.0 (compatible; Meta-ExternalHit/1.1; +http://www.facebook.com/externalhit_uatext.php)
+Bot	Mozilla/5.0 (compatible; MetaJobBot; http://www.metajob.de/crawler)
+Bot	Mozilla/5.0 (compatible; Miniflux/2.0.10; +https://miniflux.net)
+Bot	Mozilla/5.0 (compatible; Miniflux/2.0.11; +https://miniflux.app)
+Bot	Mozilla/5.0 (compatible; Miniflux/2.0.12; +https://miniflux.app)
+Bot	Mozilla/5.0 (compatible; Miniflux/2.0.3; +https://miniflux.net)
+Bot	Mozilla/5.0 (compatible; Miniflux/2.0.7; +https://miniflux.net)
+Bot	Mozilla/5.0 (compatible; Miniflux/2.0.x-dev; +https://miniflux.net)
+Bot	Mozilla/5.0 (compatible; Miniflux/3b6e44c; +https://miniflux.app)
+Bot	Mozilla/5.0 (compatible; Miniflux/ae1dc1a; +https://miniflux.app)
+Bot	Mozilla/5.0 (compatible; MissinglettrBot/2.0; +http://missinglettr.com/bot/)
+Bot	Mozilla/5.0 (compatible; MixrankBot; crawler@mixrank.com)
+Bot	Mozilla/5.0 (compatible; ModatScanner/1.2; +https://modat.io/)
+Bot	Mozilla/5.0 (compatible; MojeekBot/0.2; http://www.mojeek.com/bot.html#relaunch)
+Bot	Mozilla/5.0 (compatible; MojeekBot/0.2; http://www.mojeek.com/bot.html)
+Bot	Mozilla/5.0 (compatible; MojeekBot/0.5; http://www.mojeek.com/bot.html)
+Bot	Mozilla/5.0 (compatible; MojeekBot/0.6; +https://www.mojeek.com/bot.html)
+Bot	Mozilla/5.0 (compatible; MojeekBot/0.6; http://www.mojeek.com/bot.html)
+!	Mozilla/5.0 (compatible; MonTools.com)
+Bot	Mozilla/5.0 (compatible; Monsidobot/2.2; +http://monsido.com/bot.html; info@monsido.com)
+Bot	Mozilla/5.0 (compatible; MontasticMonitor; +https://montastic.com/)
+Bot	Mozilla/5.0 (compatible; MotoMinerBot/1.0; +https://motominer.com/Bot)
+Bot	Mozilla/5.0 (compatible; MuckRack/1.0; +http://muckrack.com)
+Bot	Mozilla/5.0 (compatible; MyBot/1.0)
+Bot	Mozilla/5.0 (compatible; NIXStatsbot/1.1; +http://www.nixstats.com/bot.html)
+Bot	Mozilla/5.0 (compatible; NLNZ_IAHarvester2024/3.3.0; +https://natlib.govt.nz/publishers-and-authors/web-harvesting/domain-harvest)
+Bot	Mozilla/5.0 (compatible; NLUX_IAHarvester/3.4.0; +http://crawl.bnl.lu/)
+Bot	Mozilla/5.0 (compatible; NTENTbot; +http://www.ntent.com/ntentbot)
+Bot	Mozilla/5.0 (compatible; NaverBot/1.0; nhnbot@naver.com)
+Bot	Mozilla/5.0 (compatible; Neevabot/1.0; +https://neeva.com/neevabot)
+Bot	Mozilla/5.0 (compatible; NerdByNature.Bot; http://www.nerdbynature.net/bot)
+Bot	Mozilla/5.0 (compatible; Nessus; http://www.nessus.org)
+Bot	Mozilla/5.0 (compatible; NetSeer crawler/2.0; +http://www.netseer.com/crawler.html; crawler@netseer.com)
+!	Mozilla/5.0 (compatible; NetcraftSurveyAgent/1.0; +info@netcraft.com)
+Bot	Mozilla/5.0 (compatible; NetpeakCheckerBot/3.6; +https://netpeaksoftware.com/checker)
+Bot	Mozilla/5.0 (compatible; NewRelicbot/2.1; +http://www.newrelic.com)
+Bot	Mozilla/5.0 (compatible; NewShareCounts.com/1.0; +http://newsharecounts.com/crawler)
+Bot	Mozilla/5.0 (compatible; NewsRoom.BI/0.1; +http://www.newsroom.bi/bot.html)
+Bot	Mozilla/5.0 (compatible; Nimbostratus-Bot/v1.3.2; http://cloudsystemnetworks.com)
+Bot	Mozilla/5.0 (compatible; Nitro-; +https://www.nitropack.io/)
+Bot	Mozilla/5.0 (compatible; NitroBot; +https://www.nitropack.io/)
+Bot	Mozilla/5.0 (compatible; Nmap Scripting Engine; https://nmap.org/book/nse.html)
+Bot	Mozilla/5.0 (compatible; Noibu; +https://www.noibu.com/)
+Bot	Mozilla/5.0 (compatible; Nooshub/1.0; +https://www.nooshub.com/statics/bots)
+Bot	Mozilla/5.0 (compatible; NostoCrawlerBot/1.0; +http://my.nosto.com/tagging)
+Bot	Mozilla/5.0 (compatible; Novaact/1.0; +https://www.novaact.com)
+Bot	Mozilla/5.0 (compatible; Odin; https://docs.getodin.com/)
+Bot	Mozilla/5.0 (compatible; OdklBot/1.0 like Linux; klass@odnoklassniki.ru)
+Bot	Mozilla/5.0 (compatible; OhDear/1.1; +https://ohdear.app/checkerOhDear.app (+https://ohdear.app/docs/checks/uptime)
+Bot	Mozilla/5.0 (compatible; OnCrawl/1.0; +http://www.oncrawl.com)
+Bot	Mozilla/5.0 (compatible; Online Domain Tools - Server Monitor/1.0; +http://server-monitoring.online-domain-tools.com)
+Bot	Mozilla/5.0 (compatible; OpenGraph.io/1.1; +https://opengraph.io/ AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36
+Bot	Mozilla/5.0 (compatible; OpenHoseBot/2.1; +http://www.openhose.org/bot.html)
+Bot	Mozilla/5.0 (compatible; Operator/1.0; +https://www.example.com/bot.html)
+!	Mozilla/5.0 (compatible; Optimizer)
+Bot	Mozilla/5.0 (compatible; OrangeBot/2.0; support.orangebot@orange.com
+Bot	Mozilla/5.0 (compatible; Orbbot/1.1;)
+Bot	Mozilla/5.0 (compatible; PR-CY.RU; + https://a.pr-cy.ru)
+Bot	Mozilla/5.0 (compatible; PRTG Network Monitor (www.paessler.com ); Windows)
+Bot	Mozilla/5.0 (compatible; PRTGCloudBot/1.0; +http://www.paessler.com/prtgcloudbot; for_[edf7e62f223b268942b7efa36b6be1e305fcdadb])
+Bot	Mozilla/5.0 (compatible; Pagespeed/1.1 Fetcher; +http://www.pagespeed.de)
+Bot	Mozilla/5.0 (compatible; PanguBot +https://www.pangutech.com)
+Bot	Mozilla/5.0 (compatible; PaperLiBot/2.1; http://support.paper.li/entries/20023257-what-is-paper-li)
+Bot	Mozilla/5.0 (compatible; PaperLiBot/2.1; https://support.paper.li/entries/20023257-what-is-paper-li)
+Bot	Mozilla/5.0 (compatible; Paqlebot/2.0; +http://www.paqle.dk/about/paqlebot)
+Bot	Mozilla/5.0 (compatible; PhindBot; +https://www.phind.com/)
+Bot	Mozilla/5.0 (compatible; PingAdmin.Ru/1.2; +http://pingadmin.ru/free_test/)
+Bot	Mozilla/5.0 (compatible; Pinterestbot/1.0; +http://www.pinterest.com/bot.html)
+Bot	Mozilla/5.0 (compatible; PlagAwareBot/3.2; +https://www.plagaware.com/bot)
+Bot	Mozilla/5.0 (compatible; Poduptime; +fediverse.observer)
+Bot	Mozilla/5.0 (compatible; Pomothy-Bot/1.0)
+Bot	Mozilla/5.0 (compatible; PriEcoBot/1.0; +https://prieco.net)
+Bot	Mozilla/5.0 (compatible; PricedroneShoppingBot/1.0; +http://pricedrone.com/robot/)
+Bot	Mozilla/5.0 (compatible; Primalbot; +https://www.primal.com;)
+Bot	Mozilla/5.0 (compatible; PrivacyAwareBot/1.1; +http://www.privacyaware.org)
+!	Mozilla/5.0 (compatible; Pro Sitemaps Generator; pro-sitemaps.com) Gecko Pro-Sitemaps/1.0
+Bot	Mozilla/5.0 (compatible; ProjectShield-UrlCheck; +http://g.co/projectshield)
+Bot	Mozilla/5.0 (compatible; QualifiedBot/1.0; +https://www.qualified.com/legal/qualified-crawler-user-agent)
+Bot	Mozilla/5.0 (compatible; Qualys; +https://www.qualys.com/)
+Bot	Mozilla/5.0 (compatible; Qwantbot-news/2.0; +https://help.qwant.com/bot/)
+Bot	Mozilla/5.0 (compatible; Qwantbot/1.0_12345; +https://help.qwant.com/bot/)
+Bot	Mozilla/5.0 (compatible; Qwantbot/1.0_800166; +https://help.qwant.com/bot/)
+Bot	Mozilla/5.0 (compatible; Qwantify/2.0n; +https://www.qwant.com/)/*
+Bot	Mozilla/5.0 (compatible; Qwantify/2.4w; +https://www.qwant.com/)/2.4w
+Bot	Mozilla/5.0 (compatible; Qwantify/Bleriot/1.1; +https://help.qwant.com/bot)
+Bot	Mozilla/5.0 (compatible; Qwantify/Bleriot/1.2.1; +https://help.qwant.com/bot)
+Bot	Mozilla/5.0 (compatible; Qwarrybot/2.0; +http://www.qwarry.com/bot.html)
+Bot	Mozilla/5.0 (compatible; RSiteAuditor)
+Bot	Mozilla/5.0 (compatible; RankActiveLinkBot; +https://rankactive.com/resources/rankactive-linkbot)
+Bot	Mozilla/5.0 (compatible; RankSonicSiteAuditor/1.0; +https://ranksonic.com/ranksonic_sab.html)
+Bot	Mozilla/5.0 (compatible; RavenCrawler/2.0; +https://raventools.com/seo-website-auditor/)
+Bot	Mozilla/5.0 (compatible; RegionStuttgartBot/1.0; +http://it.region-stuttgart.de/competenzatlas/unternehmen-suchen/)
+!	Mozilla/5.0 (compatible; RetroListeCOM/1.0)
+Bot	Mozilla/5.0 (compatible; ReverseEngineeringBot/0.1; +https://torus.company/bot.html)
+Bot	Mozilla/5.0 (compatible; RidderBot/1.0; bot@ridder.co)
+Bot	Mozilla/5.0 (compatible; RidderBot/1.0; bot@ridder.co) (iPhone; CPU iPhone OS 8_4_1 like Mac OS X) Mobile/12H321
+Bot	Mozilla/5.0 (compatible; Rivva; http://rivva.de)
+Bot	Mozilla/5.0 (compatible; SBIntuitionsBot/0.1; +https://www.sbintuitions.co.jp/bot/)
+Bot	Mozilla/5.0 (compatible; SEOkicks; +https://www.seokicks.de/robot.html)
+Bot	Mozilla/5.0 (compatible; SERPtimizerBot; +http://serptimizer.com/serptimizer-bot)
+Bot	Mozilla/5.0 (compatible; SERankingBacklinksBot/1.0; +https://seranking.com/backlinks-crawler)
+Bot	Mozilla/5.0 (compatible; SISTRIX Crawler; http://crawler.sistrix.net/)
+Bot	Mozilla/5.0 (compatible; SMTBot/1.0; +http://www.similartech.com/smtbot)
+Bot	Mozilla/5.0 (compatible; SSSSBot/0.0.1; +http://s-ans.xyz:80/)
+Bot	Mozilla/5.0 (compatible; Sansec Security Monitor/1.0; +https://sansec.io/monitor)
+Bot	Mozilla/5.0 (compatible; Schema-Markup-Validator; +https://validator.schema.org/)
+Bot	Mozilla/5.0 (compatible; Scoop.it/1.0; +http://www.scoop.it/bot)
+Bot	Mozilla/5.0 (compatible; ScoutJet; +http://www.scoutjet.com/)
+Bot	Mozilla/5.0 (compatible; ScrapeheroBot/1.0; +https://scrapehero.de/)
+Bot	Mozilla/5.0 (compatible; Seekport Crawler; http://seekport.com/)
+Bot	Mozilla/5.0 (compatible; SeekportBot; +https://bot.seekport.com)
+Bot	Mozilla/5.0 (compatible; Semanticbot/1.0; +http://sempi.tech/bot.html)
+SemrushBot	Mozilla/5.0 (compatible; SemrushBot-BA; +http://www.semrush.com/bot.html)
+SemrushBot	Mozilla/5.0 (compatible; SemrushBot-SA/0.97; +http://www.semrush.com/bot.html)
+SemrushBot	Mozilla/5.0 (compatible; SemrushBot-SI/0.97; +http://www.semrush.com/bot.html)
+SemrushBot	Mozilla/5.0 (compatible; SemrushBot/0.98~bl; +http://www.semrush.com/bot.html)
+SemrushBot	Mozilla/5.0 (compatible; SemrushBot/3~bl; +http://www.semrush.com/bot.html)
+SemrushBot	Mozilla/5.0 (compatible; SemrushBot/6~bl; +http://www.semrush.com/bot.html)
+SemrushBot	Mozilla/5.0 (compatible; SemrushBot/7~bl; +http://www.semrush.com/bot.html)
+Bot	Mozilla/5.0 (compatible; SequelWP; +https://sequelwp.com/)
+Bot	Mozilla/5.0 (compatible; ServerDensity; +https://www.serverdensity.com/)
+Bot	Mozilla/5.0 (compatible; ServerHunterSpider/1.1; +https://www.serverhunter.com/spider/)
+Bot	Mozilla/5.0 (compatible; SeznamBot/3.2-test1-1; +http://napoveda.seznam.cz/en/seznambot-intro/)
+Bot	Mozilla/5.0 (compatible; SeznamBot/3.2-test1; +http://napoveda.seznam.cz/en/seznambot-intro/)
+Bot	Mozilla/5.0 (compatible; SeznamBot/3.2-test2; +http://napoveda.seznam.cz/en/seznambot-intro/)
+Bot	Mozilla/5.0 (compatible; SeznamBot/3.2-test4; +http://napoveda.seznam.cz/en/seznambot-intro/)
+Bot	Mozilla/5.0 (compatible; SeznamBot/3.2; +http://fulltext.sblog.cz/)
+Bot	Mozilla/5.0 (compatible; SeznamBot/3.2; +http://napoveda.seznam.cz/en/seznambot-intro/)
+Bot	Mozilla/5.0 (compatible; SeznamBot/4.0; +http://napoveda.seznam.cz/seznambot-intro/)
+Bot	Mozilla/5.0 (compatible; SimpleScraper)
+Bot	Mozilla/5.0 (compatible; SinceraSyntheticUser/1.0; +http://app.sincera.io/bots)
+Bot	Mozilla/5.0 (compatible; SiteAuditBot/1.1; +https://siteauditbot.com)
+Bot	Mozilla/5.0 (compatible; SiteExplorer/1.0b; +http://siteexplorer.info/)
+Bot	Mozilla/5.0 (compatible; SiteExplorer/1.1b; +http://siteexplorer.info/Backlink-Checker-Spider/)
+Bot	Mozilla/5.0 (compatible; SiteSearch360/1.0; +https://sitesearch360.com/)
+Bot	Mozilla/5.0 (compatible; SlickBot/1.0; +http://slickstream.com)
+Bot	Mozilla/5.0 (compatible; Snacktory; +https://github.com/karussell/snacktory)
+Bot	Mozilla/5.0 (compatible; SnapURLPreview/1.0; +https://www.snapchat.com)
+Bot	Mozilla/5.0 (compatible; SnapchatAds/1.0; +https://businesshelp.snapchat.com/s/article/adsbot-crawler)
+Bot	Mozilla/5.0 (compatible; Software-Security-Research; +https://www.ruhr-uni-bochum.de/)
+Bot	Mozilla/5.0 (compatible; Sonic/1.0; http://www.yama.info.waseda.ac.jp/~crawler/info.html)
+Bot	Mozilla/5.0 (compatible; Speedy Spider; http://www.entireweb.com/about/search_tech/speedy_spider/)
+Bot	Mozilla/5.0 (compatible; Spider; +https://www.spider.com/)
+Bot	Mozilla/5.0 (compatible; SpiderLing (a SPIDER for LINGustic research); +http://nlp.fi.muni.cz/projects/biwec/)
+Bot	Mozilla/5.0 (compatible; Splunk/1.0.0; https://splunk.com)
+Bot	Mozilla/5.0 (compatible; SputnikBot/2.3; +http://corp.sputnik.ru/webmaster)
+Bot	Mozilla/5.0 (compatible; StatistikAustria/1.0; +http://www.statistik.gv.at)
+Bot	Mozilla/5.0 (compatible; StatusNestBacklinkSpider; +https://statusnest.com/)
+Bot	Mozilla/5.0 (compatible; StorygizeBot; http://www.storygize.com)
+Bot	Mozilla/5.0 (compatible; StractBot/0.1; open source search engine; +https://trystract.com/webmasters)
+Bot	Mozilla/5.0 (compatible; SurdotlyBot/1.0; +http://sur.ly/bot.html; Linux; Android 4; iPhone; CPU iPhone OS 6_0_1 like Mac OS X)
+Bot	Mozilla/5.0 (compatible; Swiftbot/1.0; UID/649dce5512ab734096a50277; +http://swiftype.com/swiftbot)
+Bot	Mozilla/5.0 (compatible; SynthesiBot/1.0)
+Bot	Mozilla/5.0 (compatible; Sysomos/1.0; +http://www.sysomos.com/; Sysomos)
+Bot	Mozilla/5.0 (compatible; TTD-Content; +https://www.thetradedesk.com/general/ttd-content)
+Bot	Mozilla/5.0 (compatible; Taboolabot/3.7; +http://www.taboola.com)
+Bot	Mozilla/5.0 (compatible; TavilyBot; +https://tavily.com/)
+Bot	Mozilla/5.0 (compatible; TestURI; +http://testuri.org/)
+Bot	Mozilla/5.0 (compatible; Thinkbot/0.5.8; +In_the_test_phase,_if_the_Thinkbot_brings_you_trouble,_please_block_its_IP_address._Thank_you.)
+Bot	Mozilla/5.0 (compatible; Timpibot/0.8; +http://www.timpi.io)
+Bot	Mozilla/5.0 (compatible; Timpibot/0.9; +http://www.timpi.io)
+Bot	Mozilla/5.0 (compatible; TinEye-bot/1.31; +http://www.tineye.com/crawler.html)
+Bot	Mozilla/5.0 (compatible; TombaPublicWebCrawler/1.0; +https://tombascraper.com)
+Bot	Mozilla/5.0 (compatible; ToutiaoSpider/1.0; http://web.toutiao.com/media_cooperation/;)
+!	Mozilla/5.0 (compatible; TrendsmapResolver/0.1)
+Bot	Mozilla/5.0 (compatible; TwinAgent; +https://www.twinagent.com/)
+!	Mozilla/5.0 (compatible; Twingly Recon; twingly.com)
+Bot	Mozilla/5.0 (compatible; U; AnyEvent-HTTP/2.24; +http://software.schmorp.de/pkg/AnyEvent)
+Bot	Mozilla/5.0 (compatible; UASlinkChecker/2.1; +https://udger.com/support/UASlinkChecker)
+!	Mozilla/5.0 (compatible; UGAResearchAgent/1.0; Please visit: NISLabUGA.github.io)
+Bot	Mozilla/5.0 (compatible; URLAppendBot/1.0; +http://www.profound.net/urlappendbot.html)
+Bot	Mozilla/5.0 (compatible; Uptime/1.0; http://uptime.com)
+Bot	Mozilla/5.0 (compatible; UptimeBot/1.0; +https://www.getuptime.co)
+Bot	Mozilla/5.0 (compatible; UptimeStatistics; +https://www.uptimestatistics.com/)
+Bot	Mozilla/5.0 (compatible; Uptimebot/1.0; +http://www.uptime.com/uptimebot)
+Bot	Mozilla/5.0 (compatible; Uptimia; www.uptimia.com)
+Bot	Mozilla/5.0 (compatible; UrlSuMa.de crawler)
+Bot	Mozilla/5.0 (compatible; VKRobot/1.0)
+Bot	Mozilla/5.0 (compatible; Vagabondo/2.1; webcrawler at wise-guys dot nl)
+Bot	Mozilla/5.0 (compatible; Veoozbot/1.0; +http://www.veooz.com/veoozbot.html)
+Bot	Mozilla/5.0 (compatible; Verispider; +https://www.projecthoneypot.org/)
+Bot	Mozilla/5.0 (compatible; Vigil/1.0; +http://vigil-app.com/bot.html)
+Bot	Mozilla/5.0 (compatible; VoluumDSP-content-bot/2.0; +dsp-dev@codewise.com)
+Bot	Mozilla/5.0 (compatible; WARDBot/1.0; http://ward.ai/robot)
+Bot	Mozilla/5.0 (compatible; WISEbot/1.0; +http://www.cision.com)
+Bot	Mozilla/5.0 (compatible; WPMU DEV Hub/2.0; +https://wpmudev.com)
+Bot	Mozilla/5.0 (compatible; WPScan; +https://wpscan.com/wordpress-security-scanner)
+Bot	Mozilla/5.0 (compatible; WPSec/1.3; +https://wpsec.com)
+Bot	Mozilla/5.0 (compatible; WSM/2.0; +https://webspidermount.com/)
+Bot	Mozilla/5.0 (compatible; WTotem; +https://www.webtotem.com/)
+Bot	Mozilla/5.0 (compatible; Watchful; +https://www.watchful.net/)
+Bot	Mozilla/5.0 (compatible; WebCEO Online/1.0; +http://online.webceo.com)
+Bot	Mozilla/5.0 (compatible; WebDataStats/1.0 ; +https://webdatastats.com/policy.html)
+!	Mozilla/5.0 (compatible; WebThumbnail/2.2; Website Thumbnail Generat
+Bot	Mozilla/5.0 (compatible; Website-info.net-Robot; https://website-info.net/robot)
+Bot	Mozilla/5.0 (compatible; WebwikiBot/2.1; +https://www.webwiki.com)
+Bot	Mozilla/5.0 (compatible; WellKnownBot/0.1; +https://well-known.dev/about/#bot)
+Bot	Mozilla/5.0 (compatible; WepchSearchEngine; +https://www.wepch.com/)
+Bot	Mozilla/5.0 (compatible; Whoiswebsitebot/0.1; +http://www.whoiswebsite.net)
+Bot	Mozilla/5.0 (compatible; WireReaderBot/1.0; +https://wirereader.app)
+Bot	Mozilla/5.0 (compatible; WordCountBot/0.1;)
+Bot	Mozilla/5.0 (compatible; WormlyBot; +http://wormly.com)
+Bot	Mozilla/5.0 (compatible; XML Sitemaps Generator; http://www.xml-sitemaps.com) Gecko XML-Sitemaps/1.0
+Bot	Mozilla/5.0 (compatible; XY-Archive-Compliance-Crawler; +https://archive.xyplanningnetwork.com/)
+Bot	Mozilla/5.0 (compatible; XoviBot/2.0; +http://www.xovibot.net/)
+Bot	Mozilla/5.0 (compatible; XoviOnpageCrawler; +http://www.xovi.de/)
+YahooBot	Mozilla/5.0 (compatible; Y!J SearchMonkey/1.0 (Y!J-AGENT; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html))
+YandexBot	Mozilla/5.0 (compatible; YaDirectFetcher/1.0; Dyatel; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YaK/1.0; http://linkfluence.com/; bot@linkfluence.com)
+YahooBot	Mozilla/5.0 (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html)
+YahooBot	Mozilla/5.0 (compatible; Yahoo Link Preview; https://help.yahoo.com/kb/mail/yahoo-link-preview-SLN23615.html)
+YahooBot	Mozilla/5.0 (compatible; Yahoo! Slurp China; http://misc.yahoo.com.cn/help.html)
+YahooBot	Mozilla/5.0 (compatible; Yahoo! Slurp/3.0; http://help.yahoo.com/help/us/ysearch/slurp)
+YahooBot	Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)
+Bot	Mozilla/5.0 (compatible; YandexAccessibilityBot/3.0; +http://yandex.com/bots
+Bot	Mozilla/5.0 (compatible; YandexAdNet/1.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexBlogs/0.99; robot; +http://yandex.com/bots)
+YandexBot	Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)
+YandexBot	Mozilla/5.0 (compatible; YandexBot/3.0; MirrorDetector; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexCalendar/1.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexDirect/3.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexDirectDyn/1.0; +http://yandex.com/bots
+Bot	Mozilla/5.0 (compatible; YandexFavicons/1.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexForDomain/1.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexImageResizer/2.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexImages/3.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexMarket/1.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexMarket/2.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexMedia/3.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexMetrika/2.0; +http://yandex.com/bots yabs01)
+Bot	Mozilla/5.0 (compatible; YandexMetrika/2.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexMetrika/3.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexMetrika/4.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexMobileScreenShotBot/1.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexNews/4.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexOntoDB/1.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexOntoDBAPI/1.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexPagechecker/1.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexPartner/3.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexRCA/1.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexRenderResourcesBot/1.0; +http://yandex.com/bots) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0
+Bot	Mozilla/5.0 (compatible; YandexSearchShop/1.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexSitelinks; Dyatel; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexSpravBot/1.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexTracker/1.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexTurbo/1.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexUserproxy; robot; +http://yandex.com/bots
+Bot	Mozilla/5.0 (compatible; YandexVerticals/1.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexVertis/3.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexVideo/3.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexVideoParser/1.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; YandexWebmaster/2.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (compatible; Yellowbrandprotectionbot/1.0; +https://www.yellowbp.com/bot.html)
+Bot	Mozilla/5.0 (compatible; Yeti/1.1; +http://naver.me/bot)
+Bot	Mozilla/5.0 (compatible; Yeti/1.1; +http://naver.me/spd)
+Bot	Mozilla/5.0 (compatible; ZoomInfo-DataEnrichment/1.0; +https://www.zoominfo.com)
+Bot	Mozilla/5.0 (compatible; ZumBot/1.0; http://help.zum.com/inquiry)
+Bot	Mozilla/5.0 (compatible; ZuperlistBot/1.0)
+Bot	Mozilla/5.0 (compatible; adbeat_bot; +support@adbeat.com; support@adbeat.com)
+BingBot	Mozilla/5.0 (compatible; adidxbot/2.0;  http://www.bing.com/bingbot.htm)
+BingBot	Mozilla/5.0 (compatible; adidxbot/2.0; +http://www.bing.com/bingbot.htm)
+Bot	Mozilla/5.0 (compatible; adscanner/)
+Bot	Mozilla/5.0 (compatible; aiHitBot/2.9; +https://www.aihitdata.com/about)
+Bot	Mozilla/5.0 (compatible; alexa site audit/1.0; +http://www.alexa.com/help/webmasters; )
+Bot	Mozilla/5.0 (compatible; allOrigins/3; +http://allorigins.win/)
+Bot	Mozilla/5.0 (compatible; archive.org_bot +http://archive.org/details/archive.org_bot)
+Bot	Mozilla/5.0 (compatible; archive.org_bot +http://www.archive.org/details/archive.org_bot)
+Bot	Mozilla/5.0 (compatible; archive.org_bot/heritrix-1.15.4 +http://www.archive.org)
+Bot	Mozilla/5.0 (compatible; archive.org_bot; Wayback Machine Live Record; +http://archive.org/details/archive.org_bot)
+Bot	Mozilla/5.0 (compatible; atlassian-bot; +https://www.atlassian.com/)
+BingBot	Mozilla/5.0 (compatible; bingbot/2.0;  http://www.bing.com/bingbot.htm)
+BingBot	Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm
+BingBot	Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)
+BingBot	Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) SitemapProbe
+Bot	Mozilla/5.0 (compatible; bne.es_bot; https://www.bne.es/es/colecciones/archivo-web-espanola/aviso-webmasters) Firefox/129.0.1
+Bot	Mozilla/5.0 (compatible; bnf.fr_bot; +http://bibnum.bnf.fr/robot/bnf.html)
+Bot	Mozilla/5.0 (compatible; bnf.fr_bot; +http://www.bnf.fr/fr/outils/a.dl_web_capture_robot.html)
+Bot	Mozilla/5.0 (compatible; botify; http://botify.com)
+Bot	Mozilla/5.0 (compatible; certytags/1.0; +https://certybot.certytags.com)
+Bot	Mozilla/5.0 (compatible; channable; +https://www.channable.com/)
+Bot	Mozilla/5.0 (compatible; coccoc/1.0; +http://help.coccoc.com/)
+Bot	Mozilla/5.0 (compatible; coccoc/1.0; +http://help.coccoc.com/searchengine)
+CocCocBot	Mozilla/5.0 (compatible; coccocbot-image/1.0; +http://help.coccoc.com/searchengine)
+CocCocBot	Mozilla/5.0 (compatible; coccocbot-web/1.0; +http://help.coccoc.com/searchengine)
+Bot	Mozilla/5.0 (compatible; cookie-maestro; +https://www.cookiemaestro.com/)
+Bot	Mozilla/5.0 (compatible; discobot/1.0; +http://discoveryengine.com/discobot.html)
+Bot	Mozilla/5.0 (compatible; discobot/2.0; +http://discoveryengine.com/discobot.html)
+Bot	Mozilla/5.0 (compatible; electricmonk/3.2.0 +https://www.duedil.com/our-crawler/)
+Bot	Mozilla/5.0 (compatible; epicbot; +http://www.epictions.com/epicbot)
+Bot	Mozilla/5.0 (compatible; eright/1.0; +bot@eright.com)
+Bot	Mozilla/5.0 (compatible; ev-crawler/1.0; +https://headline.com/legal/crawler)
+!	Mozilla/5.0 (compatible; evc-batch/2.0)
+Bot	Mozilla/5.0 (compatible; fiperbot/0.1 +https://www.fiper.net/bot.html)
+Bot	Mozilla/5.0 (compatible; fr-crawler/1.1)
+Bot	Mozilla/5.0 (compatible; heritrix/1.12.1 +http://www.webarchiv.cz)
+Bot	Mozilla/5.0 (compatible; heritrix/1.12.1b +http://netarkivet.dk/website/info.html)
+Bot	Mozilla/5.0 (compatible; heritrix/1.14.2 +http://rjpower.org)
+Bot	Mozilla/5.0 (compatible; heritrix/1.14.2 +http://www.webarchiv.cz)
+Bot	Mozilla/5.0 (compatible; heritrix/1.14.3 +http://archive.org)
+Bot	Mozilla/5.0 (compatible; heritrix/1.14.3 +http://www.accelobot.com)
+Bot	Mozilla/5.0 (compatible; heritrix/1.14.3 +http://www.webarchiv.cz)
+Bot	Mozilla/5.0 (compatible; heritrix/1.14.3.r6601 +http://www.buddybuzz.net/yptrino)
+Bot	Mozilla/5.0 (compatible; heritrix/1.14.4 +http://parsijoo.ir)
+Bot	Mozilla/5.0 (compatible; heritrix/1.14.4 +http://www.exif-search.com)
+Bot	Mozilla/5.0 (compatible; heritrix/2.0.2 +http://aihit.com)
+Bot	Mozilla/5.0 (compatible; heritrix/2.0.2 +http://seekda.com)
+Bot	Mozilla/5.0 (compatible; heritrix/3.0.0-SNAPSHOT-20091120.021634 +http://crawler.archive.org)
+Bot	Mozilla/5.0 (compatible; heritrix/3.1.0-RC1 +http://boston.lti.cs.cmu.edu/crawler_12/)
+Bot	Mozilla/5.0 (compatible; heritrix/3.1.1 +http://places.tomtom.com/crawlerinfo)
+Bot	Mozilla/5.0 (compatible; heritrix/3.1.1 +http://www.mixdata.com)
+Bot	Mozilla/5.0 (compatible; heritrix/3.1.1-SNAPSHOT-20120116.200628 +http://www.archive.org/details/archive.org_bot)
+Bot	Mozilla/5.0 (compatible; heritrix/3.1.1; UniLeipzigASV +http://corpora.informatik.uni-leipzig.de/crawler_faq.html)
+Bot	Mozilla/5.0 (compatible; heritrix/3.2.0 +http://suki.ling.helsinki.f
+Bot	Mozilla/5.0 (compatible; heritrix/3.2.0 +http://www.crim.ca)
+Bot	Mozilla/5.0 (compatible; heritrix/3.2.0 +http://www.exif-search.com)
+Bot	Mozilla/5.0 (compatible; heritrix/3.2.0 +http://www.mixdata.com)
+Bot	Mozilla/5.0 (compatible; heritrix/3.3.0-SNAPSHOT-20140702-2247 +http://archive.org/details/archive.org_bot)
+Bot	Mozilla/5.0 (compatible; heritrix/3.3.0-SNAPSHOT-20160309-0050; UniLeipzigASV +http://corpora.informatik.uni-leipzig.de/crawler_faq.html)
+Bot	Mozilla/5.0 (compatible; hypestat/1.0; +https://hypestat.com/bot)
+Bot	Mozilla/5.0 (compatible; image.coccoc/1.0; +http://help.coccoc.com/)
+Bot	Mozilla/5.0 (compatible; imageSpider; +https://www.bytedance.com/)
+Bot	Mozilla/5.0 (compatible; imagecoccoc/1.0; +http://help.coccoc.com/)
+Bot	Mozilla/5.0 (compatible; imagecoccoc/1.0; +http://help.coccoc.com/searchengine)
+Bot	Mozilla/5.0 (compatible; imrbot/1.10.8 +http://www.mignify.com)
+!	Mozilla/5.0 (compatible; inoreader.com; 1 subscribers)
+Bot	Mozilla/5.0 (compatible; intelx.io_bot +https://intelx.io)
+Bot	Mozilla/5.0 (compatible; kazbtbot/0.1; +http://kazbt.com/)
+Bot	Mozilla/5.0 (compatible; laion-huggingface-processor; +https://laion.ai/)
+Bot	Mozilla/5.0 (compatible; linkdexbot/2.0; +http://www.linkdex.com/about/bots/)
+Bot	Mozilla/5.0 (compatible; linkdexbot/2.0; +http://www.linkdex.com/bots/)
+Bot	Mozilla/5.0 (compatible; linkdexbot/2.1; +http://www.linkdex.com/about/bots/)
+Bot	Mozilla/5.0 (compatible; linkdexbot/2.1; +http://www.linkdex.com/bots/)
+Bot	Mozilla/5.0 (compatible; linkdexbot/2.2; +http://www.linkdex.com/bots/)
+Bot	Mozilla/5.0 (compatible; memorybot/1.21.14 +http://mignify.com/bot.html)
+Bot	Mozilla/5.0 (compatible; monitis - premium monitoring service; http://www.monitis.com)
+Bot	Mozilla/5.0 (compatible; monitoring360bot/1.1; +https://app.360monitoring.com/bot.html)
+Bot	Mozilla/5.0 (compatible; oBot/2.3.1; +http://filterdb.iss.net/crawler/)
+Bot	Mozilla/5.0 (compatible; officestorebot/1.0; +https://aka.ms/officestorebot)
+Bot	Mozilla/5.0 (compatible; online-webceo-bot/1.0; +http://online.webceo.com)
+Bot	Mozilla/5.0 (compatible; parse.ly scraper/0.16; +http://parsely.com)
+PingdomBot	Mozilla/5.0 (compatible; pingbot/2.0; +http://www.pingdom.com/)
+Bot	Mozilla/5.0 (compatible; proximic; +http://www.proximic.com)
+Bot	Mozilla/5.0 (compatible; proximic; +http://www.proximic.com/info/spider.php)
+Bot	Mozilla/5.0 (compatible; redditbot/1.0; +http://www.reddit.com/feedback)
+Bot	Mozilla/5.0 (compatible; rogerBot/1.0; UrlCrawler; http://www.seomoz.org/dp/rogerbot)
+Bot	Mozilla/5.0 (compatible; rss-is-dead.lol web bot; +https://rss-is-dead.lol)
+Bot	Mozilla/5.0 (compatible; rss2tg bot; +http://komar.in/en/rss2tg_crawler)
+Bot	Mozilla/5.0 (compatible; seo-audit-check-bot/1.0)
+Bot	Mozilla/5.0 (compatible; seoLyt/1.0; +https://seolyt.com)
+Bot	Mozilla/5.0 (compatible; seoscanners.net/1; +spider@seoscanners.net)
+Bot	Mozilla/5.0 (compatible; spbot/1.0; +http://www.seoprofiler.com/bot/ )
+Bot	Mozilla/5.0 (compatible; spbot/1.1; +http://www.seoprofiler.com/bot/ )
+Bot	Mozilla/5.0 (compatible; spbot/1.2; +http://www.seoprofiler.com/bot/ )
+Bot	Mozilla/5.0 (compatible; spbot/2.0.1; +http://www.seoprofiler.com/bot/ )
+Bot	Mozilla/5.0 (compatible; spbot/2.0.2; +http://www.seoprofiler.com/bot/ )
+Bot	Mozilla/5.0 (compatible; spbot/2.0.3; +http://www.seoprofiler.com/bot/ )
+Bot	Mozilla/5.0 (compatible; spbot/2.0.4; +http://www.seoprofiler.com/bot )
+Bot	Mozilla/5.0 (compatible; spbot/2.0; +http://www.seoprofiler.com/bot/ )
+Bot	Mozilla/5.0 (compatible; spbot/2.1; +http://www.seoprofiler.com/bot )
+Bot	Mozilla/5.0 (compatible; spbot/3.0; +http://www.seoprofiler.com/bot )
+Bot	Mozilla/5.0 (compatible; spbot/3.1; +http://www.seoprofiler.com/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.0.1; +http://www.seoprofiler.com/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.0.2; +http://www.seoprofiler.com/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.0.3; +http://www.seoprofiler.com/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.0.4; +http://www.seoprofiler.com/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.0.5; +http://www.seoprofiler.com/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.0.6; +http://www.seoprofiler.com/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.0.7; +http://OpenLinkProfiler.org/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.0.7; +https://www.seoprofiler.com/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.0.8; +http://OpenLinkProfiler.org/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.0.9; +http://OpenLinkProfiler.org/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.0; +http://www.seoprofiler.com/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.0a; +http://www.seoprofiler.com/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.0b; +http://www.seoprofiler.com/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.1.0; +http://OpenLinkProfiler.org/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.2.0; +http://OpenLinkProfiler.org/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.3.0; +http://OpenLinkProfiler.org/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.4.0; +http://OpenLinkProfiler.org/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.4.1; +http://OpenLinkProfiler.org/bot )
+Bot	Mozilla/5.0 (compatible; spbot/4.4.2; +http://OpenLinkProfiler.org/bot )
+Bot	Mozilla/5.0 (compatible; spbot/5.0.1; +http://OpenLinkProfiler.org/bot )
+Bot	Mozilla/5.0 (compatible; spbot/5.0.2; +http://OpenLinkProfiler.org/bot )
+Bot	Mozilla/5.0 (compatible; spbot/5.0.3; +http://OpenLinkProfiler.org/bot )
+Bot	Mozilla/5.0 (compatible; spbot/5.0; +http://OpenLinkProfiler.org/bot )
+Bot	Mozilla/5.0 (compatible; special_archiver/3.1.1 +http://www.archive.org/details/archive.org_bot)
+Bot	Mozilla/5.0 (compatible; special_archiver; Archive-It; +http://archive-it.org/files/site-owners-special.html)
+Bot	Mozilla/5.0 (compatible; startmebot/1.0; +https://start.me/bot)
+Bot	Mozilla/5.0 (compatible; stepstoneCrawlBot; +https://www.thestepstonegroup.com/crawler/)
+Bot	Mozilla/5.0 (compatible; sukibot_heritrix/3.1.1 +http://suki.ling.helsinki.fi/eng/webmasters.html)
+Bot	Mozilla/5.0 (compatible; t3versionsBot/1.0; +https://www.t3versions.com/bot)
+Bot	Mozilla/5.0 (compatible; tchelebi/1.0; +http://tchelebi.io)
+!	Mozilla/5.0 (compatible; theoldreader.com)
+Bot	Mozilla/5.0 (compatible; top100.rambler.ru crawler)
+Bot	Mozilla/5.0 (compatible; tracemyfile/1.0; +bot@tracemyfile.com)
+Bot	Mozilla/5.0 (compatible; tracking-quality-spider/0.1; https://www.awin.com)
+Bot	Mozilla/5.0 (compatible; trovitBot 1.0; +http://www.trovit.com/bot.html)
+!	Mozilla/5.0 (compatible; um-FC/1.0; https://www.ubermetrics-technologies.com/; Windows NT 6.1; WOW64; rv:125.0) Gecko/20100101 Firefox/125.1
+!	Mozilla/5.0 (compatible; um-IC/1.0; https://www.ubermetrics-technologies.com/; Windows NT 6.1; WOW64; rv:125.0) Gecko/20100101 Firefox/125.1
+!	Mozilla/5.0 (compatible; um-LN/1.0; mailto: techinfo@ubermetrics-technologies.com)
+!	Mozilla/5.0 (compatible; upday/1.0; +upday)
+Bot	Mozilla/5.0 (compatible; useeBookChecker/0.2; +http://usee.pl/useeBookChecker.html)
+Bot	Mozilla/5.0 (compatible; vebidoobot/1.0; +https://blog.vebidoo.de/vebidoobot/
+Bot	Mozilla/5.0 (compatible; videootvBot; +https://www.videoo.tv)
+Bot	Mozilla/5.0 (compatible; vkShare; +http://vk.com/dev/Share)
+Bot	Mozilla/5.0 (compatible; vuhuvBot/1.0; +http://vuhuv.com/bot.html)
+Bot	Mozilla/5.0 (compatible; webspidermount; +https://www.webspidermount.com/)
+Bot	Mozilla/5.0 (compatible; wmtips.com/2.0; +http://www.wmtips.com/tools/)
+Bot	Mozilla/5.0 (compatible; woorankreview/2.0; +https://www.woorank.com/)
+Bot	Mozilla/5.0 (compatible; woriobot +http://worio.com)
+Bot	Mozilla/5.0 (compatible; woriobot support [at] zite [dot] com +http://zite.com)
+Bot	Mozilla/5.0 (compatible; wpbot/1.1; +https://forms.gle/ajBaxygz9jSR8p8G9)
+Bot	Mozilla/5.0 (compatible; yoozBot-2.2; http://yooz.ir; info@yooz.ir)
+Bot	Mozilla/5.0 (compatible; zenback bot; powered by logly +http://corp.logly.co.jp/)
+Bot	Mozilla/5.0 (compatible;AspiegelBot)
+Bot	Mozilla/5.0 (compatible;FindITAnswersbot/1.0;+http://search.it-influentials.com/bot.htm)
+Bot	Mozilla/5.0 (compatible;HostTracker/2.0;+http://www.host-tracker.com/)
+!	Mozilla/5.0 (compatible;Impact.com Agent) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36
+PetalBot	Mozilla/5.0 (compatible;PetalBot;+https://webmaster.petalsearch.com/site/petalbot)
+Bot	Mozilla/5.0 (compatible;acapbot/0.1.;treat like Googlebot)
+Bot	Mozilla/5.0 (compatible;acapbot/0.1;treat like Googlebot)
+Bot	Mozilla/5.0 (compatible;contxbot/1.0)
+Bot	Mozilla/5.0 (compatible;vu-server-health-scanner/1.0;https://130.37.198.75/index.html)
+!	Mozilla/5.0 (feeder.co; Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36
+!	Mozilla/5.0 (iPad; CPU OS 15_3_1 like Mac OS X) adbeat.com/policy AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.3.1 Mobile/15E148 Safari/604.1
+BytedanceBot	Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.3754.1902 Mobile Safari/537.36; Bytespider
+BytedanceBot	Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.4454.1745 Mobile Safari/537.36; Bytespider
+BytedanceBot	Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.7597.1164 Mobile Safari/537.36; Bytespider;bytespider@bytedance.com
+BytedanceBot	Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2988.1545 Mobile Safari/537.36; Bytespider
+BytedanceBot	Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.4141.1682 Mobile Safari/537.36; Bytespider
+BytedanceBot	Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.3478.1649 Mobile Safari/537.36; Bytespider
+Bot	Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1 (compatible; woorankreview/2.0; +https://www.woorank.com/)
+!	Mozilla/5.0 (iPhone; CPU iPhone OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Hotjar Version/11.0 Mobile/15E148 Safari/604.1
+Bot	Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1 (compatible; KargoBot-Artemis-Mobile; +https://www.kargo.com/kargobot-artemis)
+Bot	Mozilla/5.0 (iPhone; CPU iPhone OS 16_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Mobile/15E148 Safari/604.1 (compatible; NanoInteractive/1.0; +https://nanointeractive.com/crawler/)
+Bot	Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko)                 Version/6.0 Mobile/10A5376e Safari/8536.25 (compatible; SMTBot/1.0; +http://www.similartech.com/smtbot)
+AppleBot	Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25 (compatible; Applebot/0.3; +http://www.apple.com/go/applebot)
+GoogleBot	Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25 (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)
+GoogleBot	Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+!	Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Mobile/11A465 Twitter for iPhone BrandVerity/1.0 (http://www.brandverity.com/why-is-brandverity-visiting-me)
+BingBot	Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53 (compatible; adidxbot/2.0;  http://www.bing.com/bingbot.htm)
+BingBot	Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53 (compatible; adidxbot/2.0; +http://www.bing.com/bingbot.htm)
+BingBot	Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53 (compatible; bingbot/2.0;  http://www.bing.com/bingbot.htm)
+BingBot	Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)
+!	Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53 BingPreview/1.0b
+Bot	Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/600.1.3 (KHTML, like Gecko) Version/8.0 Mobile/12A4345d Safari/600.1.4 moatbot
+AppleBot	Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B410 Safari/600.1.4 (Applebot/0.1; +http://www.apple.com/go/applebot)
+YandexBot	Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4 (compatible; YandexBot/3.0; +http://yandex.com/bots)
+Bot	Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4 (compatible; YandexMobileBot/3.0; +http://yandex.com/bots)
+GoogleBot	Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/537.36 (KHTML, like Gecko) Version/8.0 Mobile/12F70 Safari/600.1.4 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+Bot	Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12F70 Safari/600.1. 4 (compatible; HyScore/1.0; +https://hyscore.io/crawler/)
+GoogleBot	Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12F70 Safari/600.1.4 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
+Bot	Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12F70 Safari/600.1.4 (compatible; Laserlikebot/0.1)
+Bot	Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12F70 Safari/600.1.4 (compatible; OnCrawl/1.0; +http://www.oncrawl.com)
+GoogleBot	Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1 (compatible; AdsBot-Google-Mobile; +http://www.google.com/mobile/adsbot.html)
+GoogleBot	Mozilla/5.0 (iPhone; U; CPU iPhone OS 10_0 like Mac OS X; en-us) AppleWebKit/602.1.38 (KHTML, like Gecko) Version/10.0 Mobile/14A5297c Safari/602.1 (compatible; Mediapartners-Google/2.1; +http://www.google.com/bot.html)
+GoogleBot	Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7 (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)
+GoogleBot	Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8B117 Safari/6531.22.7 (compatible; Mediapartners-Google/2.1; +http://www.google.com/bot.html)
+YahooBot	Mozilla/5.0 (iPhone; Y!J-BRY/YATSH crawler; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html)
+Bot	Mozilla/5.0 (keys-so-bot)
+Bot	Mozilla/5.0 (l9scan/2.0; +https://github.com/LeakIX/l9scan)
+Bot	Mozilla/5.0 (nomore404.com robot/1.1; +https://nomore404.com/)
+BingBot	Mozilla/5.0 (seoanalyzer; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)
+Bot	Mozilla/5.0 (watchOS 6.2; Watch; compatible; sv-watchagent; HTTPClient 4.5)
+!	Mozilla/5.0 (watchTowr; Windows NT 10.0; Win64; x64; rv:84.0) Gecko/20100101 Firefox/84.0
+GoogleBot	Mozilla/5.0 AppleWebKit (compatible; s4a-probe-bot/1.0; Fake-Googlebot; +https://www.seo4ajax.com/webscraper)
+Bot	Mozilla/5.0 AppleWebKit (compatible; s4a/1.0; +https://www.seo4ajax.com/webscraper)
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) (compatible; Coveobot/2.0;+http://www.coveo.com/bot.html)
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 (Refindbot/1.0)
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.131 Safari/537.36 1.6.4 (+https://csirt.cz/cs/dns-crawler)
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; AzureAI-SearchBot/1.0;
+OpenAIBot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ChatGPT-User/1.0; +https://openai.com/bot
+OpenAIBot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; OAI-SearchBot/1.0; +https://openai.com/searchbot
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ShapBot/0.1.0
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; ABEvalBot/0.1) Version/11.1.2 Safari/605.1.15
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Amazing-SearchBot/0.1; +https://amazing.com/bot.html) Chrome/119.0.6045.214 Safari/537.36
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Amzn-SearchBot/0.1) Chrome/119.0.6045.214 Safari/537.36
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Aranet-SearchBot/1.0; +https://aranet.ai/bot) Chrome/131.0.0.0 Safari/537.36
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; AudigentAdBot; +http://www.audigent.com/bot.html) Chrome/W.X.Y.Z Safari/537.36
+AnthropicBot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Claude-SearchBot/1.0; +https://www.anthropic.com)
+AnthropicBot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Claude-User/1.0; +Claude-User@anthropic.com)
+AnthropicBot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; ClaudeBot/1.0; +claudebot@anthropic.com)
+OpenAIBot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; GPTBot/1.0; +https://openai.com/gptbot)
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; GeedoProductSearch; +http://www.geedo.com/product-search.html) Chrome/79.0.3945.88 Safari/537.36
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Gemini-Deep-Research; +https://gemini.google/overview/deep-research/) Chrome/135.0.0.0 Safari/537.36
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Google-CloudVertexBot; +https://cloud.google.com/enterprise-search) Chrome/W.X.Y.Z Safari/537.36
+GoogleBot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Safari/537.36
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; LinerBot/1.0; +https://docs.getliner.com/docs/linerbot)
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Linespider/1.1; +https://lin.ee/4dwXkTH) Chrome/W.X.Y.Z Safari/537.36
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; MistralAI-User/1.0; +https://docs.mistral.ai/robots)
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Nicecrawler/1.1; +http://www.nicecrawler.com/) Chrome/90.0.4430.97 Safari/537.36
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; NoahBot/1.0; +https://noahwire.com/bot-info)
+PerplexityBot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Perplexity-User/1.0; +https://perplexity.ai/perplexity-user)
+PerplexityBot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot)
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; PerplexityUser/1.0; +https://perplexity.ai)
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Scrunchbot/1.0; +https://scrunchai.com/bots)
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; SleepBot/1.0; +http://sleepbot.com/) Chrome/131.0.0.0 Safari/537.36
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; WRTNBot; +https://wrtn.ai/wrtnbot)
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; WorldBot/0.1; +https://worldlabs.ai)
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; ZanistaBot/1.0; +https://zanista.ai/crawler-info) Chrome/W.X.Y.Z Safari/537.36
+BingBot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/103.0.5060.134 Safari/537.36
+BingBot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Safari/537.36
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; impendoom-bot/0.1.0; +https://impendoom.com/) Safari/537.36
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; qcbot/1.0; +http://quic.cloud/bot.html) Chrome/112.0.0.0 Safari/537.36
+Bot	Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; rakutenusabot-image/1.0) Chrome/114.0.0.0 Safari/537.36
+!	Mozilla/5.0 AppleWebKit/537.36 Chrome/139.0.7258.127 Safari/537.36 Google-Ads-Conversions
+Bot	Mozilla/5.0 AppleWebKit/605.1.15 (KHTML, like Gecko; compatible; iAskBot/1.0; +https://iask.ai/) Chrome/120.0.6099.119 Safari/605.1.15
+Bot	Mozilla/5.0 Moreover/5.1 (+http://www.moreover.com)
+!	Mozilla/5.0 [en] (X11, U; OpenVAS)
+Bot	Mozilla/5.0 compatible; yelpspider/yelpspider-1.0 (Crawlerbot run by Yelp Inc; yelpbot at yelp dot com)
+!	Mozilla/5.0 edansbot (Windows NT 10.0; Win64; x64; rv:90.0) Gecko/20100101 Firefox/118.0
+!	Mozilla/5.0 researchscan.comsys.rwth-aachen.de
+!	Mozilla/5.0 zgrab/0.x
+Bot	Mozilla/5.0(windows NT 10.0; Win64; x64) AppleWebkit/537.36(KHTML, like Gecko)  Chrome/90.0.4430.72  Safari/537.36 factset_spyderbot
+Bot	Mozilla/5.0+(compatible; MonSpark/1.0; http://www.monspark.com/)
+Bot	Mozilla/5.0+(compatible; MxToolbox/Beta7; http://www.mxtoolbox.com/)
+Bot	Mozilla/5.0+(compatible; UptimeRobot/2.0; http://www.uptimerobot.com/)
+Bot	Mozilla/5.0+(compatible;+PiplBot;+http://www.pipl.com/bot/)
+!	Mozilla/5.0/Firefox/42.0 - nbertaupete95(at)gmail.com
+!	Mozilla/5.00 (Nikto/2.1.5) (Evasions:None) (Test:Port Check)
+!	Mozilla/5.0; Keydrop.io/1.0(onlyscans.com/about);
+Bot	Mozilla/5.1 (compatible; DBot/7.5.6; +http://a14download.com)
+Bot	Mozilla/7.0 (compatible; Golfe/1.1; +http://www.goo-olfe.ae/bot.html)
+Bot	Mozzila/5.0 (compatible; Sonic/1.0; http://www.yama.info.waseda.ac.jp/~crawler/info.html)
+Bot	NAVER Blog Rssbot
+!	NING/1.0
+Bot	NINJA bot
+Bot	NestDaddybot/1.0.0 (+https://nestdaddy.com/bot)
+!	NetAPI v1
+Bot	NetResearchServer/4.0(loopimprovements.com/robot.html)
+!	NetSystemsResearch studies the availability of various services across the internet. Our website is netsystemsresearch.com
+Bot	Neticle Crawler v1.0 ( https://neticle.com/bot/en/ )
+Bot	Netumo/0.2 (+https://www.netumo.app/)
+Bot	Netvibes (crawler/bot; http://www.netvibes.com
+Bot	Netvibes (crawler; http://www.netvibes.com)
+Bot	Netvibes (http://www.netvibes.com)
+!	New York Times Newsgathering
+Bot	NewsBlur Feed Fetcher - 1 subscriber - http://www.newsblur.com/site/0000000/webpage (Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.1 Safari/605.1.15)
+Bot	NewsGator FetchLinks extension/0.2.0 (http://graemef.com)
+!	NewsGator/3.0,gzip(gfe),gzip(gfe)
+Bot	NewsGatorOnline/2.0 (http://www.newsgator.com)
+Bot	Newsify Feed Fetcher - 3 subscribers - http://www.newsify.co/site/899429/automaton-twocanoes-software (Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_1) AppleWebKit/534.48.3 (KHTML, like Gecko) Version/5.1 Safari/534.48.3)
+!	NextCloud-News/1.0
+Bot	NicheIndex/1.0 RSS Harvest (+https://nicheindex.co)
+GoogleBot	Nokia6820/2.0 (4.83) Profile/MIDP-1.0 Configuration/CLDC-1.0 (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)
+Bot	Notion/1.0 (https://notion.so; team@makenotion.com)
+Bot	NsToolsBot/analyse
+Bot	NutchCVS/0.7.1 (Nutch; http://lucene.apache.org/nutch/bot.html; nutch-agent@lucene.apache.org)
+Bot	OICrawler/Nutch https://openindex.ai
+!	OWLer-W (owler@ows.eu)
+Bot	OdklBot/1.0 (share@odnoklassniki.ru)
+!	Omnisend/1.0
+Bot	OnlineOrNot.com_bot_1.0_(https://onlineornot.com)
+Bot	OpenGraphCheck/2.1 (+https://opengraphcheck.com)
+Bot	OpenTheBoxBot/1.0
+Bot	Orlo-LinkPreview/1.0
+Bot	OutclicksBot/2 +https://www.outclicks.net/agent/PryJzTl8POCRHfvEUlRN5FKtZoWDQOBEvFJ2wh6KH5J
+Bot	OutclicksBot/2 +https://www.outclicks.net/agent/VjzDygCuk4ubNmg40ZMbFqT0sIh7UfOKk8s8ZMiupUR
+Bot	OutclicksBot/2 +https://www.outclicks.net/agent/gIYbZ38dfAuhZkrFVl7sJBFOUhOVct6J1SvxgmBZgCe
+Bot	OutclicksBot/2 +https://www.outclicks.net/agent/p2i4sNUh7eylJF1S6SGgRs5mP40ExlYvsr9GBxVQG6h
+Bot	Overcast/1.0 Podcast Sync (123 subscribers; feed-id=456789; +http://overcast.fm/)
+!	Owler (ows.eu/owler)
+!	PDF24 URL To PDF
+Bot	PHP-Curl-Class/4.13.0 (+https://github.com/php-curl-class/php-curl-class) PHP/7.2.24 curl/7.61.1
+Bot	PHP-Curl-Class/4.13.0 (+https://github.com/php-curl-class/php-curl-class) PHP/7.3.19 curl/7.66.0
+Bot	PHP-Curl-Class/4.13.0 (+https://github.com/php-curl-class/php-curl-class) PHP/7.3.23 curl/7.66.0
+Bot	PHP-Curl-Class/4.13.0 (+https://github.com/php-curl-class/php-curl-class) PHP/7.4.10 curl/7.69.1
+Bot	PHP-Curl-Class/4.13.0 (+https://github.com/php-curl-class/php-curl-class) PHP/7.4.11 curl/7.69.1
+Bot	PHP-Curl-Class/4.13.0 (+https://github.com/php-curl-class/php-curl-class) PHP/7.4.7 curl/7.69.1
+Bot	PHP-Curl-Class/4.13.0 (+https://github.com/php-curl-class/php-curl-class) PHP/7.4.9 curl/7.69.1
+!	PS_Daily/1.0 Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36
+Bot	PageThing http://pagething.com curl www
+Bot	Pandalytics/1.0 (https://domainsbot.com/pandalytics/)
+!	Panopta v1.1
+Bot	ParselySharesBot (+http://parsely.com)
+Bot	PayPal/AUHR-214.0-51787073PayPal IPN ( https://www.paypal.com/ipn )
+!	Pcore-HTTP/v0.40.3
+!	Pcore-HTTP/v0.44.0
+!	Penthouse Critical Path CSS Generator
+Bot	PhxBot/0.1 (phxbot@protonmail.com)
+PingdomBot	Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)
+Bot	Pinterest/0.2 (+http://www.pinterest.com/bot.html)
+Bot	PiplBot (+http://www.pipl.com/bot/)
+!	Pixalate.com/1.0
+Bot	Plesk screenshot bot https://support.plesk.com/hc/en-us/articles/10301006946066
+Bot	PocketCasts/1.0 (Pocket Casts Feed Parser; +http://pocketcasts.com/)
+Bot	PocketParser/2.0 (+https://getpocket.com/pocketparser_ua)
+Bot	PodchaserParser/2.0 (https://podchaser.com)
+Bot	Podimo/1.0 (+https://podimo.com/)
+Bot	Poggio-Citations 1.0 (+https://docs.poggio.io/api/robots)
+!	PostRank/2.0 (postrank.com)
+!	PostRank/2.0 (postrank.com; 1 subscribers)
+!	Potions/1.0.0
+Bot	PressEngineBot (+http://pressengine.net/crawl-policy)
+Bot	Protopage/3.0 (http://www.protopage.com)
+Bot	Pulsepoint XT3 web scraper
+Bot	Python-urllib/1.17
+Bot	Python-urllib/2.5
+Bot	Python-urllib/2.6
+Bot	Python-urllib/2.7
+Bot	Python-urllib/3.1
+Bot	Python-urllib/3.2
+Bot	Python-urllib/3.3
+Bot	Python-urllib/3.4
+Bot	Python-urllib/3.5
+Bot	Python-urllib/3.6
+Bot	Python-urllib/3.7
+Bot	Python/3.7 aiohttp/3.6.2a2
+Bot	Python/3.8 aiohttp/3.7.2
+Bot	Python/3.9 aiohttp/3.7.3
+Bot	QualifiedBot/1.0
+Bot	Quantcastbot/1.0 (+http://www.quantcast.com/bot)
+Bot	Quora-Bot/1.0 (http://www.quora.com)
+Bot	RED/2.0.14 (https://redbot.org/)
+Bot	RSS.Social/1.0 +https://rss.social/bot
+Bot	RSSAPI/2.0 (+https://rssapi.net/)
+Bot	RSSMicro.com RSS/Atom Feed Robot
+Bot	RSSingBot (http://www.rssing.com)
+Bot	Rackspace Monitoring/1.1 (https://monitoring.api.rackspacecloud.com)
+Bot	Rakuten Image extraction bot
+Bot	RankurBot/3.3 (+http://rankur.com)
+Bot	Reaper/2.07 ( http://www.sitesearch.ca/reaper)
+Bot	Recurly Webhooks/2.0 (+https://docs.recurly.com/push-notifications)
+!	Reelevant/1.0
+Bot	RepoLookoutBot/v1.1.0-297-gcf436d3 (abuse reports to abuse@repo-lookout.org)
+Bot	Retool/2.0 (+https://docs.tryretool.com/docs/apis)
+Bot	Riddler (http://riddler.io/about)
+Bot	Riddler (http://riddler.io/about.html)
+Bot	RobotsChecker/0.6 (+http://www.blocked.org.uk)
+Bot	RuxitSynthetic/1.0
+Bot	RyteBot/1.0.0 (+https://bot.ryte.com/)
+GoogleBot	SAMSUNG-SGH-E250/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0 (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)
+Bot	SBL-BOT (http://sbl.net)
+Bot	SENTINEL-LinkCheck/1.0 (+https://sentinel.oblivionzone.com/bot)
+Bot	SEOlizer/1.1 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13 (+https://www.seolizer.de/bot.html)
+!	SFDC-Callout/49.0
+Bot	SMTBot (similartech.com/smtbot)
+Bot	SMTnetPMBot/
+!	SSL Labs
+Bot	SSL Labs (https://www.ssllabs.com/about/assessment.html)
+Bot	SafeDNSBot (https://www.safedns.com/searchbot)
+Bot	SafeSearch microdata crawler (https://safesearch.avira.com, safesearch-abuse@avira.com)
+Bot	ScourRSSBot/1.0 (+https://scour.ing/bot)
+Bot	Scrapy/0.20.1 (+http://scrapy.org)
+Bot	Scrapy/1.0.3 (+http://scrapy.org)
+Bot	Screaming Frog SEO Spider/2,55
+Bot	Screaming Frog SEO Spider/5.1
+Bot	Scrubby/2.2 (http://www.scrubtheweb.com/)
+Bot	SearchAtlas.com SEO Crawler
+Bot	Seekbot/1.0 (http://www.seekbot.net/bot.html) RobotsTxtFetcher/1.2
+Bot	SemanticScholarBot/1.0 (+http://s2.allenai.org/bot.html)
+!	SendGrid Event API
+GoogleBot	SentiBot www.sentibot.eu (compatible with Googlebot)
+Bot	SentryUptimeBot/1.0 (+http://docs.sentry.io/product/alerts/uptime-monitoring/)
+Bot	SenutoBot/1.0 (compatible; SenutoBot/1.0; +https://www.senuto.com/)
+Bot	SeobilityBot (SEO Tool; https://www.seobility.net/sites/bot.html)
+Bot	SerendeputyBot/0.8.6 (http://serendeputy.com/about/serendeputy-bot)
+Bot	Server Density Service Monitoring v2Server Density Agent
+Bot	SeznamHomepageCrawler/v1.0.6
+Bot	ShortPixel/1.0 (+https://shortpixel.com)
+Bot	Shortwave Image Fetcher
+Bot	Sidetrade indexer bot
+Bot	Silk/1.0 Also seen as: silk/1.0 (+http://www.slider.com/silk.htm)/3.7
+Bot	SimpleCrawler/0.1
+Bot	SimplePie/1.3-dev (Feed Parser; http://simplepie.org; Allow like Gecko)
+Bot	SirdataBot (+https://semantic-api.docs.sirdata.net/contextual-api/contextual-api/introduction)
+Bot	SiteCheckerBotCrawler/1.0 (+http://sitechecker.pro)
+!	SiteLock (AccMan Connector)/1.0
+Bot	SiteScoreBot v20210315 - https://sitescore.ai
+!	SiteSucker for macOS/6.1.5
+!	Skroutz ImageBot v1
+!	SkroutzBot v1.0
+Bot	Slack-ImgProxy (+https://api.slack.com/robots)
+Bot	Slack-ImgProxy 0.59 (+https://api.slack.com/robots)
+Bot	Slack-ImgProxy 0.66 (+https://api.slack.com/robots)
+Bot	Slack-ImgProxy 1.106 (+https://api.slack.com/robots)
+Bot	Slack-ImgProxy 1.136 (+https://api.slack.com/robots)
+Bot	Slack-ImgProxy 1.138 (+https://api.slack.com/robots)
+Bot	Slack-ImgProxy 149 (+https://api.slack.com/robots)
+Bot	Slackbot 1.0 (+https://api.slack.com/robots)
+Bot	Slackbot-LinkExpanding (+https://api.slack.com/robots)
+Bot	Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)
+Bot	SmarshBot/1.0
+Bot	SmartologyBot/1.0 (+http://www.smartology.net/smartologybot)
+Bot	Snap URL Preview Service; bot; snapchat; https://developers.snap.com/robots
+!	Snipcart/1.0
+Bot	Sogou News Spider/4.0(+http://www.sogou.com/docs/help/webmasters.htm#07)
+Bot	Sogou Pic Spider/3.0(+http://www.sogou.com/docs/help/webmasters.htm#07)
+Bot	Sogou web spider/4.0(+http://www.sogou.com/docs/help/webmasters.htm#07)
+!	Sora POS/1.0 (Sora Websoft)
+Bot	SottopopNone/1.0(+https://upcontent.com/robots)
+Bot	Spectate/1.0 (+https://docs.spectate.net/faq/uptime-monitor-bot)
+Bot	Speedy Spider (Entireweb; Beta/1.2; http://www.entireweb.com/about/search_tech/speedyspider/)
+Bot	Speedy Spider (http://www.entireweb.com/about/search_tech/speedy_spider/)
+Bot	SpringserveBot/1.0
+!	Stape/1.0.0Stape
+Bot	StartpagePrivateImageProxy/2.0 (https://www.startpage.com/; support@startpage.com) requests/2.25.1
+Bot	Statabot/1.0 https://www.stata.com/support/statabot
+Bot	StateOfPlay-ResearchBot/1.0
+Bot	StatsDroneBot (https://statsdrone.com/statsdrone-bot-documentation/) Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36
+Bot	StatusCake_Uptime_Checker/1.0
+Bot	Stripe/1.0 (+https://stripe.com/docs/webhooks)
+Bot	SummalyBot/5.1.0
+Bot	Summify (Summify/1.0.1; +http://summify.com)
+Bot	Superfeedr bot/2.0 http://superfeedr.com - Make your feeds realtime: get in touch - feed-id:1162088860
+Bot	Svix-Webhooks/1.65.0 (sender-9YMgn; +https://www.svix.com/http-sender/)Webhooks/1.65.0 (sender-9YMgn)
+!	Swisscows Favicons
+Bot	Synapse (bot; +https://github.com/matrix-org/synapse)
+Bot	TLS tester from https://testssl.sh/
+Bot	TactiScout/recruit (+http://find-it.world/TempCrawl/Crawltheque.php)
+Bot	TangibleeBot/1.0.0.0 (http://tangiblee.com/bot)
+Bot	TaraGroup Intelligent Bot V1
+Bot	TelegramBot (like TwitterBot)
+Bot	TerraCotta https://github.com/CeramicTeam/CeramicTerracotta
+!	Test Certificate Info
+Bot	Testomatobot/1.0 (Linux x86_64; +https://www.testomato.com/testomatobot) minicrawler/5.2.2
+Bot	TextRazor Downloader (https://www.textrazor.com)
+!	The Knowledge AI
+!	Thinklab (thinklab.com)
+Bot	Timpibot/0.9 (+http://www.timpi.io)
+Bot	TinEye/1.1 (http://tineye.com/crawler.html)
+Bot	Tiny Tiny RSS/1.15.3 (http://tt-rss.org/)
+Bot	Tiny Tiny RSS/17.12 (a2d1fa5) (http://tt-rss.org/)
+Bot	Tiny Tiny RSS/19.2 (b68db2d) (http://tt-rss.org/)
+Bot	Tiny Tiny RSS/19.8 (http://tt-rss.org/)
+!	Trustly/1
+!	Tumblr/14.0.835.186
+Bot	Turnitin (https://bit.ly/2UvnfoQ)
+Bot	TurnitinBot (https://turnitin.com/robot/crawlerinfo.html)
+Bot	Tweakers Image Proxy https://tweakers.net
+!	TwilioProxy/1.1
+TwitterBot	Twitterbot/0.1
+TwitterBot	Twitterbot/1.0
+!	UA Clearscopebot or similar
+Bot	UT-Dorkbot/1.0
+!	Upflow/1.0
+Bot	Uptime-Kuma/1.18.0
+Bot	Uptime-Kuma/1.23.10
+Bot	Uptime-Kuma/1.23.11
+Bot	Uptime-Kuma/1.23.12
+Bot	Uptime-Kuma/1.23.13
+Bot	Uptime-Kuma/1.23.14
+Bot	Uptime-Kuma/1.23.15
+Bot	Uptime-Kuma/1.23.16
+Bot	Uptimebot.org - Free website monitoring
+!	Urlcheckr/2.0
+Bot	Validator.nu/LV
+!	Valve/Steam HTTP Client 1.0 (SteamChatURLLookup)
+Bot	VelenPublicWebCrawler (velen.io)
+Bot	Vercelbot (+https://vercel.com)
+Bot	Verity/1.1 (https://gumgum.com/verity; verity-support@gumgum.com)
+Bot	VsuSearchSpider/1.0
+Bot	W3C-checklink/2.90 libwww-perl/5.64
+Bot	W3C-checklink/3.6.2.3 libwww-perl/5.64
+Bot	W3C-checklink/4.2 [4.20] libwww-perl/5.803
+Bot	W3C-checklink/4.2.1 [4.21] libwww-perl/5.803
+Bot	W3C-checklink/4.3 [4.42] libwww-perl/5.805
+Bot	W3C-checklink/4.3 [4.42] libwww-perl/5.808
+Bot	W3C-checklink/4.3 [4.42] libwww-perl/5.820
+Bot	W3C-checklink/4.5 [4.154] libwww-perl/5.823
+Bot	W3C-checklink/4.5 [4.160] libwww-perl/5.823
+!	W3C-mobileOK/DDC-1.0
+Bot	W3C_I18n-Checker/1.0
+!	W3C_Unicorn/1.0
+Bot	W3C_Validator/1.3
+Bot	WEDOS OnLine monitoring; https://www.wedos.online/
+Bot	WGETbot/1.0 (+http://wget.alanreed.org)
+!	WJHRO/1.0 (WorldPay Java HTTP Request Object)
+Bot	WOVN Crawler
+Bot	WP Time Capsule API/1.0 ( https://cron.wptimecapsule.com/; https://service.wptimecapsule.com/ )
+Bot	WPMU DEV Broken Link Checker Spider
+Bot	WPMUDEV Uptime Monitor 5.0 (https://wpmudev.com)
+Bot	WPScan v3.8.22 (https://wpscan.com/wordpress-security-scanner)
+Bot	WatchMouse (http://watchmouse.com/ ; HQ)
+Bot	Watchbot monitoring robot (https://watchbot.fflow.net)
+!	WeSEE:Search
+Bot	WeSEE:Search/0.1 (Alpha, http://www.wesee.com/en/support/bot/)
+!	Web Measure/1.0 (https://webresearch.eecs.umich.edu/overview-of-web-measurements/) Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36
+!	Web Screen Service By hyperhost.ua
+!	WebCopier v4.6
+Bot	WebSniffer/1.1 (+http://websniffer.com/)
+Bot	WebZIP/3.5 (http://www.spidersoft.com)
+!	Webflow 1.0 - Site Screenshot
+!	WebsiteOps (hello@websiteops.io)
+Bot	Wget/1.14 (linux-gnu)
+Bot	Wget/1.20.3 (linux-gnu)
+!	WhatWeb/0.5.5
+!	WhatsApp/0.3.4479 N
+!	WhatsApp/0.3.4679 N
+!	WhatsApp/0.3.4941 N
+!	WhatsApp/2.12.15/i
+!	WhatsApp/2.12.16/i
+!	WhatsApp/2.12.17/i
+!	WhatsApp/2.12.449 A
+!	WhatsApp/2.12.453 A
+!	WhatsApp/2.12.510 A
+!	WhatsApp/2.12.540 A
+!	WhatsApp/2.12.548 A
+!	WhatsApp/2.12.555 A
+!	WhatsApp/2.12.556 A
+!	WhatsApp/2.16.1/i
+!	WhatsApp/2.16.13 A
+!	WhatsApp/2.16.2/i
+!	WhatsApp/2.16.42 A
+!	WhatsApp/2.16.57 A
+!	WhatsApp/2.17.70 W
+!	WhatsApp/2.19.175 A
+!	WhatsApp/2.19.244 A
+!	WhatsApp/2.19.258 A
+!	WhatsApp/2.19.308 A
+!	WhatsApp/2.19.330 A
+!	WhatsApp/2.19.92 i
+Bot	Wheregoes.com Redirect Checker/1.0
+Bot	WikiDo/1.1 (http://wikido.com; crawler@wikido.com)
+Bot	WordPress/X.X.X; https://example.com
+!	WordupInfoSearch/1.0
+Bot	Wotbox/2.0 (bot@wotbox.com; http://www.wotbox.com)
+Bot	Wotbox/2.01 (+http://www.wotbox.com/bot/)
+Bot	WovnCrawler/1.0
+!	Xenu Link Sleuth/1.3.8
+Bot	YandoriRSSBot/3.0 (Go)
+Bot	Yanga WorldSearch Bot v1.1/beta (http://www.yanga.co.uk/)
+!	YokoyGroupAG/1.0
+Bot	YouBot (+http://www.you.com)
+!	Zendesk Webhook
+!	ZooShot 0.42
+Bot	ZoomBot (Linkbot 1.0 http://suite.seozoom.it/bot.html)
+!	ZoominfoBot (zoominfobot at zoominfo dot com)
+!	acunetix-product/wvs
+BingBot	adidxbot/1.1 (+http://search.msn.com/msnbot.htm)
+BingBot	adidxbot/2.0 (+http://search.msn.com/msnbot.htm)
+Bot	advanced_crawler (+http://example.com)
+Bot	agent6/Nutch-1.1
+!	air.ai/scanning Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/126.0.0.0 Safari/537.36
+Bot	amibot - http://www.amidalla.de - tech@amidalla.com libwww-perl/5.831
+Bot	artemis web reader/1.0 - https://artemis.jamesg.blog/bot
+!	asnriskscorer/1.0
+Bot	axios/0.18.0
+Bot	axios/0.19.0
+Bot	bidswitchbot/1.0
+Bot	binlar_2.6.3 binlar2.6.3@unspecified.mail
+Bot	binlar_2.6.3 binlar_2.6.3@unspecified.mail
+Bot	binlar_2.6.3 larbin2.6.3@unspecified.mail
+Bot	binlar_2.6.3 phanendra_kalapala@McAfee.com
+Bot	binlar_2.6.3 test@mgmt.mic
+Bot	bitlybot/2.0
+Bot	bitlybot/3.0 (+http://bit.ly/)
+Bot	bl.uk_lddc_bot/3.4.0-20220727 (+https://www.bl.uk/legal-deposit-web-archiving)
+Bot	bl.uk_ldfc_bot/3.4.0-20220727 (+https://www.bl.uk/legal-deposit/web-archiving)
+Bot	blogmuraBot (+http://www.blogmura.com)
+!	bluesky-domain-status-classifier/1.0
+Bot	bot-pge.chlooe.com/1.0.0 (+http://www.chlooe.com/)
+Bot	br-crawler/0.5
+Bot	cXensebot/1.1a
+Bot	carbon-umbrella-bot/1.0
+Bot	caveman-hunter/0.0.0 (+https://fedi.buzz/)
+!	check_http/v2.2.1 (nagios-plugins 2.2.1)
+!	cloudflare-csup (Cloudflare Radar)
+!	coccoc/1.0 ()
+Bot	coccoc/1.0 (http://help.coccoc.com/)
+Bot	coccoc/1.0 (http://help.coccoc.vn/)
+Bot	cognitiveSEO Bot
+Bot	cohere-training-data-crawler (+crawler@cohere.ai)
+Bot	colly - https://github.com/gocolly/colly
+!	colly/2.1.0
+Bot	crawl4ai-adapter/1.0
+Bot	crawler4j (http://code.google.com/p/crawler4j/)
+Bot	crawler4j (https://github.com/yasserg/crawler4j/)
+!	cron-job.org monitor
+!	crusty/0.12.0
+Bot	curl/7.29.0
+Bot	curl/7.47.0
+Bot	curl/7.54.0
+Bot	curl/7.55.1
+Bot	curl/7.64.0
+Bot	curl/7.64.1
+Bot	curl/7.65.3
+!	cypex.ai/scanning Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/126.0.0.0 Safari/537.36
+Bot	datagnionbot (+http://www.datagnion.com/bot.html)
+Bot	dcrawl/1.0
+Bot	deepnoc - https://deepnoc.com/bot
+Bot	dlvr.it/1.0 (+http://dlvr.it/fetcher)
+Bot	domain research project (+https://trentwil.es/domains.html)
+Bot	downnotifier.com monitoring
+Bot	drupact/0.7; http://www.arocom.de/drupact
+!	ds9 2.004.ec2
+Bot	e.ventures Investment Crawler (eventures.vc)
+!	eMoney Advisor
+Bot	eMoneyBot/1.0; +https://emoneyadvisor.com/DataAggregationNotice/
+Bot	eRepublik.tools - Multithreaded Crawler -
+Bot	easyDNS Monitoring ( http://easyurl.net/monitoring )
+!	easybill-ImportManager/ShopwareClient
+Bot	ecotrek GmbH - SustainabilityCrawler (bot@ecotrek.tech)
+Bot	elmah.io Uptime Monitoring
+Bot	elmahio-uptimebot/2.0
+Bot	everyfeed-spider/2.0 (http://www.everyfeed.com)
+!	facebookcatalog/1.0
+FacebookBot	facebookexternalhit/1.0 (+http://www.facebook.com/externalhit_uatext.php)
+FacebookBot	facebookexternalhit/1.1
+FacebookBot	facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)
+Bot	fedistatsCrawler/1.0
+Bot	findlinks/1.0 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/1.1.3-beta8 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/1.1.3-beta9 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/1.1.5-beta7 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/1.1.6-beta1 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/1.1.6-beta1 (+http://wortschatz.uni-leipzig.de/findlinks/; YaCy 0.1; yacy.net)
+Bot	findlinks/1.1.6-beta2 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/1.1.6-beta3 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/1.1.6-beta4 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/1.1.6-beta5 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/1.1.6-beta6 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/2.0 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/2.0.1 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/2.0.2 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/2.0.4 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/2.0.5 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/2.0.9 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/2.1 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/2.1.3 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/2.1.5 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/2.2 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/2.5 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	findlinks/2.6 (+http://wortschatz.uni-leipzig.de/findlinks/)
+Bot	g2reader-bot/1.0 (+http://www.g2reader.com/)
+!	github-camo (c006e452)
+Bot	got (https://github.com/sindresorhus/got)
+Bot	gotosocial/0.19.2+git-90851fc (+https://chirp.zadzmo.org)
+Bot	gsa-crawler (Enterprise; T3-LNMUGC6JBKQNE; thomas@brainfuck.space)
+Bot	hCardValidator/1 PHP/5 (http://hcard.geekhood.net)
+Bot	hgfAlphaXCrawl/1.0 (+https://www.fim.uni-passau.de/data-science/forschung/open-search)
+!	holmes/2.3
+Bot	http.rb/2.2.2 (Mastodon/1.5.1; +https://example-masto-instance.org/)
+Bot	http://seewithkids.com/bot
+!	https://gdnplus.com:Gather Analyze Provide.
+Bot	https://www.ezoic.com/bot/ Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36 (compatible; EzLynx/0.1; +http://www.ezoic.com/bot.html)
+!	httpunit/1.x
+Bot	ia_archiver (+http://www.alexa.com/site/help/webmasters; crawler@alexa.com)
+Bot	iaskspider/2.0
+Bot	ichiro/2.0 (http://help.goo.ne.jp/door/crawler.html)
+!	ichiro/2.0 (ichiro@nttr.co.jp)
+Bot	ichiro/3.0 (http://help.goo.ne.jp/door/crawler.html)
+Bot	ichiro/3.0 (http://help.goo.ne.jp/help/article/1142)
+Bot	ichiro/3.0 (http://search.goo.ne.jp/option/use/sub4/sub4-1/)
+Bot	ichiro/4.0 (http://help.goo.ne.jp/door/crawler.html)
+Bot	ichiro/5.0 (http://help.goo.ne.jp/door/crawler.html)
+!	imgproxy/3.21.0
+Bot	infoobot/0.1 (https://www.infoo.nl/bot.html)
+!	internetVista monitor (Mozilla compatible)
+Bot	iskanie (+http://www.iskanie.com)
+Bot	istellabot-nutch/Nutch-1.10
+Bot	it2media-domain-crawler/1.0 on crawler-prod.it2media.de
+Bot	it2media-domain-crawler/2.0
+!	iubenda-radar/2.25.2
+Bot	jetmon/1.0 (Jetpack Site Uptime Monitor by WordPress.com)
+Bot	jpg-newsbot/2.0; (+https://vipnytt.no/bots/)
+Bot	kagi-fetcher/1.0
+!	keycdn-tools/speed
+!	l9explore/1.2.2
+!	larbin_2.6.2 (larbin@correa.org)
+MsnBot	librabot/1.0 (+http://search.msn.com/msnbot.htm)
+MsnBot	librabot/2.0 (+http://search.msn.com/msnbot.htm)
+Bot	linkReader/1.0 (+https://gochitchat.ai)
+Bot	linkapediabot (+http://www.linkapedia.com)
+!	linkdex.com/v2.0
+Bot	linkdexbot/Nutch-1.0-dev (http://www.linkdex.com/; crawl at linkdex dot com)
+Bot	lkxscan/v0.1.0 (+https://leakix.net) l9explore/v1.0.0 (+https://github.com/LeakIX/l9explore)
+Bot	ltx71 - (http://ltx71.com/)
+!	lwp-trivial/1.35
+Bot	lyonl-asset-proxy/1.0 (+https://lyonl.com/crawler)
+Bot	lyonl-crawler/0.1 (+https://lyonl.com/crawler; crawler@lyonl.com)
+!	magicsearchdev/1.0
+Bot	magpie-crawler/1.1 (U; Linux amd64; en-GB; +http://www.brandwatch.net)
+Bot	masscan/1.0 (https://github.com/robertdavidgraham/masscan)
+!	meta-externalads/1.1
+Bot	meta-externalads/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)
+FacebookBot	meta-externalagent/1.1
+FacebookBot	meta-externalagent/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)
+FacebookBot	meta-externalfetcher/1.1
+FacebookBot	meta-externalfetcher/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)
+Bot	meta-webindexer/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)
+!	mindUpBot (datenbutler.de)
+Bot	montastic-monitor www.montastic.com
+Bot	mozilla/5.0 (compatible; SandobaCrawler/1.0; +https://www.sandoba.com/en/crawler/)
+Bot	mozilla/5.0 (compatible; discobot/1.1; +http://discoveryengine.com/discobot.html)
+MsnBot	msnbot-NewsBlogs/2.0b (+http://search.msn.com/msnbot.htm)
+MsnBot	msnbot-UDiscovery/2.0b (+http://search.msn.com/msnbot.htm)
+MsnBot	msnbot-media/1.0 (+http://search.msn.com/msnbot.htm)
+MsnBot	msnbot-media/1.1 (+http://search.msn.com/msnbot.htm)
+MsnBot	msnbot-media/2.0b (+http://search.msn.com/msnbot.htm)
+MsnBot	msnbot/1.0 (+http://search.msn.com/msnbot.htm)
+MsnBot	msnbot/1.1 (+http://search.msn.com/msnbot.htm)
+MsnBot	msnbot/2.0b (+http://search.msn.com/msnbot.htm)
+MsnBot	msnbot/2.0b (+http://search.msn.com/msnbot.htm).
+MsnBot	msnbot/2.0b (+http://search.msn.com/msnbot.htm)._
+Bot	netEstate NE Crawler (+http://www.sengine.info/)
+Bot	netEstate NE Crawler (+http://www.website-datenbank.de/)
+Bot	newspaper/0.1.0.7
+Bot	newspaper/0.2.5
+Bot	newspaper/0.2.6
+Bot	newspaper/0.2.8
+Bot	node-fetch/1.0 (+https://github.com/bitinn/node-fetch)
+!	okhttp/2.5.0
+!	okhttp/2.7.5
+!	okhttp/3.2.0
+!	okhttp/3.5.0
+!	okhttp/4.1.0
+Bot	omgili/0.5 +http://omgili.com
+!	opencode-smartfetch/1.0
+!	page-preview-tool Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36
+Bot	peer39_crawler/1.0
+!	pingping.io/1.0
+Bot	productsup.io/crawler
+Bot	psbot-image (+http://www.picsearch.com/bot.html)
+Bot	psbot-page (+http://www.picsearch.com/bot.html)
+Bot	psbot/0.1 (+http://www.picsearch.com/bot.html)
+Bot	pulsetic.com (+https://pulsetic.com)
+Bot	python-httpx/0.13.0.dev1
+Bot	python-httpx/0.16.1
+Bot	python-opengraph-jaywink/0.2.0 (+https://github.com/jaywink/python-opengraph)
+Bot	python-requests/2.11.1
+Bot	python-requests/2.18.4
+Bot	python-requests/2.19.1
+Bot	python-requests/2.20.0
+Bot	python-requests/2.21.0
+Bot	python-requests/2.22.0
+Bot	python-requests/2.9.2
+Bot	rawweb-bot/1.0
+!	remove.bg/1.0 background removal website
+Bot	rogerbot/1.0 (http://moz.com/help/pro/what-is-rogerbot-, rogerbot-crawler+partager@moz.com)
+Bot	rogerbot/1.0 (http://moz.com/help/pro/what-is-rogerbot-, rogerbot-crawler+shiny@moz.com)
+Bot	rogerbot/1.0 (http://moz.com/help/pro/what-is-rogerbot-, rogerbot-wherecat@moz.com
+Bot	rogerbot/1.0 (http://moz.com/help/pro/what-is-rogerbot-, rogerbot-wherecat@moz.com)
+Bot	rogerbot/1.0 (http://www.moz.com/dp/rogerbot, rogerbot-crawler@moz.com)
+Bot	rogerbot/1.0 (http://www.seomoz.org/dp/rogerbot, rogerbot-crawler+shiny@seomoz.org)
+Bot	rogerbot/1.0 (http://www.seomoz.org/dp/rogerbot, rogerbot-crawler@seomoz.org)
+Bot	rogerbot/1.0 (http://www.seomoz.org/dp/rogerbot, rogerbot-wherecat@moz.com)
+Bot	rogerbot/1.1 (http://moz.com/help/guides/search-overview/crawl-diagnostics#more-help, rogerbot-crawler+pr2-crawler-05@moz.com)
+Bot	rogerbot/1.1 (http://moz.com/help/guides/search-overview/crawl-diagnostics#more-help, rogerbot-crawler+pr4-crawler-11@moz.com)
+Bot	rogerbot/1.1 (http://moz.com/help/guides/search-overview/crawl-diagnostics#more-help, rogerbot-crawler+pr4-crawler-15@moz.com)
+Bot	rogerbot/1.2 (http://moz.com/help/pro/what-is-rogerbot-, rogerbot-crawler+phaser-testing-crawler-01@moz.com)
+Bot	rss-parser / Buttondown
+Bot	rssbot/1.4.3 (+https://t.me/RustRssBot)
+Bot	screeenly-bot 2.0
+Bot	semaltbot/0.1 (+http://semalt.net)
+!	semanticbot (info@semanticaudience.com)
+Bot	sentry/8.22.0 (https://sentry.io)
+Bot	serpstatbot/1.0 (advanced backlink tracking bot; curl/7.58.0; http://serpstatbot.com/; abuse@serpstatbot.com)
+Bot	serpstatbot/1.0 (advanced backlink tracking bot; http://serpstatbot.com/; abuse@serpstatbot.com)
+Bot	solarwinds/1.0 ( www.solarwinds.com/solarwinds-observability)
+Bot	sqlmap/1.7.8#stable (https://sqlmap.org)
+Bot	synthetic-monitoring-agent/v0.20.1-0-g66af84ad (linux amd64; 66af84ad6a8755895d4b69606281ca7354c1589a; 2024-02-12 16:50:07+00:00; +https://github.com/grafana/synthetic-monitoring-agent)
+Bot	trafilatura/2.0.0 (+https://github.com/adbar/trafilatura)
+Bot	uipbot/1.0 (uipbot@semasio.com)
+!	updown.io daemon 2.11
+!	venus/fedoraplanet
+Bot	videootv Bot
+!	visionheight.com/scan Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/126.0.0.0 Safari/537.36
+Bot	vmcrawl/0.17.7 (https://vmcrawl.com)
+Bot	vmcrawl/0.x (https://docs.vmst.io/vmcrawl)
+Bot	webgains-bot (https://www.webgains.com/public/en/)
+Bot	weborama-fetcher (+http://www.weborama.com)
+Bot	webprosbot/2.0 (+mailto:abuse-6337@webpros.com)
+!	websitepulse checker/3.0 (compatible; MSIE 5.5; Netscape 4.75; Linux)
+Bot	webzio (+https://webz.io/bot.html)
+!	wheresitup.com/1.1
+Bot	wlc3 Pywikibot/9.0.0.dev0 (g18371) requests/2.31.0 Python/3.10.12.final.0
+!	workona-favicon-service/1.0.0
+Bot	wowLink Crawler/1.0
+Bot	wp.com feedbot/1.0 (+https://wp.com)
+!	wsr-agent/1.0
+Bot	www.GettHIT.com | Free Traffic Exchange Bot | If you are seeing this, then your website has been listed in our traffic exchange service. | Visit Us : https://www.getthit.com/bot | Macintosh; Intel Mac OS X 10_7_5 (compatible; getthit.com/3.1;)
+!	www.deadlinkchecker.com Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.86 Safari/537.36
+Bot	www.deadlinkchecker.com XMLHTTP/1.0
+Bot	www.deadlinkchecker.com XMLHTTP/1.0 Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.86 Safari/537.36
+Bot	www.integromedb.org/Crawler
+Bot	yacybot (-global; amd64 FreeBSD 9.2-RELEASE-p10; java 1.7.0_65; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (-global; amd64 Linux 2.6.32-042stab111.11; java 1.7.0_79; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (-global; amd64 Linux 2.6.32-042stab116.1; java 1.7.0_79; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (-global; amd64 Linux 3.10.0-229.4.2.el7.x86_64; java 1.7.0_79; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (-global; amd64 Linux 3.10.0-229.4.2.el7.x86_64; java 1.8.0_45; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (-global; amd64 Linux 3.13.0-61-generic; java 1.7.0_79; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (-global; amd64 Linux 3.14.32-xxxx-grs-ipv6-64; java 1.8.0_111; Europe/de) http://yacy.net/bot.html
+Bot	yacybot (-global; amd64 Linux 3.16.0-4-amd64; java 1.7.0_75; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (-global; amd64 Linux 3.19.0-15-generic; java 1.8.0_45-internal; Europe/de) http://yacy.net/bot.html
+Bot	yacybot (-global; amd64 Linux 3.2.0-4-amd64; java 1.7.0_65; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (-global; amd64 Linux 3.2.0-4-amd64; java 1.7.0_67; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (-global; amd64 Linux 4.4.0-57-generic; java 9-internal; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (-global; amd64 Linux 5.2.11-Jinsol; java 12.0.2; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (-global; amd64 Linux 5.2.8-Jinsol; java 12.0.2; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (-global; amd64 Linux 5.2.9-Jinsol; java 12.0.2; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (-global; amd64 Windows 8 6.2; java 1.7.0_55; Europe/de) http://yacy.net/bot.html
+Bot	yacybot (-global; amd64 Windows 8.1 6.3; java 1.7.0_55; Europe/de) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 FreeBSD 10.3-RELEASE-p7; java 1.7.0_95; GMT/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 FreeBSD 10.3-RELEASE; java 1.8.0_77; GMT/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 2.6.32-042stab093.4; java 1.7.0_65; Etc/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 2.6.32-042stab094.8; java 1.7.0_79; America/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 2.6.32-042stab108.8; java 1.7.0_91; America/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 2.6.32-573.3.1.el6.x86_64; java 1.7.0_85; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.10.0-229.7.2.el7.x86_64; java 1.8.0_45; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.10.0-327.22.2.el7.x86_64; java 1.7.0_101; Etc/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.11.10-21-desktop; java 1.7.0_51; America/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.12.1; java 1.7.0_65; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.13.0-042stab093.4; java 1.7.0_79; Europe/de) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.13.0-042stab093.4; java 1.7.0_79; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.13.0-45-generic; java 1.7.0_75; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.13.0-74-generic; java 1.7.0_91; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.13.0-83-generic; java 1.7.0_95; Europe/de) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.13.0-83-generic; java 1.7.0_95; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.13.0-85-generic; java 1.7.0_101; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.13.0-85-generic; java 1.7.0_95; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.13.0-88-generic; java 1.7.0_101; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.14-0.bpo.1-amd64; java 1.7.0_55; Europe/de) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.14.32-xxxx-grs-ipv6-64; java 1.7.0_75; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.16-0.bpo.2-amd64; java 1.7.0_65; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.16.0-4-amd64; java 1.7.0_111; Europe/de) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.16.0-4-amd64; java 1.7.0_75; America/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.16.0-4-amd64; java 1.7.0_75; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.16.0-4-amd64; java 1.7.0_79; Europe/de) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.16.0-4-amd64; java 1.7.0_79; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.16.0-4-amd64; java 1.7.0_91; Europe/de) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.16.0-4-amd64; java 1.7.0_95; Europe/en) http://yacy.net/bot.html
+Bot	yacybot (/global; amd64 Linux 3.16.0-4-amd64; java 1.8.0_111; Europe/en) http://yacy.net/bot.html

--- a/testdata/devices.tsv
+++ b/testdata/devices.tsv
@@ -1,0 +1,2919 @@
+# Real device fixtures: <expected device type>\t<agent>.
+#
+# Nothing here is a bot. That is the point: bot detection leans on generic
+# tokens, and this file is the precision half of the bargain, sampled across the
+# distinct shapes of the source set so the browsers, phones, feature phones and
+# consoles of twenty years all get a say. TestDeviceFixturesAreNotBots asserts
+# no row reads as a crawler; the device type is asserted where we claim one.
+#
+# Agent strings collected from the sources credited in testdata/NOTICE.md and
+# redistributed under their licences. The expectations beside them are this
+# project's own: a row is a claim about what the agent means, not a snapshot of
+# whatever the parser said the day it was written.
+
+Phone	ABC NP3/4.3.397 version 6.3.10b4.1, build 397 (Android SDK built for x86; google Android SDK built for x86; Android 10)
+Phone	ABC/4.3.392 version 6.2.15, build 392 (moto g play (2021); motorola moto g play (2021); Android 11) AppleWebKit
+Phone	AMOI M8228 Linux/3.0.13 Android/4.0.4 Release/11.06.2012 Browser/AppleWebKit534.30 Profile/MIDP-2.0 Configuration/CLDC-1.1 Mobile Safari/534.30 Android 4.0.1;
+Unknown	AMOI-V810 NetFront/3.2
+Unknown	ASUS Transformer Pad TF300TL; 4.1.1; JRO03C.WW_epad-10.4.3.9-20121106; de-ch
+Unknown	ASUS-V55/1.0
+Unknown	AiMeiTuan /samsung-2.3.6-GT-I9050-800x480-240-4.1.2-116-351910054299883-dianshi1
+Unknown	Alcatel-BE5/1
+Unknown	Alcatel-BH4/1.0
+Unknown	Alcatel-E5/1.0 UP.Browser/7.0.2 (GUI) MMP/2.0
+Unknown	Alcatel-M5/1.0 UP.Browser/7.1 (GUI) MMP/2.0
+Unknown	Alcatel-OT-216/1.0 ObigoInternetBrowser/Q03C
+Unknown	Alcatel-OT-600A/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 ObigoInternetBrowser/Q03C
+Unknown	Alcatel-OT-800X/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 ObigoInternetBrowser/Q05A
+Unknown	Alcatel-OT-C551/1.0 UP.Browser/7.1 (GUI) MMP/2.0 UP.Link/6.3.0.0.0
+Unknown	Alcatel-OT-C750/1.0 UP.Browser/7.1 (GUI) MMP/2.0
+Unknown	Alcatel-OT-S215A/1.0 ObigoInternetBrowser/Q03C
+Unknown	Alcatel-OT-V570/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 ObigoInternetBrowser/Q03C
+Unknown	Alcatel-OT-v770A/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 ObigoInternetBrowser/Q03C
+Unknown	Amoi-A320/Plat-F-VIM/WAP2.0 UP.Browser/6.2.2.7.c.1.101 (GUI) MMP/1.0
+Unknown	Amoi-CA8/1.0 UP.Browser/6.2.2.5 (GUI) MMP/1.0
+Unknown	Amoi-E5/(2006.10.21)SW1.0.2/WAP2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	Amoi-M350/Plat-V-VIM/WAP2.0/MIDP2.0/CLDC1.0 UP.Browser/6.2.3.3 (GUI) MMP/2.0
+Unknown	Amoi-S6/1.0 UP.Browser/5.0.3.2 (GUI)
+Phone	Android 17 - samsung meliuslte
+Phone	Android 2.3.5;AppleWebKit/533.1;Build/HuaweiM650;M650 Build/HuaweiM650
+Phone	Android 2.3.6;AppleWebKit/525.10;Build/HuaweiU8680;T-Mobile myTouch Build/HuaweiU8680
+Phone	Android 2.3.6;AppleWebKit/533.1;Build/GRK39F;LG p720h Build/GRK39F
+Phone	Android 2.3.6;AppleWebKit/533.1;Build/HuaweiU8680;Phoenix Build/HuaweiU8680
+Phone	Android 2.3.7;AppleWebKit/533.1;Build/MIUI;Axioo Vigo 410 Build/MIUI
+Phone	Android 4.0.3;AppleWebKit/534.30;Build/HuaweiT8830;T8830 Build/HuaweiT8830
+Phone	Android 4.0.3;AppleWebKit/535.19;Build/HuaweiU8666N;HUAWEI U8666N Build/HuaweiU8666N
+Phone	Android 4.0.4;AppleWebKit/530.17;Build/HuaweiU8836D;U8836D Build/HuaweiU8836D
+Phone	Android 4.0.4;AppleWebKit/534.30;Build/HuaweiU9202L;U9202L-1 Build/HuaweiU9202L
+Phone	Android 4.0.4;AppleWebKit/534.30;Build/IMM76I;Karbonn A9 Build/IMM76I
+Phone	Android 4.0.4;AppleWebKit/535.19;Build/HuaweiU8950-1;HUAWEI U8950-1 Build/HuaweiU8950-1
+Phone	Android 4.1.1;AppleWebKit/537.36;Build/HuaweiU8686;Prism II Build/HuaweiU8686
+Phone	Android 4.1.2;AppleWebKit/534.30;Build/JZO54K;LG-E435f_gugu Build/JZO54K
+Phone	Android 4.3;AppleWebKit/537.36;Build/JSS15J;SAMSUNG-SM-N9008_TD Release/08.30.2013 Browser/AppleWebKit53
+Phone	Android com.mobileroadie.app_1414 5.1.000 lge-LG-P710 4.1.2 de DE
+Phone	Android/1.0 (hwu8650 HuaweiU8650B836)
+Phone	Android/1.0 (hwu8950N-1 HuaweiU8950N-1)
+Phone	Android/3.2.0.2 samsung/GT-I9195 4.2.2
+Phone	Android/HTC/HTC One mini/m4
+Tablet	AndroidNative/2.0.51 (Linux; U; Android 4.2.2; de-de; LENOVO IdeaTab A3000-H; Build/JDQ39) tablet; 1024x552; Lenovo
+Phone	AppTokens/Android/de/LGE/LG-D802/4.2.2/1.1.0/-/-/-/-/-/-
+Phone	AppTokens/Android/de/samsung/SM-P605/4.3/1.1.0/-/-/-/-/-/-
+Wearable	AppleCoreMedia/1.0.0.16R5303d (Apple Watch; U; CPU OS 5_0 like Mac OS X; en_au)
+Tablet	AppsLauncher/Android/de/samsung/SM-T315/4.2.2/1.5.20/-/-/-/-/-/-
+Phone	BBC News (AndroidApp; 2.5.1 WW; 58) LG-E975 (Android 4.1.2, SDK 16)
+Phone	BBC iPlayer (AndroidApp; 3.1.0.748; 3100748) HTC Butterfly s (Android 4.3, SDK 18)
+Unknown	BIRD K298
+Unknown	BIRD S710_BLEU/1.00 Nucleus RTOS/V1.11.19 MTK6223/07A Release/07.28.2007 Browser/Teleca
+Unknown	BIRD.D220/SW3.09.1015/WAP2.0 Profile/MIDP-2.0 Configuration/CLDC-1.0
+Phone	BRAND: samsung; MODEL: GT-N7100; VERSION.RELEASE: 4.3; VERSION.INCREMENTAL: N7100XXUEMK9; VERSION.SDK: 18; FINGERPRINT: samsung/t03gxx/t03g:4.3/JSS15J/N7100XXUEMK9:user/release-keys; com.socialblade.android.youtubesubscriberswidget/0.0.7 (Linu
+Phone	BaconReader/3.3.1(Android 4.4.2; LGE Nexus 4)
+Phone	Band/2.4.4 (Android OS 4.1.2;samsung SHV-E210K)
+Phone	Bible (LGE VS840 4G cayman_vzw_us;Android 2.3.6;en_US)
+Phone	Bible 4.0.12 (LGE LG-LS855 lge_bproj;Android 2.3.4;en_US)
+Phone	Bible 4.3.7 (LENOVO IdeaTab A3000-H IdeaTabA3000-H;Android 4.2.2;en_US;gzip)
+Phone	Bible 4.3.7 (samsung GT-I9210 GT-I9210;Android 4.1.2;sv_SE;gzip)
+Phone	BlackBerry (4.3)"  User-Agent: BlackBerry8330/4.3.0 Profile/MIDP-2.0Configuration/CLDC-1.1 VendorID/105 protocol: HTTP/1.1
+Phone	BlackBerry6750/4.0.0 Profile/MIDP-1.0 Configuration/CLDC-1.0 UP.Browser/5.0.3.3
+Phone	BlackBerry8220/4.1.0.98 Profile/MIDP-2.0 Configuration/CLDC-1.1/UCWEB7.6.0.75/159/800
+Phone	BlackBerry9788/1.0.0.104 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	Bluevibe 3.0 r3912 Mozilla/4.0 (compatible; MSIE 6.0; LG-KS360/V10b Teleca/WAP2.0 MIDP-2.0/CLDC-1.1) UNTRUSTED/1.0
+Unknown	Bluevibe 3.0 r3912 Mozilla/4.0 (compatible; MSIE 6.0; SAMSUNG-SGH-T528G/T528UDKJ2 Profile/MIDP-2.0 Configuration/CLDC-1.0) UNTRUSTED/1.0
+Unknown	CELKON.C297.SonyEricssonK700c/R2AE SEMC-Browser/4.0.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Phone	CocoonJS/1.4 (android 4.0.3; LG-P880 AppleWebKit/999.00 (KHTML, like Gecko) Mobile Safari/9999.00.0
+Phone	Dalvik/1.2.0 (Linux; U; Android 2.2.2; MTC Mini Build/HuaweiMTC_Mini)
+Phone	Dalvik/1.4.0 (Linux; U; Android 2.3.3; HTC S910m Build/GRI40)
+Phone	Dalvik/1.4.0 (Linux; U; Android 2.3.5; Fly IQ245ro.product.brand=Lenovo Build/GRJ22)
+Phone	Dalvik/1.4.0 (Linux; U; Android 2.3.6; X905 Build/GRK39F)
+Phone	Dalvik/1.6.0 (Linux; U; Android 4.0.3; I-mobile I-style Q1i Build/IML74K)
+Phone	Dalvik/1.6.0 (Linux; U; Android 4.1.2; LG-P880 MIUI/3.7.19)
+Phone	Dalvik/1.6.0 (Linux; U; Android 4.2.2; HUAWEI G730-T00 Build/HuaweiG730-T00)
+Phone	Dalvik/1.6.0 (Linux; U; Android 4.4.2; MI PAD MIUI/KXFCNBF2.0)
+Phone	Dalvik/1.6.0(Linux; U; Android 4.2.2; C6903 Sony/14.1.G.1.518) SonySelectSDK/1.0.9 mashup/0.2
+Phone	Dalvik/1.6.0(Linux; U; Android 4.3; D5503 Sony/14.2.A.1.114) SonySelectSDK/1.0.17 SonySelect/3.0.22
+Phone	Dalvik/1.6.0(Linux; U; Android 4.4.2; D6503 Sony/17.1.A.2.36) SonySelectSDK/999.999.999 TestClient/1.0
+Phone	Deezer/4.3.0.9 (Android; 4.4.2; Mobile; de) HTC HTC One
+Unknown	DoCoMo/2.0 D701i(c100;TB;W23H12)
+Unknown	DoCoMo/2.0 D702iF
+TV	DoCoMo/2.0 D903iTV
+Unknown	DoCoMo/2.0 F01E(c500;TB;W24H16)
+Unknown	DoCoMo/2.0 F08A3
+Unknown	DoCoMo/2.0 F706i
+Unknown	DoCoMo/2.0 F901iS(c100;TB;W23H12)
+Unknown	DoCoMo/2.0 L03A
+Unknown	DoCoMo/2.0 M702iG
+Unknown	DoCoMo/2.0 N01C(c500;TB;W24H16)
+Unknown	DoCoMo/2.0 N03D(c500;TB;W16H10)
+Unknown	DoCoMo/2.0 N601i(c100;TB;W24H12)
+Unknown	DoCoMo/2.0 N900iS(c100;TB;W24H12)
+Unknown	DoCoMo/2.0 NetFront3.0(c100;TB)
+Unknown	DoCoMo/2.0 P01E(c500;TB;W24H16)
+Unknown	DoCoMo/2.0 P701iD(c100;TB;W24H12)
+Unknown	DoCoMo/2.0 P706ie
+TV	DoCoMo/2.0 P903iTV
+Unknown	DoCoMo/2.0 SH01C(c500;TB;W16H10)
+Unknown	DoCoMo/2.0 SH05A3(c500;TB;W20H12)
+Unknown	DoCoMo/2.0 SH702iD
+Unknown	DoCoMo/2.0 SH902i
+Unknown	DoCoMo/2.0 SO905iCS(c100;TB;W24H18)
+Unknown	Dr.Web anti-virus Light Version: 7.00.10.7031 Device model: HTC One S Firmware version: 4.1.1
+Unknown	Dr.Web anti-virus Light Version: 7.00.10.7031 Device model: LG-P705 Firmware version: 4.0.3
+Unknown	Dr.Web anti-virus Light Version: 7.00.11.7032 Device model: HTC One X Firmware version: 4.2.2
+Unknown	Dr.Web anti-virus Light Version: 7.00.8.7029 Device model: ASUS Transformer Pad TF300TG Firmware version: 4.2.1
+Unknown	Dr.Web anti-virus Light Version: 7.00.9.7030 Device model: HTC Wildfire Firmware version: 2.2.1
+Phone	ERO247 Android Application (13, ero247 v2.1) - HTC HTC Desire HD A9191 htc_wwe - 00000000-7785-F425-FFFF-FFFFA20D793D
+Phone	ERO247 Android Application (13, ero247 v2.1) - HTC HTC EVO 3D X515m htc_europe - 00000000-6076-94EF-69F0-E30D4B911CFA
+Phone	ERO247 Android Application (13, ero247 v2.1) - HTC HTC One SV htc_europe - 00000000-169F-435B-B120-263856D18099
+Phone	ERO247 Android Application (13, ero247 v2.1) - HTC HTC Sensation XL with Beats Audio X315e htc_europe - FFFFFFFF-9424-50D0-FFFF-FFFFE17E822B
+Phone	ERO247 Android Application (13, ero247 v2.1) - HTC HTC Wildfire tmo_uk - 00000000-6D51-DDD6-FFFF-FFFFEC8DB655
+Phone	ERO247 Android Application (13, ero247 v2.1) - HUAWEI U8180 Huawei - 00000000-40B0-1EDD-FFFF-FFFFDA716B36
+Phone	ERO247 Android Application (13, ero247 v2.1) - LGE LG-E400 lge - 00000000-1622-7AA4-FFFF-FFFFD27D6CB8
+Phone	ERO247 Android Application (13, ero247 v2.1) - LGE LG-P350 LGE - 00000000-2B54-92D7-40B8-B36D0F95CB93
+Phone	ERO247 Android Application (13, ero247 v2.1) - LGE LG-P760 lge - 00000000-00EB-486A-7E4B-7B9218D5B761
+Phone	ERO247 Android Application (13, ero247 v2.1) - Motorola XT389 motorola - 00000000-7A1B-CEBF-AA9B-8E000FDFFD69
+Phone	ERO247 Android Application (13, ero247 v2.1) - Samsung GT-S5830 Samsung - 00000000-7B1D-9496-529A-27AF7E00D8BE
+Phone	ERO247 Android Application (13, ero247 v2.1) - Sony C6603 Sony - 00000000-0C48-16E6-6401-D14659A7E193
+Phone	ERO247 Android Application (13, ero247 v2.1) - Sony Ericsson LT26i SEMC - 00000000-5510-D339-9BEB-37B04BF057F0
+Phone	ERO247 Android Application (13, ero247 v2.1) - Sony Ericsson ST18i SEMC - FFFFFFFF-8CD1-B56E-1B7A-4B931712C07B
+Phone	ERO247 Android Application (13, ero247 v2.1) - Sony Ericsson WT19i SEMC - FFFFFFFF-9CB0-2D96-FFFF-FFFF88676C44
+Phone	ERO247 Android Application (13, ero247 v2.1) - Sony ST21i Sony - 00000000-3BF6-3BA5-B67D-B76C35D89F8E
+Phone	ERO247 Android Application (13, ero247 v2.1) - TCT ALCATEL ONE TOUCH 918D TCT - 00000000-2EF9-EED2-FFFF-FFFF979CEDEB
+Phone	ERO247 Android Application (13, ero247 v2.1) - TCT Vodafone Smart II TCT - FFFFFFFF-DA38-1081-17A9-496716A69E76
+Phone	ERO247 Android Application (13, ero247 v2.1) - lge LG-P970 lge - 00000000-5AFF-3276-28C9-FD913C6FA208
+Phone	ERO247 Android Application (13, ero247 v2.1) - motorola Milestone MOTO_DACH - FFFFFFFF-AE6F-6587-BC1D-506172E3F813
+Phone	ERO247 Android Application (13, ero247 v2.1) - samsung GT-I5800 samsung - 00000000-0033-C587-FFFF-FFFFD74A85AC
+Phone	ERO247 Android Application (13, ero247 v2.1) - samsung GT-I8190 samsung - 00000000-11D2-B767-ACDC-283F3642E593
+Phone	ERO247 Android Application (13, ero247 v2.1) - samsung GT-I9001 samsung - 00000000-0446-AC8D-B638-E66F3C42221F
+Phone	ERO247 Android Application (13, ero247 v2.1) - samsung GT-I9100 samsung - 00000000-0672-0554-0009-F11713ABE776
+Phone	ERO247 Android Application (13, ero247 v2.1) - samsung GT-I9195 samsung - 00000000-5E8B-FF0E-FFFF-FFFFAD0579BE
+Phone	ERO247 Android Application (13, ero247 v2.1) - samsung GT-N7000 samsung - 00000000-136C-9E8A-BC6D-D578274EC5BD
+Phone	ERO247 Android Application (13, ero247 v2.1) - samsung GT-N8020 samsung - 00000000-09B7-1346-6198-234368712977
+Phone	ERO247 Android Application (13, ero247 v2.1) - samsung GT-S5300 samsung - FFFFFFFF-98B6-1899-AE75-2ACC0FFFE9DD
+Phone	ERO247 Android Application (13, ero247 v2.1) - samsung GT-S5570I samsung - FFFFFFFF-C0CA-1F41-73BF-98A958A4CD93
+Phone	ERO247 Android Application (13, ero247 v2.1) - samsung GT-S5830i samsung - 00000000-287F-7E53-FFFF-FFFFF05A0BE7
+Phone	ERO247 Android Application (13, ero247 v2.1) - samsung GT-S6312 samsung - FFFFFFFF-9300-7895-BC80-EFA00A6263F9
+Phone	ERO247 Android Application (13, ero247 v2.1) - samsung SM-N9005 samsung - 00000000-5696-F3DA-FFFF-FFFFB3D006F9
+Phone	ERO247 Android Application (13, ero247 v2.1) - unknown SPX-5 yusu - FFFFFFFF-C042-30C6-607B-59724104EC5D
+Phone	ERO247 Android Application (16, ero247 v2.2.2) - HTC HTC One mini htc - FFFFFFFF-8DD7-A8DB-FFFF-FFFF8116AFCF
+Phone	ERO247 Android Application (16, ero247 v2.2.2) - LGE Nexus 5 google - FFFFFFFF-94DA-6FB1-53E6-57AC3924B339
+Phone	ERO247 Android Application (16, ero247 v2.2.2) - Sony Ericsson MT15i SEMC - 00000000-57D9-9BE6-FFFF-FFFF91201E9A
+Phone	ERO247 Android Application (16, ero247 v2.2.2) - alps Cynus T1 alps - 00000000-67DC-738B-FFFF-FFFF94CF1257
+Phone	ERO247 Android Application (16, ero247 v2.2.2) - samsung GT-S5280 samsung - 00000000-6EFB-1AA4-FFFF-FFFFBA9C06C2
+Phone	ERO247 Android Application (16, ero247 v2.2.2) - samsung GT-S7562 samsung - 00000000-7131-D070-D56D-2E1C778E1A78
+Phone	ERO4U Android Application (16, ero4u v2.2.2) - Sony C1605 Sony - 00000000-5A82-015A-FFFF-FFFFD4AA26D1
+Phone	ET1 Android Application (16, et1 v2.2.2) - TCT ALCATEL ONE TOUCH 992D TCT - FFFFFFFF-F0A7-117E-FFFF-FFFF8EC948B2
+Phone	Evernote Android/AM_571_655.1057103 (ru_RU); Android/4.3; HTC One/18;
+Unknown	FAKE_USER_AGENT SAMSUNG RL-A760
+Unknown	Futbol24 1.7.1/11 (samsung/GT-I9505; OS 18; 1080x1920@480; deu)
+Phone	GT-N7102 Linux/3.0.13 Android/4.1.1 Release/01.25.2013 Browser/AppleWebKit534.30 Profile/MIDP-2.0 Configuration/CLDC-1.1 Mobile Safari/534.30 Android 4.0.1;
+Phone	GetJarSDK/20130302.04 (8) com.miniclip.railrush/24 android/4.3 (asus; WW_epad; K00E)
+Phone	Gismeteo Android 1.0.5, LGE hammerhead, 4.4.2
+Phone	GoogleEarth/7.1.0002.2011(Android;Android (HTC Sensation XL with Beats Audio X315e-runnymede-user-4.0.3);de-DE;kml:2.2;client:Free;type:default)
+Phone	GoogleEarth/7.1.0003.1255(Android;Android (HTC Sensation XE with Beats Audio Z715e-pyramid-user-4.0.3);de-DE;kml:2.2;client:Free;type:default)
+Phone	Groupon/2.10.3156 (Android 4.2.2; HTC Endeavoru / Htc HTC One X; O2 - de)[preload=false;locale=en_DE;clientidbase=android-htc-rev]
+Phone	Groupon/2.10.3166 (Android 4.1.2; Samsung Espresso10rf / Samsung GT-P5100; O2 - de)[preload=true;locale=de_DE;clientidbase=android-samsung]
+Phone	Groupon/2.3.2787 (Android 4.2.2; Samsung Ks01lte / Samsung GT-I9506; O2 - de)[preload=true;locale=de_DE;clientidbase=android-samsung]
+Phone	Groupon/3.0.3228 (Android 4.1.2; Samsung P4noterf / Samsung GT-N8000; O2 - de)[preload=false;locale=de_DE;clientidbase=android-samsung]
+Computer	HPiPAQrw6815/1.0 Mozilla/4.0 (compatible; MSIE 4.01; Windows CE; PPC; 240x320)
+Unknown	HTC Agent
+Phone	HTC Butterfly_4.3_weibo_4.2.6_android
+Unknown	HTC Desire S_4.0.4_weibo_2.8.1_htc_new
+Phone	HTC Droid Incredible 2 Android_SDK
+Phone	HTC Gratia Android_SDK
+Phone	HTC Incredible S_2.3.5_weibo_4.1.5_android
+Computer	HTC MAX 4G Mozilla/4.0 (compatible; MSIE 4.01; Windows CE; PPC)/7.6.1.82/31/400
+Unknown	HTC One X; 4.2.2; JDQ39; de-de
+Unknown	HTC P3350
+Computer	HTC S620/5.2.968/WAP2.0 Profile/MIDP2.0 Configuration/CLDC1.0 (compatible; MSIE 6.0; Windows CE; Smartphone)
+Unknown	HTC Sensation XE
+Unknown	HTC Streaming Player htc / 1.0 / htc_europe / 4.1.2
+Unknown	HTC Streaming Player htc_europe / 1.0 / htc_chacha / 2.3.5
+Unknown	HTC Streaming Player htc_europe / 1.0 / htc_pico / 2.3.5
+Unknown	HTC Streaming Player htc_europe / 1.0 / htc_saga / 2.3.5
+Unknown	HTC Streaming Player htc_wwe / 1.0 / htc_ace / 2.3.5
+Unknown	HTC Streaming Player htc_wwe / 1.0 / htc_vivo / 4.0.4
+Unknown	HTC Streaming Player vodafone_uk / 1.0 / htc_legend / 2.2
+Phone	HTC Thunderbolt Android_SDK
+Phone	HTC Touch Viva T2223 / YouTube-3.0
+Unknown	HTC-7 Mozart T8698/UCWEB2.0.0.149/47/32079
+Unknown	HTC-A620e/UCWEB2.5.0.202/47/33624
+Unknown	HTC-F5151/1.0 Mozilla/5.0 (BMP; U; en) AppleWebKit/530.8 (KHTML, like Gecko) OBIGO/W10 Safari/530.8
+Phone	HTC-J-One-mini/1.0 Linux/2.6.35.7 Android/4.1.1 Release/08.12.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
+Unknown	HTC-PI39100/UCWEB2.8.0.249/47/355
+Unknown	HTC-Radar C110e/UCWEB2.2.0.157/47/355
+Unknown	HTC-T8697/UCWEB2.0.0.149/47/32079\n
+Phone	HTC-Windows Phone 8X by HTC/UCWEB2.7.0.223/49/355
+Phone	HTC802t_TD/1.0 Android/4.1 release/2013 Browser/WAP2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Computer	HTCGemini/131169 Mozilla/4.0 (compatible; MSIE 4.01; Windows CE; PPC; 240x320)
+Phone	HTC_ChaCha_A810e/Mozilla/5.0(Linux; U; Android 2.3.3;it-it; Build/GRH78C) AppleWebkit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	HTC_DesireS_S510e_Mozilla/5.0(Linux; U; Android 2.3.3;it-it; Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Tablet	HTC_Diamond Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11)
+Tablet	HTC_HERALD Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11)
+Unknown	HTC_OneXplus/1.0
+Computer	HTC_P3301 Mozilla/4.0 (compatible; MSIE 4.01; Windows CE; PPC)/UC Browser7.7.1.88
+Computer	HTC_P3700 Opera/9.50 (Windows NT 5.1; U; en)
+Unknown	HTC_SensationXE_Beats/1.0
+Tablet	HTC_Snap_S526 Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0)
+Tablet	HTC_Touch Cruise Mozilla/4.0 (compatible; MSIE 4.01; Windows CE; PPC; 240x320; HTC_Touch Cruise)/UC Browser7.7.1.88
+Tablet	HTC_Touch2_T3333 Opera/9.50 (Windows NT 5.1; U; en)
+Tablet	HTC_Touch_3G_T3232 Opera/9.50 (Windows NT 5.1; U; nl)
+Tablet	HTC_Touch_Diamond2_T5353 Opera/9.50 (Windows NT 5.1; U; en)
+Tablet	HTC_Touch_HD_T8282-orange/PPC; 480x800 OpVer 34.119.2.731 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11)
+Tablet	HTC_Touch_Pro2_TPC Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0)
+Tablet	HTC_Touch_Viva_T2223 Opera/9.50 (Windows NT 5.1; U; en)
+Unknown	HTC_WildfireS_A510e/1.0
+Unknown	HUAWEI-G6626/1.0 MOCOR_09A/ThreadX 4.0 Release/05.26.2011 Browser/Dorado WAP-Browser 1.0  Profile/MIDP-2.0 Config/CLDC-1.1
+Unknown	HUAWEI-M318/001.00 ACS-NetFront/3.2
+Unknown	HUAWEI-U2800/001.00 Browser/Obigo-Browser/Q05A MMS/UNIBOX/V1.2 HuaweiJava/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+TV	HbbTV/1.1.1 (+PVR;Humax;HD FOX+;1.00.12;1.0)CE-HTML/1.0 ANTGalio/3.1.1.23.04.09
+TV	HbbTV/1.1.1 (; CUS:MEDION; MB70; 1.0; 1.0;) LOH; Opera; CE-HTML/1.0 NetFront/4.1 NETRANGEMMH
+TV	HbbTV/1.1.1 (; ST; FLTk3D; 1.0; 1.0;) NetFront/3.5
+TV	HbbTV/1.1.1 (;Metz;MMS;;;) CE-HTML/1.0
+TV	HbbTV/1.1.1 (;Samsung;SmartTV2013;T-FXPDEUC-1102.2;;) WebKit
+Unknown	HideMe.mobi Browser Nokia7500/2.0 (05.21) Profile/MIDP-2.1 Configuration/CLDC-1.1
+TV	Http://Atamg.wup.ru/SAMSUNG-GT-S5233T/S5233TXEJF1 SHP/VPP/R5 Jasmine/0.8 Qtv5.3 SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1
+Unknown	Huawei/1.0/0HuaweiG6610/SW03 Browser/Obigo-Browser/Q03C MMS/Obigo-MMS/1.2
+TV	Huawei/1.0/0HuaweiU1300/B123 Browser/Obigo-Browser/Q05A MMS/Obigo-MMS/Q05A SyncML/HW-SyncML/1.0 Java/HWJa/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 Player/QTV-Player/5.3
+Phone	Huawei/1.0/HUAWEI-G6609   Browser/Opera MMS/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 Opera/9.80 (MTK; Nucleus; Opera Mobi/4000; U; de-DE) Presto/2.5.28 Version/10.10
+Phone	HuaweiT8500_TD/1.0 (Linux; U; Android 2.2.2; zh-cn) Release/7.27.2011 Browser/WAP2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 AppleWebKit/533.1
+Unknown	HuaweiU3100/B000 Browser/Obigo-Browser/Q05A MMS/Obigo-MMS/Q05A SyncML/HW-SyncML/1.0 Java/HWJa/2.0 Profile/MIDP-2.0 Configurat
+Computer	ICE Browser/5.05 (Java 1.4.0; Windows 2000 5.0 x86)
+Phone	ICQ_Android/5.1 (Android; 15; 4.0.4; LG-P990-P99030a.1211302332; LG-P990; de-DE)
+Phone	Instagram 1.0.0 Android IC (10/2.3.4; 240dpi; 540x960; HTC/sprint; PG86100; shooter; shooter)
+Phone	Instagram 1.1.7 Android (10/2.3.4; 160dpi; 480x320; LGE/Verizon; LG-VS700; VS700; gelato; en_US)
+Phone	Instagram 3.0.5 Android (10/2.3.6; 240dpi; 480x800; samsung; SAMSUNG-SGH-I927; SGH-I927; n1; en_US)
+Phone	Instagram 3.1.0 Android (10/2.3.4; 160dpi; 320x480; HTC/metropcs_us; HTC-PG762; marvelc; marvelc; en_US)
+Phone	Instagram 4.2.2 Android (10/2.3.5; 240dpi; 480x800; HTC/o2_de; HTC Desire HD A9191; ace; spade; de_DE)
+Phone	Instagram 5.0.2 Android (15/4.0.3; 240dpi; 540x960; HTC/vodafone_de; HTC Sensation Z710e; pyramid; pyramid; de_DE)
+Phone	Instagram 5.0.7 Android (17/4.2.2; 240dpi; 480x800; samsung; SM-G350; cs02; hawaii_ss_cs02; de_DE)
+Phone	Instagram 5.1.0 Android (17/4.2.2; 240dpi; 480x854; GT-1317/samsung; GT-1317; GT-1317; mt6572; de_DE)
+Phone	Instagram 5.1.7 Android (18/4.3; 480dpi; 1080x1920; samsung/Verizon; SCH-I545; jfltevzw; qcom; en_US)
+Unknown	JUC (DFH3;U; 4.0.3; zh-cn; HTC_Sensation_XL_with_Beats_Audio_X315e; 480*800) UCWEB7.9.0.94/139/352
+Computer	JUC (Linux; U; 2.3.5; zh-cn; HTC_Sensation_XL_with_Beats_Audio_X315b; 480*800) UCWEB7.9.3.103/139/1002
+Computer	JUC (Linux; U; 2.3.6; zh-cn; Motorola_MOT-XT681; 480*854) UCWEB7.9.0.94/139/800
+Computer	JUC (Linux; U; 4.0.4; zh-cn; Celkon_CT_9; 480*752) UCWEB7.9.0.94/139/444
+Computer	JUC (Linux; U; 4.0.8; zh-cn; HTC_inspire_4G; 480*800) UCWEB7.9.4.145/139/800
+Phone	JUC(Linux;U;Android2.3.3;Zh_cn;SAMSUNG-SGH-I997R;480*800;)UCWEB7.8.0.95/139/444
+Unknown	KWC-E1000/1.0.12 UP.Browser/7.2.6.1.537 (GUI) MMP/2.0
+Unknown	KWC-K127/1002 UP.Browser/6.2.3.9.g.1.110 (GUI) MMP/2.0
+Unknown	KWC-K483J/1007 UP.Browser/6.2.3.2.c.1.101 (GUI) MMP/2.0 UP.Link/6.3.0.0.0
+Unknown	KWC-KE414/1.0.33 UP.Browser/4.1.26l4
+Unknown	KWC-KX414c/1.0.39 UP.Browser/4.1.26l4 UP.Link/1.1
+Unknown	KWC-M1000/1.0.01 UP.Browser/6.2.3.9.g.1.110 (GUI) MMP/2.0
+Unknown	KWC-Rio/ UP.Browser/7.2.7.2.552 (GUI) MMP/2.0
+Unknown	KWC-S2410/1000 UP.Browser/7.2.6.1.821 (GUI) MMP/2.0
+Tablet	Kinder-Tablet-1.0-Weltbild-Mozilla/5.0 (Linux; U; Android 4.2.2; en-US; EOS10 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Unknown	LENOVO-E307_ENG_FRE/(2005.06.20)S267/WAP1.2.1 Profile//
+Computer	LENOVO-ET980/(2005.10.01)Ver1.0.1/WAP2.0 Profile/MIDP-2.0 Configuration/CLDC-1.0/ (compatible; MSIE 4.01; Windows CE; PPC; 240x320)
+Phone	LENOVO-Lenovo-A288t/1.0 Linux/2.6.35.7 Android/2.3.5 Release/03.27.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
+Unknown	LENOVO-P780/176A
+Unknown	LENOVO-V806/(2004.07.01)SW2.0.0/WAP2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	LENOVO-i921/240A
+Unknown	LG CB630
+Unknown	LG CU500v
+Unknown	LG GD510
+Unknown	LG GT360
+Unknown	LG KE590i
+Unknown	LG KF510
+Unknown	LG KP200
+Unknown	LG KU311
+Unknown	LG MG300d
+Unknown	LG S5300
+Unknown	LG-350 MIDP-2.0/CLDC-1.1 Release/31.12.2010 Browser/Opera Sync/SyncClient1.1 Profile/MIDP-2.0 Configuration/CLDC-1.1 Opera/9.80 (MTK; U; pt-BZ) Presto/2.5.28 Version/10.10
+Unknown	LG-A200/V100 Obigo/WAP2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	LG-BL20f Browser/Obigo-Q7.3 MMS/LG-MMS-V1.0/1.2 MediaPlayer/LGPlayer/1.0 Java/ASVM/1.1 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	LG-C1300i UP.Browser/6.2.3 (GUI) MMP/1.0
+Unknown	LG-C3100 AU/4.10 Profile/MIDP-1.0 Configuration/CLDC-1.0
+Unknown	LG-C810/1.0 UP.Browser/4.1.26l
+Unknown	LG-CG300 UP.Browser/6.2.3 (GUI) MMP/1.0
+Unknown	LG-CU6160/1.0 UP.Browser/4.1.26l
+Unknown	LG-CU920/V1.0s Obigo/Q05A Profile/MIDP-2.0 Configuration/CLDC-1.1 Nokia6233/2.0
+Phone	LG-E612 LG-Android-MMS-V2.0/1.2
+Unknown	LG-G1500 AU/4.2
+Unknown	LG-G4010 AU/4.12 UP.Link/1.1
+Unknown	LG-G5310/JM AU/4.10 Profile/MIDP-1.0 Configuration/CLDC-1.0
+Unknown	LG-G850 V100 UP.Browser/6.2.2 (GUI) MMP/1.0 Profile/MIDP-1.0 Configuration/CLDC-1.0
+Unknown	LG-GB230/V100
+Unknown	LG-GC900F/V10d
+Unknown	LG-GD510/V100 Teleca/WAP2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1 UNTRUSTED/1.0 Bluevibe 2.4 r3799 Mozilla/4.0 (compatible; MSIE 6.0; LG-GD510/V100 Teleca/WAP2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1)
+Unknown	LG-GM205Obigo/WAP2.0MIDP-2.0/CLDC-1.1
+Unknown	LG-GM600/V100 Obigo/WAP2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	LG-GR500F/V10a Teleca/Q7.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Phone	LG-GR501/V10d Obigo/Q7.1 Profile/MIDP-2.1 Configuration/CLDC-1.1 UNTRUSTED/1.0 UCWEB/2.0 (Java; U; MIDP-2.0; en-US; LG-GR501) U2/1.0.0 UCBrowser/9.3.0.326 U2/1.0.0 Mobile
+Unknown	LG-GT350i/V100 Obigo/WAP2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	LG-GU220/V100 Obigo/WAP2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	LG-GU290f/V10f Teleca/Q7.0 Profile/MIDP-2.1 Configuration/CLDC-1.1 Novarra-Vision/8.0
+Unknown	LG-GU297/V10d Teleca/Q7.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	LG-GW305/V100 Obigo/WAP2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Phone	LG-GW520/V10a Obigo/WAP2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1 UNTRUSTED/1.0 UCWEB/2.0 (Java; U; MIDP-2.0; en-US; LG-GW520) U2/1.0.0 UCBrowser/9.3.0.326 U2/1.0.0 Mobile
+Unknown	LG-GX300/V100 Obigo/WAP2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	LG-KF245 Obigo/WAP2.0 MIDP-2.0/CLDC-1.1
+Unknown	LG-KF600D OBIGO
+Unknown	LG-KG200j/V01 Obigo/WAP2.0 MIDP-2.0/CLDC-1.1
+Unknown	LG-KG77 MIC/1.1.14 MIDP-2.0/CLDC-1.1
+Phone	LG-KM900/V100 Obigo/WAP2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1 UNTRUSTED/1.0 UCWEB/2.0 (Java; U; MIDP-2.0; en-US; LG-KM900) U2/1.0.0 UCBrowser/9.4.0.342 U2/1.0.0 Mobile
+Unknown	LG-KP265 Obigo/WAP2.0 MIDP-2.0/CLDC-1.1
+Phone	LG-KP502 Teleca/WAP2.0 MIDP-2.0/CLDC-1.1 UNTRUSTED/1.0 UCWEB/2.0 (Java; U; MIDP-2.0; es-LA; LG-KP502 Teleca) U2/1.0.0 UCBrowser/9.3.0.326 U2/1.0.0 Mobile
+Unknown	LG-KS365/V100 Obigo/WAP2.0 Profile/MIDP-2.0/CLDC-1.1
+Unknown	LG-L1150 UP.Browser/6.2.3 (GUI) MMP/1.0 UP.Browser/6.2.3.2 (GUI) MMP/2.0
+Unknown	LG-LG220CTF268435459300686055000000017725198456 UPBROWSER/6238 (GUI) MMP/20
+Unknown	LG-LG410/V10b[TF011804005705266004525013042038847] Teleca/WAP2.0
+Unknown	LG-LG500G/V100[TFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX] Obigo/WAP2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	LG-LG900G/V100[TF012192001015834487725017156907356] Obigo/WAP2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1,gzip(gfe),gzip(gfe),gzip(gfe)
+Unknown	LG-ME500c MIC/WAP2.0 MIDP-2.0/CLDC-1.1
+Unknown	LG-ME770d MIC/1.1.14 MIDP-2.0/CLDC-1.1
+Unknown	LG-MG130 UP.Browser/6.2.3 GUI MMP/1.0
+Unknown	LG-MG230 Obigo/WAP2.0 MIDP-2.0/CLDC-1.1
+Unknown	LG-MG320d MIC/WAP2.0 MIDP-2.0/CLDC-1.1
+Unknown	LG-MU550 Obigo/WAP2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Phone	LG-P970/ Mozilla/5.0 (Linux; U; Android 2.2.2; de-de; Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.0/1.2
+Unknown	LG-S5100 MIC
+Unknown	LG-T325/V100 Obigo/Q7.3 MMS/LG-MMS-V1.1/1.2 MediaPlayer/LGPlayer/1.0 Java/ASVM/1.1 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	LG-W800/1.0 UP.Browser/6.2.3.2 (GUI) MMP/2.0
+Unknown	LG/KC910e/V10c Browser/Obigo-Q7.1 MMS/LG-MMS-V1.0/1.2 MediaPlayer/LGPlayer/1.0 Java/ASVM/1.1 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	LG/KT525/v1.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	LG/U8100
+Unknown	LG285/1.0 UP.Browser/6.2.3.9 (GUI) MMP/2.0
+Unknown	LGE SyncML DM Client/3.0
+Unknown	LGE-AX260/1.0 UP.Browser/6.2.3.8 (GUI) MMP/2.0
+Unknown	LGE-BX4170 UP.Browser/4.1.27
+Unknown	LGE-GW370B Obigo/Q7.3 MMP/2.0
+Unknown	LGE-LG300/1.0 UP.Browser/6.2.3.8 (GUI) MMP/2.0
+Unknown	LGE-LG8700 UP.Browser/6.2.3.2 (GUI) MMP/2.0
+Unknown	LGE-MN180/1.0 UP.Browser/6.2.3.8 (GUI) MMP/2.0
+Unknown	LGE-MX300/1
+Unknown	LGE-PLS225/1.0 UP.Browser/6.2.3.7.e.1.101 (GUI) MMP/2.0
+Unknown	LGE-TM520/1.0 UP.Browser/4.1.22b UP.Link/4.3.4.4d
+Unknown	LGE-VN150/1.0 UP.Browser/6.2.3.2 (GUI) MMP/2.0
+Unknown	LGE-VX6000 UP.Browser/4.1.27
+Unknown	LGECU400 UPLINK
+Phone	LNV-Lenovo A790e_2.3.5_weibo_3.0.5_android
+Phone	Layar/4.0 Android/2.2 (samsung GT-I9010)
+Phone	Lenovo A298t_TD/1.0 Linux/2.6.35.7 Android 2.3.5 Release/04.07.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
+Phone	Lenovo A60+ Linux/2.6.35 Android/2.3.6 Release/05.04.2012 Browser/AppleWebKit533.1 Profile/MIDP-2.0 Configuration/CLDC-1.1 Mobile Safari/533.1
+Unknown	Lenovo G900
+Phone	Lenovo S560/S100 Linux/3.0.13 Android/4.0.3 Release/12.12.2011 Browser/AppleWebKit534.30 Profile/MIDP-2.0 Configuration/CLDC-1.1 Mobile Safari/534.30
+Phone	Lenovo-A269/S001 Linux/3.4.5 Android/2.3.6 Release/06.02.2013 Browser/AppleWebKit533.1 Profile/MIDP-2.0 Configuration/CLDC-1.1 Mobile Safari/533.1 Mozilla/5.0 (Linux; U; Android 2.3.6; )
+Phone	Lenovo-A390t_TD/S100 Release/11.2012 Mozilla/5.0 (Linux; U; Android 4.0.3) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Lenovo-A65/S204 Linux/2.6.35.7 Android/2.3 Release/12.07.2011 Browser/AppleWebKit533.1 Profile/ Configuration/
+Phone	Lenovo-A880/S100 Linux/3.4.5 Android/4.2 Release/08.07.2013 Browser/AppleWebKit 534.30 Profile/ Configuration;
+Unknown	Lenovo-S520/S100 LMP/LML Release/2010.01.25 Profile/MIDP2.0 Configuration/CLDC1.1
+Unknown	Lenovo-i300_VN/S102 LMP/LML Release/2009.08.13 Profile/MIDP2.0 Configuration/CLDC1.1
+Phone	LenovoS868t_TD/1.0 Android 4.0.3 Release/10.01.2012 Browser/WAP2.0 appleWebkit/534.30
+Unknown	Lumia 510
+Tablet	MID7500 Mozilla/5.0 (iPad; CPU OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A405 Safari/7534.48.3
+Unknown	MOT-20.1_/00.62 UP.Browser/6.2.3.4.c.1.120 (GUI) MMP/2.0
+Unknown	MOT-280/00.00.00 MIB/2.2.1 Profile/MIDP-1.0 Configuration/CLDC-1.0
+Unknown	MOT-85/0000 UPBROWSER/4126M737
+Unknown	MOT-A-1F/00.04 UP.Browser/4.1.27a1 UP.Link/5.1.2.12 (Google WAP Proxy/1.0)
+Unknown	MOT-A-3E/00.02 UP.Browser/7.0.2.2.c.1.108 (GUI) MMP/2.0
+Unknown	MOT-A-7D/00.01 UP.Browser/7.0.2.2.c.1.108 (GUI) MMP/2.0
+Unknown	MOT-A-8B/00.00 UP.Browser/7.0.2.2.c.1.109 (GUI) MMP/2.0 UP.Link/5.1.2.17
+Unknown	MOT-A-A7/00.01 UP.Browser/7.2.7.2.542 (GUI) MMP/2.0 Push/PO UP.Link/6.5.1.2.0
+Unknown	MOT-A-B7/00.01 UP.Browser/7.2.7.2.512 (GUI) MMP/2.0 Push/PO
+Unknown	MOT-A-D2/00.01 UP.Browser/7.0.2.2.c.1.126 (GUI) MMP/2.0 UP.Link/5.1.2.17
+Unknown	MOT-A-E2/00.00 UP.Browser/7.2.7.2.iDEN.103 (GUI) MMP/2.0 Push/PO UP.Link/6.6.0.0.0
+Unknown	MOT-A1200w/1.0/"Revolution_Of_The_World_V2
+Unknown	MOT-A668/ WAP.Browser/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.0
+Unknown	MOT-A820/00.00.00 MIB/2.1 Profile/MIDP-1.0 Configuration/CLDC-1.0
+Unknown	MOT-C 390/0BA00FR MIB/221 PROFILE/MIDP-20 CONFIGURATION/CLDC-10
+Unknown	MOT-C357/1.0 UP.Browser 6.2.2.1 (GUI) MMP-2.0 /M4 3.02
+Phone	MOT-CB/0.0.21 UP/4.0.5m (compatible; YOSPACE SmartPhone Emulator Website Edition 1.11)
+Unknown	MOT-CfoneMART L7/08.B7.DCR MIB/2.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	MOT-E 398/0BD223R MIB/221 PROFILE/MIDP-20 CONFIGURATION/CLDC-10
+Computer	MOT-E680i/E680I_G_0D.C0.A1R Mozilla/4.0 (compatible; MSIE 6.0; Linux; Motorola E680i; 935) Profile/MIDP-2.0 Configuration/CLDC-1.1 Opera 7.50 [en]
+Unknown	MOT-E825/03.0F.01. MIB/BER2.2 Profile/MIDP-2.0 Configuration/CLDC-1.0
+Unknown	MOT-EX118 MIDP-2.0/CLDC-1.1 Release/31.12.2010 Browser/Opera Sync/SyncClient1.1 Profile/MIDP-2.0 Configuration/CLDC-1.1 Opera/9.80 (MTK; U) Presto/2.5.28 Version/10.10
+Unknown	MOT-F5/4.1.9 UP.Browser/4.1.23c
+Unknown	MOT-GATW_/00.62 UP.Browser/6.2.3.4.c.1.109 (GUI) MMP/2.0
+Unknown	MOT-K3m/99.40.07R BER2.2 Mozilla/4.0 (compatible; MSIE 6.0; 12003173) Profile/MIDP-2.0 Configuration/CLDC-1.1  Opera 8.00 [de]
+Unknown	MOT-L6w/0A.65.07R MIB/2.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	MOT-L9/08.21.07R MIB/BER2.2 Profile/MIDP-2.0 Configuration/CLDC-1.1 EGE/1.0
+Phone	MOT-ME860/1.0 Mozilla/5.0 Android/2.2.2 Release/6.30.2011 Browser/AppleWebKit/533.1
+Unknown	MOT-MOTO E398@ITUNES
+Computer	MOT-MOTORAZRV8_CMCC/1.0 LinuxOS/2.6.10 Release/06.30.2007 Browser/Opera8.50 Profile/MIDP-2.0 Configuration/CLDC-1.1 Software/R601_G_80.41.1BR
+Computer	MOT-MOTOROKRE6/1.0 LinuxOS/2.4.20 Release/8.4.2006 Browser/Opera8.00 Profile/MIDP2.0 Configuration/CLDC1.1 Software/R533_G_11.10.54R
+Unknown	MOT-MOTOV9/A0.05.20R_03 BER2.2 Mozilla/4.0 (compatible; MSIE 6.0; 13003348) Profile/MIDP-2.0 Configuration/CLDC-1.1  Opera 8.60 [de]
+Phone	MOT-MT680_TD/1.0 Android/2.3 (Linux; Android 2.3) Release/04.13.2012 Browser/WAP 2.0 AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Unknown	MOT-MXE_V6/99.41.08R BER2.2 Mozilla/4.0 (compatible; MSIE 6.0; 12163225) Profile/MIDP-2.0 Configuration/CLDC-1.1 Opera 8.00 [en]
+Unknown	MOT-P2K-C/10.01 UP/4.1.21b UP.Browser/4.1.21b-XXXX
+Unknown	MOT-PEBL U6
+Unknown	MOT-R38.0/00.62 UP.Browser/6.2.3.4.c.1.123 (GUI) MMP/2.0
+Unknown	MOT-R974_/00.72 UP.Browser/7.2.7.5.656 (GUI) MMP/2.0
+Unknown	MOT-RAZRV3xM/85.97.43P MIB/BER2.2 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	MOT-RAZRV3xx/96.4A.20R BER2.2 Mozilla/4.0 (compatible; MSIE 6.0; 2097) Profile/MIDP-2.0 Configuration/CLDC-1.1 Opera 8.00 [en]
+Unknown	MOT-RAZRV6vb/99.41.04ER BER2.2 Mozilla/4.0 (compatible; MSIE 6.0; 12163189) Profile/MIDP-2.0 Configuration/CLDC-1.1 Opera 8.00 [es]
+Unknown	MOT-Slash L7/08.B7.DER MIB/2.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	MOT-T732./11.03 UP.Browser/4.1.25i
+Unknown	MOT-V1075/85.97.C6P MIB/BER2.2 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	MOT-V180/0B.D1.09R MIB/2.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.0
+Unknown	MOT-V188/0B.D2.2BR MIB/2.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.0
+Unknown	MOT-V26X_/00.62 UP.Browser/6.2.3.2 (GUI) MMP/2.0
+Unknown	MOT-V300/0B.08.03I MIB/2.2 Profile/MIDP-2.0 Configuration/CLDC-1.0
+Unknown	MOT-V3b/0E.A4.29R MIB/2.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.0
+Unknown	MOT-V3ie/08.02.05R MIB/2.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	MOT-V3t/0E.C8.0CR MIB/2.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	MOT-V525M/0B.09.1DR MIB/2.2 Profile/MIDP-2.0 Configuration/CLDC-1.0
+Unknown	MOT-V551J/08.18.16R MIB/2.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.0
+Unknown	MOT-V620/08.17.0FR MIB/2.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.0
+Unknown	MOT-V750/1.0 UP.Browser/7.2.6.1.731 (GUI) MMP/2.0
+Unknown	MOT-V975/80.3F.64I MIB/2.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	MOT-VE20/1.0 UP.Browser/7.2.6.1.731 (GUI) MMP/2.0
+Unknown	MOT-W213/0.0.44 UP.Browser/6.3.0.6.c.17 (GUI) MMP/2.0
+Unknown	MOT-W385/1.0 UP.Browser/6.2.3.4.c.1.123 (GUI) MMP/2.0
+Unknown	MOT-W398/0E3048R MIB/221 PROFILE/MIDP-20 CONFIGURATION/CLDC-11
+Unknown	MOT-W419G/[TF359479041653323000000014143392571] Obigo/Q03C MMP/2.0
+Unknown	MOT-WALKMAN E398/0E.30.49R MIB/2.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Computer	MOT-Z6/R60_G_80.xx.yyI Mozilla/4.0 (compatible; MSIE 6.0 Linux; MOTOROKR Z6;nnn) Profile/MIDP-2.0 Configuration/CLDC-1.1 Opera 8.50[yy]
+Unknown	MOT-c 380/0B.D2.2FR MIB/2.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.0
+Unknown	MOT-l7/08.B7.ACR MIB/2.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Phone	MOT-umts_ruth/Eclair Mozilla/5.0 (Linux; U; Android Eclair; en-us Build/CIB3_M3_00.15.0) AppleWebKit/530.17 (KHTML
+Computer	MOTO-W760r/Mozilla/4.0 (compatible;MSIE 6.0;Linux W760r)/R63712_U_71.xx.yyI Profile/MIDP-2.0 Configuration/CLDC-1.1 Symphony 1.0
+Unknown	MOZILLA/SMB3(Z105)/SAMSUNG-NOURLCMP-NOMIME
+Tablet	MOZILLA40 (COMPATIBLE MSIE 60 WINDOWS CE IEMOBILE 612) PPC 240X320 HTC P3450 OPVER 231022741
+Unknown	MOZILLA41 (COMPATIBLE MSIE 50 SYMBIAN OS NOKIA 3650424) OPERA 610 EN
+Unknown	MOZILLA50 (SYMBIANOS92 U SERIES60/31 SAMSUNG/SGH-I458B/
+Unknown	MOZILLA50 (SYMBIANOS93 U SERIES60/32 NOKIA6650D-1C/
+Unknown	MOZILLA50 (SYMBIANOS94 U SERIES60/50 SAMSUNG/I8910-ORANGE/
+Unknown	MQQBrowser/2.0 (Nokia6110LT06.01;SymbianOS/9.1 Series60/3.0)
+Unknown	MQQBrowser/2.2(KQB22_GA;Nokia2700c/09.97)
+Unknown	MQQBrowser/2.7 (Nokia5800iXpressMusic;SymbianOS/9.1 Series60/3.0)
+Phone	MQQBrowser/20 Mozilla/5.0 (Linux; U; Android 1.6; zh-cn; HTC TOUCH DUAL Build/DRC83) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	MQQBrowser/3.5/Mozilla/5.0 (Linux; U; Android 4.0.8; zh-cn; HTC inspire 4G For at&t Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Unknown	MQQBrowser/Mini2.2 (Nokia2220s-b/09.55)
+Unknown	MQQBrowser/Mini2.2 (Nokia3208c/10.50)
+Unknown	MQQBrowser/Mini2.2 (SAMSUNG GT-C3510)
+Unknown	MQQBrowser/Mini2.2 (SAMSUNG S3600)\n
+Unknown	MQQBrowser/Mini2.2 (SAMSUNG-B3210/DSJA1)
+Unknown	MQQBrowser/Mini2.2 (SAMSUNG-GT-B5310/B5310JPJA1)
+Unknown	MQQBrowser/Mini2.2 (SAMSUNG-GT-C3782/C3782XXLE1)
+Unknown	MQQBrowser/Mini2.2 (SAMSUNG-GT-M3710/M3710UMJB2)
+Unknown	MQQBrowser/Mini2.2 (SAMSUNG-GT-S5222)
+Unknown	MQQBrowser/Mini2.2 (SAMSUNG-S3350/UKJL1_KE1)
+Unknown	MQQBrowser/Mini2.2 (SonyEricssonC902/R3DA026)
+Unknown	MQQBrowser/Mini2.2 (SonyEricssonK310i/R4DA044)
+Unknown	MQQBrowser/Mini2.2 (SonyEricssonR300a/R2DA004 TelecaBrowser/Q04C1-1 Profile/MIDP-2.0 Configuration/CLDC-1.1)
+Unknown	MQQBrowser/Mini2.2 (SonyEricssonW205a/R1BA004 Browser/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1)
+Unknown	MQQBrowser/Mini2.2 (SonyEricssonW715/R1GA026)
+Unknown	MQQBrowser/Mini2.2 (SonyEricssonZ550a/R6GA004)
+Unknown	MQQBrowser/Mini2.4 (PantechP7040/JLUS04042011)
+Unknown	MQQBrowser/Mini2.4 (SAMSUNG-S3600i/S3600iXXIL2)
+Unknown	MQQBrowser/Mini2.4 (SonyEricssonU10a/R7AA071)
+Unknown	MQQBrowser/Mini2.4 (SonyEricssonW995a/R1GB003)
+Unknown	MQQBrowser/Mini2.5 (SonyEricssonJ108i/R7DA052)
+Unknown	MQQBrowser/Mini2.6 (SAMSUNG GT-C3212i)\n
+Unknown	MQQBrowser/Mini2.6 (SonyEricssonF305/1207-91)
+Unknown	MQQBrowser/Mini2.6 (SonyEricssonW910i/R1FA035)
+Unknown	MQQBrowser/Mini2.7 (NokiaE62-1/0618.06.17)
+Unknown	MQQBrowser/Mini2.7 (SonyEricssonWT13i/R3AF010)
+Unknown	MQQBrowser/Mini2.8 (SAMSUNG-GT-S3650W/S3650WXEIL5)
+Unknown	MQQBrowser/Mini2.8 (SAMSUNG-SGH-A657/A657UCIB5)
+Unknown	MQQBrowser/Mini2.8 (SonyEricssonJ105a/R1HA035)
+Unknown	MQQBrowser/Mini2.8 (SonyEricssonW810i/R4DB004)
+Unknown	MQQBrowser/Mini3.1 (SAMSUNG-GT-S3650C/S3650CZCII6)
+Tablet	MobileKeeper/BASIC/1033/ms_wm6professional/01.06.2718.0001 WindowsMobile6/Windows Mobile 6 Professional/HTC/HTC Kaiser Touch/5.2.23519.3
+Phone	MobilePlugin (Linux; U; Android 4.1.2; samsung goldennfcxx; JZO54K.I8190NXXAMG1)
+Phone	MobilePlugin (Linux; U; Android 4.2.2; samsung serranoltexx; JDQ39.I9195XXUBMJ7)
+Phone	MobileRTM/3.0.16 (Android, HTC Wildfire/2.2.1) SyncProto/5
+Unknown	Motorola-C290 Obigo/Q04C1-1.9 MMP/2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	Motorola-V950 Obigo/Q05A1 MMP/2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	Motorola-w385 Obigo/Q04C1 MMP/2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Phone	Mozilla 5.0 (Linux; U; Android 2.2.1; zh-cn; 3GC101 Build FRG83) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 2.2.2; zh-cn; Coolpad 5820 Build FRG83G) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 2.2.2; zh-cn; HUAWEI T8300 Build FRF91) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 2.2.2; zh-cn; ME811 Build SHDWR_X6_2.200.33) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 2.3.1; zh-cn; Newpad-K97) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 2.3.4; zh-cn; GT-S5838 Build GINGERBREAD) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 2.3.4; zh-cn; XT882 Build SWDFS_M7_4.80.0) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 2.3.5; zh-cn; Lenovo A288t Build MocorDroid2.3.5) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 2.3.5; zh-cn; XT319 Build V4.50A) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 2.3.6; zh-cn; GN100T Build GRK39F) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 2.3.6; zh-cn; HUAWEI C8860E Build HuaweiC8860E) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 2.3.6; zh-cn; Lenovo A690 Build GRK39F) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 2.3.6; zh-cn; XT928 Build 6.5.1_GC-122-DNRCG-15) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 2.3.7; zh-cn; ZTE U960s2 Build GWK74) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 4.0.3; zh-cn; HTC T328t Build IML74K) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 4.0.3; zh-cn; M030 Build IML74K) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 4.0.3; zh-cn; ZTE U930HD Build IML74K) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 4.0.4; zh-cn; HS-EG906 Build IMM76D) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 4.0.4; zh-cn; Lenovo S720 Build IMM76D) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 4.0.4; zh-cn; ZTE U795 Build IMM76D) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 4.0.9; zh-cn; HTC EVO 4G+ Build HTC EVO 4G+) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 4.1.1; zh-cn; HUAWEI G510-0010 Build HuaweiG510-0010) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Phone	Mozilla 5.0 (Linux; U; Android 4.2.1; zh-cn; Lenovo S920 Build JOP40D) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
+Unknown	Mozilla 5.0 (Symbian/3; Series60/5.2 NokiaN8-00/00.0.000; Profile/MIDP-2.1 Configuration/CLDC-1.1) AppleWebkit/525 (KHTML, like Gecko) Version/3 BrowserNG/7.3.1.8 3gpp-gba,gzip(gfe),gzip(gfe),gzip(gfe)
+Phone	Mozilla.5.0 (Linux; U; Android 2.3.6; de-de; GT-I8160P Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Unknown	Mozilla/2.0 (compatible; Go.Web/6.5; HandHTTP 1.1; Elaine/1.0; RIM957 )
+Phone	Mozilla/24.0 (iPhone; U; CPU like Mac OS X; de-de)
+Unknown	Mozilla/4.0 (BREW 3.1.5; U; en-us; Samsung; PLS_M330; POLARIS/6.1/WAP) MMP/2.0 Configuration/CLDC-1.1
+Unknown	Mozilla/4.0 (BREW 3.1.5; U; en-us; Sanyo; Polaris/6.0/AMB) Sprint SCP-2700
+Unknown	Mozilla/4.0 (Brew MP 1.0.2; U; en-us; Sanyo; NetFront/3.5.1/AMB) Sprint SCP-3820
+Tablet	Mozilla/4.0 (Compatible; MSIE 6.0; Windows CE; IEMobile 6.12)ASUS-P526/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Phone	Mozilla/4.0 (MobilePhone; NetFront/4.1; like Gecko) USCC-E4277 1.001UC
+Console	Mozilla/4.0 (PSP (PlayStation Portable); 2.00)
+Unknown	Mozilla/4.0 (Vodafone/1.0/LG-KF310/V09c Browser/Obigo-Q05A/3.12 MMS/LG-MMS-V1.0/1.2 MediaPlayer/LGPlayer/1.0 Java/ASVM/1.1 Profile/MIDP-2.0 Configuration/CLDC-1.1)
+Tablet	Mozilla/4.0 (compatible MSIE 6.0 Windows CE IEMobile 7.11) ASUS-GalaxyMini/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Phone	Mozilla/4.0 (compatible: MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; SAMSUNG; SGH-i917)
+Computer	Mozilla/4.0 (compatible; MSIE 4.01; Windows CE; HTC/X01HT; PPC; 240x320)
+Computer	Mozilla/4.0 (compatible; MSIE 4.01; Windows CE; PPC i-mate JAMAQ; 240x320)/UC Browser7.8.0.95
+Computer	Mozilla/4.0 (compatible; MSIE 4.01; Windows CE; PPC; 240x240; HPiPAQhw6900/1.0)
+Computer	Mozilla/4.0 (compatible; MSIE 4.01; Windows CE; Sprint:PPC6600-1; PPC; 240x320)
+Computer	Mozilla/4.0 (compatible; MSIE 4.01; Windows CE; i-mate JASJAR PPC; 640x480)/UC Browser7.4.0.65
+Unknown	Mozilla/4.0 (compatible; MSIE 4.0; ) Opera/UC Browser7.8.0.95/69/351, SAMSUNG-GT-C3222/C3222DDJL3 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.102 (GUI) MMP/2.0 Untrusted/1.0
+Unknown	Mozilla/4.0 (compatible; MSIE 5.0; S60/3.0 NokiaN73-1/2.0 (2.0622.0.0.7) Profile/MIDP-2.0 Configuration/CLDC-1.1)
+Unknown	Mozilla/4.0 (compatible; MSIE 5.0; Series80/2.0 Nokia9300i Profile/MIDP-2.0 Configuration/CLDC-1.1)
+Computer	Mozilla/4.0 (compatible; MSIE 6.0; Linux; Motorola A910; 781) MOT-A910/R57_G_10.06.2FI Profile/MIDP-2.0 Configuration/CLDC-1.1 Opera 8.50 [en]
+Computer	Mozilla/4.0 (compatible; MSIE 6.0; Linux; Motorola E895; 1447) MOT-E895/EZXBASE_N_00.39.A4I Profile/MIDP-2.0 Configuration/CLDC-1.1 Opera 8.00 [en]
+Unknown	Mozilla/4.0 (compatible; MSIE 6.0; Nokia7650) ReqwirelessWeb/2.0.0.0
+Unknown	Mozilla/4.0 (compatible; MSIE 6.0; Symbian OS; 246) Opera 8.60 [zh-CN]SonyEricssonM600c/R100
+Unknown	Mozilla/4.0 (compatible; MSIE 6.0; Symbian OS; Nokia 6260/3.0436.0; 9399) Opera 8.65 [en]
+Unknown	Mozilla/4.0 (compatible; MSIE 6.0; Symbian OS; Nokia E63 /6.03.08; 9399) Opera 8.65 [en]
+Computer	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; HTC-P5310 BM ) Opera 8.65 [en]
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 6.12) ASUS-P735/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 6.12) PPC; 240x320; HTC P3450; OpVer 23.102.2.741
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 6.12) SAMSUNG-SGH-i600V/1.0
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 6.12) Sprint:PPC6800
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 6.12) Vodafone/1.0/HTC_VPACompactIV/4.14.162.2
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 6.8) HTC-8500/1.2
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 6.8) Vodafone/1.0/HTC_v1510/1.23.162.2
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11) 320x240; VZW; Motorola-A4500; Windows Mobile 6.1 Standard
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11) ASUSP750/1.0
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11) Alltel HTC Touch Pro
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11) PPC; 240x320; HTC_Touch_3G_T3232-Orange; OpVer 33.171.1.6116
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11) PPC; 480x800; HTC_Touch_HD_T8282; OpVer 34.119.1.611
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11) Smartphone; 240x320; HTC S740; OpVer 0.710.0.000
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11) Sprint Treo850e
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11) USCCHTC6850
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11) Vodafone/1.0/HTC_Jade/1.40.164.2 (21259)
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11) Vodafone/1.0/HTC_Touch_3G_T3232/1.47.162.1 (42448)
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.6) HTC-6900
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.6) Samsung-SPHI325 320x240
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) 320X320 Palm Treo850e
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) HTC_HD2_T8585/480x800,gzip(gfe),gzip(gfe),gzip(gfe)
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) PPC; 240x320; HTC_Mega-T3333-Orange; OpVer 113.128.10.702
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) SAMSUNG-SCH-i220
+Tablet	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) USCCHTC6175
+Computer	Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; PPC; 240x320; HTC_P3650)
+Phone	Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; Windows Phone 6.5; SonyEricssonM1i/R1BA; Profile/MIDP-2.1; Configuration/CLDC-1.1; Windows Phone 6.5.3.5)
+Phone	Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile 7.0; HTC; HD7 T9292)
+Phone	Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0) HTC;Windows Phone 8X by HTC
+Phone	Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0) Microsoft Corporation;XDeviceEmulator
+Phone	Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0;  ; LEO70)
+Phone	Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; HTC; 7 Mozart T8698)
+Phone	Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; HTC; HD7)
+Phone	Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; HTC; Schubert)
+Phone	Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; HTC; mwp6985)
+Phone	Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; NOKIA; 909)
+Phone	Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; TOSHIBA; TSUNAGI)
+Phone	Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.5; Trident/3.1; IEMobile/7.0; Xbox)
+Unknown	Mozilla/4.0 (compatible; Nokia Podcasting; SymbianOS; NokiaN97-4/11.0.102)
+Unknown	Mozilla/4.0 (compatible; Polaris 6.2; Brew 3.1.5; en)/240X320 Samsung sam-r631
+Tablet	Mozilla/4.0 LG-GM750h Browser/IE8.12 MMS/LGMMSv1.0/1.2 Java/LGVM/1.1 Profile/MIDP-2.1 Configuration/CLDC-1.1 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0)
+Unknown	Mozilla/4.0 SonyEricssonC902v/
+Unknown	Mozilla/4.0 SonyEricssonW595v/R3DA
+Unknown	Mozilla/4.0 SonyEricssonW902v/R3EE Browser/NetFront/3.4 Profile/MIDP-2.1 Configuration/CLDC-1.1 JavaPlatform/JP-8.3.3
+Unknown	Mozilla/4.0(compatible;Polaris 6.2;Brew 3.1.5;U;en)/400x240 Samsung SCH-U820
+Unknown	Mozilla/4.08 (PDA; PalmOS/sony/model atom/Revision:2.0.22 (en)) NetFront/3.1
+Unknown	Mozilla/4.1 (compatible; MSIE 5.0; Symbian OS; Nokia 3650;424) Opera 6.10 [en]
+Unknown	Mozilla/4.1 (compatible; Teleca Q7; BMP 1.0.1; U; en) 240X400 LGE UN510 Novarra-Vision/8.0
+Unknown	Mozilla/5.0 ( Nokia5330XpressMusic/2.0 (p) Profile/MIDP-2.1 Configuration/CLDC-1.1) AppleWebKit/420+ (KHTML, like Gecko) Safari/420+
+Unknown	Mozilla/5.0 ( Nokia7510Supernova/2.0 (03.80) Profile/MIDP-2.1 Configuration/CLDC-1.1) AppleWebKit/420 (KHTML, like Gecko) Safari/420
+Phone	Mozilla/5.0 (;;; en-us; Huawei-U8651S Build/U8651SV100R001USAC85B843) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+TV	Mozilla/5.0 (;;;) AppleWebKit/534.6 HbbTV/1.1.1 (+DL+PVR; smart; ZAPPIX HD+; 1.0; 1.0;)  CE-HTML/1.0
+Phone	Mozilla/5.0 (Android 2.3.3; de-de; GT-I9001 Build/GINGERBREAD) FreeWheelAdManager/5.8.0-r10172-1308191214;com.vevo/504
+Phone	Mozilla/5.0 (Android 4.1.1; de-de; C1505 Build/11.3.A.2.23) FreeWheelAdManager/5.8.0-r10172-1308191214;com.vevo/504
+Phone	Mozilla/5.0 (Android 4.2.2; de-de; GT-P5200 Build/JDQ39) FreeWheelAdManager/5.8.0-r10172-1308191214;com.dni.vod.dmax.de/10242
+Phone	Mozilla/5.0 (Android; (OS 4.0.3) (IM 1,133MB) (EM 3,872MB) (Build IML74K) (Model HTC Sensation Z710e)  (Brand vodafone_de)) WW_Mobile_Android/2.4.0.019
+Phone	Mozilla/5.0 (Android; Mobile: HTC6500LVW; rv:20.0) Gecko/20.0 Firefox/20.0
+Phone	Mozilla/5.0 (Android; U; Android 2.3.6; zh-cn; GT-S5300; 240*320) AppleWebKit/528.5 (KHTML, like Gecko) UCBrowser/8.0.0.202/139/352 Mobile
+Phone	Mozilla/5.0 (BB10; Kbd) AppleWebKit/537.10 (KHTML, like Gecko) Version/10.1.0.1471 Mobile Safari/537.10
+Unknown	Mozilla/5.0 (BREW; U; 3.1.5; en) AppleWebKit/528.28 (KHTML, like Gecko) OBIGO/W10.1 Safari/528.5 480X800 LGE VX11000
+Phone	Mozilla/5.0 (BlackBerry; U; BlackBerry 9310; en) AppleWebKit/534.11 (KHTML, like Gecko) Version/7.1.0.477 Mobile Safari/534.11
+Phone	Mozilla/5.0 (BlackBerry; U; BlackBerry 9350; en) AppleWebKit/534.1 (KHTML, Like Gecko) Version/7.0.0.0 Mobile Safari/534.1
+Phone	Mozilla/5.0 (BlackBerry; U; BlackBerry 9850; de) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.580 Mobile Safari/534.11+
+TV	Mozilla/5.0 (DTV) NetFront/3.4 InettvBrowser/2.2 (08001F;DTV03VSFC;0002;0001)
+TV	Mozilla/5.0 (DTV; TSBNetTV/T35013A0C.0203.ADD; TVwithVideoPlayer; like Gecko) NetFront/4.1 DTVNetBrowser/2.2 (000039;T35013A0C;0203;ADD) InettvBrowser/2.2 (000039;T35013A0C;0203;ADD) YahooDTV/2.0 (Video=0x03;Audio=0x01;Screen=0x01;Device=0x00;Remote=0x10)
+TV	Mozilla/5.0 (DirectFB; Linux 35230) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/4.1.4(+mouse+3D+PORTAL_KEY+SCREEN+TUNER; LGE; GLOBAL-PLAT3; 09.00.00; 0x00000001;); LG NetCast.TV-2011
+TV	Mozilla/5.0 (DirectFB; U; Linux armv5tejl; c) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ HbbTV/1.1.1 (;RT-RK;TV;1.0;1.0;),gzip(gfe),gzip(gfe),gzip(gfe)
+Unknown	Mozilla/5.0 (F09C;FOMA;like Gecko),gzip(gfe),gzip(gfe),gzip(gfe)
+Phone	Mozilla/5.0 (HTC One S HTC; NetatmoApp/v1.1.3.22 Android 4.1.1) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3
+Phone	Mozilla/5.0 (Java; U; En-us; Samsung-gt-m8910) UCBrowser8.3.0.154/70/352/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; Id; lg-a230) UCBrowser8.3.0.154/69/352/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; Id; lg-kf510 obigo) UCBrowser8.4.0.159/70/352/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; Id; lg-t310i) UCBrowser8.3.0.154/69/444/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; Id; samsung gt-s3600i) UCBrowser8.3.0.154/69/444/UCWEB Mobile, SAMSUNG-GT-S3600i/S3600iJPIL1 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.102 (GUI) MMP/2.0 Untrusted/1.0
+Phone	Mozilla/5.0 (Java; U; Id; samsung-gt-s3650) UCBrowser8.2.0.132/69/452/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; Pt-br; aplix jblend) UCBrowser8.3.0.154/69/444/UCWEB Mobile, MOT-A3100/1.0 Release/09.09.2008 Profile/MIDP-2.0 Configuration/CLDC-1.1 Software/WM6.1 UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; Pt-br; htc touch diamond p3700) UCBrowser8.4.0.159/69/444/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; Pt-br; lg-gb230) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.5.0.185/82/352/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; Pt-br; lg-gs390) UCBrowser8.2.1.144/69/444/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; Pt-br; lg-kd876) UCBrowser8.2.1.144/69/352/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; Pt-br; lg-p525) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.5.0.185/82/352/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; Pt-br; samsung gt-b5722) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.5.0.185/82/352/UCWEB Mobile
+Phone	Mozilla/5.0 (Java; U; Pt-br; samsung gt-c3510) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.5.0.185/82/352/UCWEB Mobile, SAMSUNG-GT-C3510/C3510XXJI1 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.102 (GUI) MMP/2.0 Untrusted/1.0
+Phone	Mozilla/5.0 (Java; U; Pt-br; samsung m2710) UCBrowser8.2.1.144/69/352/UCWEB Mobile
+Phone	Mozilla/5.0 (Java; U; Pt-br; samsung-gt-b6520) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.5.0.185/82/405/UCWEB Mobile, SAMSUNG-GT-B6520/1.0 Mozilla/4.0 UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; Pt-br; samsung-gt-m5650) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.6.0.199/70/352/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; Pt-br; samsung-gt-s3572) UCBrowser8.3.0.154/69/352/UCWEB Mobile, SAMSUNG-GT-S3572/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 Untrusted/1.0
+Phone	Mozilla/5.0 (Java; U; Pt-br; samsung-gt-s5750e) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.5.0.185/83/352/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; Pt-br; samsung-sgh-i900) UCBrowser8.2.0.132/69/452/UCWEB Mobile, SAMSUNG-SGH-i900/1.0 UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; en-id; samsung gt-c3303i) UCBrowser8.2.1.144/69/444/UCWEB Mobile
+Phone	Mozilla/5.0 (Java; U; en-in; gt-s5270k) UCBrowser8.3.0.154/69/444/UCWEB Mobile, SAMSUNG-GT-S5270K/S5270KDDKH3 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.102 (GUI) MMP/2.0 Untrusted/1.0
+Phone	Mozilla/5.0 (Java; U; en-in; lg-gu220) UCBrowser8.2.0.132/69/352/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; en-in; samsung-gt-b2710d) UCBrowser8.4.0.159/69/352/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; en-in; samsung-gt-s8530) UCBrowser8.2.1.144/70/352/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; en-us; UCBrowser8.2.1.144/70/444/UCWEB Mobile SonyEricssonG700/R100 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Phone	Mozilla/5.0 (Java; U; en-us; htc star trek) UCBrowser8.3.0.154/69/352/UCWEB Mobile
+Phone	Mozilla/5.0 (Java; U; en-us; lg-c395) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.5.0.185/83/352/UCWEB Mobile
+Phone	Mozilla/5.0 (Java; U; en-us; lg-lg420g[tf012125009345399008080015075895332] obigo) UCBrowser8.3.0.154/70/352/UCWEB Mobile
+Phone	Mozilla/5.0 (Java; U; en-us; samsung gt-b3410r) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.6.0.199/84/352/UCWEB Mobile, SAMSUNG-GT-B3410R/B3410UXJC4 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.102 (GUI) MMP/2.0 Untrusted/1.0
+Phone	Mozilla/5.0 (Java; U; en-us; samsung sgh-d980) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.5.0.185/82/352/UCWEB Mobile
+Phone	Mozilla/5.0 (Java; U; en-us; samsung-gt-c3262) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.6.0.199/69/444/UCWEB Mobile, SAMSUNG-GT-C3262/C3262DDLHA Profile/MIDP-2.0 Configuration/CLDC-1.1 Untrusted/1.0
+Phone	Mozilla/5.0 (Java; U; en-us; samsung-gt-s5780) UCBrowser8.3.0.154/69/352/UCWEB Mobile UNTRUSTED/1.0 UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; en-us; samsung-sgh-i637) UCBrowser8.3.0.154/69/444/UCWEB Mobile, SAMSUNG-SGH-I637/1.0 Profile/MIDP-2.1 Configuration/CLDC-1.1 Mozilla/4.0 UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; es-la; gt-s5270y) UCBrowser8.3.0.154/69/444/UCWEB Mobile,SAMSUNG-GT-S5270Y/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.102 (GUI) MMP/2.0 Untrusted/1.0
+Phone	Mozilla/5.0 (Java; U; es-la; lg-gs505) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.6.0.199/70/352/UCWEB Mobile
+Phone	Mozilla/5.0 (Java; U; es-la; samsung-gt-b2710) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.5.0.185/84/352/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; es-la; samsung-sgh-f400) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.6.0.199/84/352/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; ru; lg-gb270) UCBrowser8.3.0.154/69/352/UCWEB Mobile UNTRUSTED/1.0
+Phone	Mozilla/5.0 (Java; U; ru; samsung-gt-s5510) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.6.0.199/84/352/UCWEB Mobile UN
+Phone	Mozilla/5.0 (L/5.0 (Linux; U; Android 4.1.2; de-de; GT-N8010 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Unknown	Mozilla/5.0 (LG-GD880-Orange/V09d AppleWebKit/531 MMS/LG-MMS-V1.0/1.2 MediaPlayer/LGPlayer/1.0 Java/ASVM/1.1 Profile/MIDP-2.1 Configuration/CLDC-1.1)
+Unknown	Mozilla/5.0 (LG-T565b AppleWebkit/531 Browser/Phantom/V2.0 Widget/LGMW/3.0 MMS/LG-MMS-V1.0/1.2 Java/ASVM/1.1 Profile/MIDP-2.1 Configuration/CLDC-1.1)
+Phone	Mozilla/5.0 (Linux U Android 1.5 en-gb T-Mobile G2 Touch Build/CUPCAKE) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2
+Phone	Mozilla/5.0 (Linux U; Android 4.0; xx-xx; LG-P714 Build/IML74K) AppleWebKit/534.30 (KHTML like Gecko) Version/4.0 Mobile Safari/534.30 UNTRUSTED/1.0
+TV	Mozilla/5.0 (Linux mipsel; U; HbbTV/1.1.1 (; TOSHIBA; DTV_RL838; 55.4.02.0; t12; ) ; ToshibaTP/1.3.0 (+VIDEO_MP4+VIDEO_X_MS_ASF+AUDIO_MPEG+AUDIO_MP4+DRM) ; pl) AppleWebKit/534.1 (KHTML, like Gecko)
+TV	Mozilla/5.0 (Linux mipsel; U; HbbTV/1.1.1 (; TOSHIBA; DTV_VL963; 64.4.08.7; t12; ) ; ToshibaTP/1.3.0 (+VIDEO_MP4+VIDEO_X_MS_ASF+AUDIO_MPEG+AUDIO_MP4+DRM+3D+NATIVELAUNCH+OFFLINEAPP+WEBSTORAGE) ; pl) AppleWebKit/534.1 (KHTML, like Gecko)
+Phone	Mozilla/5.0 (Linux: U: Android 2.2.1: it-it: Vodafone 858 Build/Vodafone858C02B617) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1;225419377
+Phone	Mozilla/5.0 (Linux; Android 11) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/87.0.4280.141 Mobile DuckDuckGo/5 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 2.2.1; en-US; PantechP8000 Build/XG2) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 2.2.2; zh-TW; SH8118U Build/HK9) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 2.3.1; PMP3384BRU Build/GINGERBREAD) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31 OPR/14.0.1074.57768
+Phone	Mozilla/5.0 (Linux; Android 2.3.3; DROID Pro Build/4.5.1-110-VNS-22) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57768
+Phone	Mozilla/5.0 (Linux; Android 2.3.3; HTC Desire S Build/GRI40) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.3; MID8127 Build/GRI40) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31 OPR/14.0.1074.58201
+Phone	Mozilla/5.0 (Linux; Android 2.3.3; S300) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22 OPR/14.0.1025.53005
+Phone	Mozilla/5.0 (Linux; Android 2.3.3; SGH-T959D Build/GINGERBREAD) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.40 Mobile Safari/537.31 OPR/14.0.1074.54070
+Tablet	Mozilla/5.0 (Linux; Android 2.3.3; en-GB; m801 Build/HCL ME Tablet X1) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 2.3.4; Axioo-VIGO410 Build/GRJ22) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.4; Fly IQ285 Turbo Build/GINGERBREAD) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.4; HTC Acquire Build/GRJ22) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57768
+Phone	Mozilla/5.0 (Linux; Android 2.3.4; IM-A725L Build/GINGERBREAD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36 OPR/16.0.1212.64336
+Phone	Mozilla/5.0 (Linux; Android 2.3.4; LG-C729 Build/GRJ22) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22 OPR/14.0.1025.53463
+Phone	Mozilla/5.0 (Linux; Android 2.3.4; LG-P690f Build/GRJ22) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.4; LT15i Build/4.0.2.A.0.69) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.4; MT11i Build/4.0.2.A.0.69) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22 OPR/14.0.1025.53463
+Phone	Mozilla/5.0 (Linux; Android 2.3.4; PantechP9060 Build/GINGERBREAD) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22 OPR/14.0.1025.52315
+Phone	Mozilla/5.0 (Linux; Android 2.3.4; ST15i Build/4.0.2.A.0.84) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.4; XT860 Build/5.5.1-112_SLU-79) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57768
+Phone	Mozilla/5.0 (Linux; Android 2.3.4; en-US; X315e Build/GRJ22) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 2.3.5; BASE Tab 7.1 Build/GINGERBREAD) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.5; DROIDZ Force Build/MocorDroid2.3.5) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.58201
+Phone	Mozilla/5.0 (Linux; Android 2.3.5; GS01 Build/GRJ90) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.5; GT-N7000 Build/GINGERBREAD) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.5; HTC Rhyme S510b Build/GRJ90) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.5; HUAWEI-U9000 Build/GRJ90) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.5; ISW11K Build/145.0.0002) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.5; MITO_A78 Build/GINGERBREAD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36 OPR/16.0.1212.64336
+Phone	Mozilla/5.0 (Linux; Android 2.3.5; NEC-101T Build/112550120101) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57768
+Phone	Mozilla/5.0 (Linux; Android 2.3.5; Philips W632 Build/GRJ90) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.40 Mobile Safari/537.31 OPR/14.0.1074.54070
+Phone	Mozilla/5.0 (Linux; Android 2.3.5; San Francisco II Build/OUK_B03) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.40 Mobile Safari/537.31 OPR/14.0.1074.54070
+Phone	Mozilla/5.0 (Linux; Android 2.3.5; U8600 Build/HuaweiU8600) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.5; ZTE-N910 Build/GRJ90) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.5; en-US; TCL_A919 Build/GRJ90) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; A2_Classic Build/GRK39F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36 OPR/16.0.1212.63537
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; A95 Build/CelkonCelkon_A95) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.40 Mobile Safari/537.31 OPR/14.0.1074.54070
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; ALCATEL_one_touch_995 Build/GINGERBREAD) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.40 Mobile Safari/537.31 OPR/14.0.1074.54070
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; Aqua Star Build/MocorDroid2.3.5) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; En-US; SCH-W999 Build/GRK39F) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; Fly IQ245Plus Build/GRK39F) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; Huawei-U8665 Build/HuaweiU8665B037) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.40 Mobile Safari/537.31 OPR/14.0.1074.54070
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; Intex Aqua Marvel Build/GRK39F) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.40 Mobile Safari/537.31 OPR/14.0.1074.54070
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; Karbonn A2 Build/GRK39F) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22 OPR/14.0.1025.52315
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; LG-L38C Build/GRK39F) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22 OPR/14.0.1025.53463
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; LG-VS410PP Build/GRK39F) AppleWebKit/537.36 (KHTML, Like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36 OPR/16.0.1212.64336
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; MB611 Build/4.5.1-149-BGN-2.0-87) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22 OPR/14.0.1025.53005
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; MSD7 Build/GRK39F) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.40 Mobile Safari/537.31 OPR/14.0.1074.54070
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; ONE TOUCH 4007X Build/GRK39F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.63 Mobile Safari/537.36 OPR/15.0.1162.60140
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; SAMSUNG-SGH-I577 Build/GINGERBREAD) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57768
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; Spice Mi-355 Build/GRK39F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36 OPR/16.0.1212.63537
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; TECNO_B3 Build/TECNO_B3) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.40 Mobile Safari/537.31 OPR/14.0.1074.54070
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; Videocon A15 Build/GRK39F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36 OPR/16.0.1212.64336
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; XT303 Build/07.17.03R_S) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.40 Mobile Safari/537.31 OPR/14.0.1074.54070
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; XT610 Build/4.5.2-51_V2L-28_R01) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.40 Mobile Safari/537.31 OPR/14.0.1074.54070
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; YP-GS1 Build/GINGERBREAD) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57768
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; en-IE; TOOKY A81 Build/GRK39F) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; en-US; HUAWEI U8661 Build/GRK39F) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 2.3.6; i-mobile i-style 3 Build/GRK39F) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22 OPR/14.0.1025.52315
+Phone	Mozilla/5.0 (Linux; Android 2.3.7; A19 Build/REL_2.3.12) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.7; MB520 Build/GWK74) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57768
+Phone	Mozilla/5.0 (Linux; Android 2.3.7; ST25i Build/6.0.B.3.184) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 2.3.7; XT556 Build/V1.58R) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57768
+Phone	Mozilla/5.0 (Linux; Android 2.3.7; en-US; ZTE U880s Build/GWK74) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 3.1; HTC PG09410 Build/HMJ15) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31 OPR/14.0.1074.58201
+Phone	Mozilla/5.0 (Linux; Android 3.1; MZ505 Build/Moto_MZ505) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31 OPR/14.0.1074.58201
+Phone	Mozilla/5.0 (Linux; Android 3.2.1; ARCHOS 70it2 Build/HTK75D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31 OPR/14.0.1074.57768
+Phone	Mozilla/5.0 (Linux; Android 3.2.1; HTC Flyer Build/HTK75C) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31 OPR/14.0.1074.57768
+Phone	Mozilla/5.0 (Linux; Android 3.2.1; LG-LU8300 Build/HTK75D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Safari/537.36 OPR/16.0.1212.64462
+Phone	Mozilla/5.0 (Linux; Android 3.2.1; YPY_10FTA Build/HTK75D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31 OPR/14.0.1074.58201
+Phone	Mozilla/5.0 (Linux; Android 3.2; GT-P6200 Build/HTJ85B) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 3.2; SGH-T859 Build/HTJ85B) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Safari/537.22 OPR/14.0.1025.53463
+Phone	Mozilla/5.0 (Linux; Android 4.0.1; Galaxy Nexus Build/ITL41F) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.0.3 FROZN by jcarrz1; Transformer TF101 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3;  cm_tenderloin Build/GWK74) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133  Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; A500 Build/IML74K) AppleWebKit/535.19 (KHTML
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; ADR6425LVW Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19 [UsableNet Lift Mobile]
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; ALCATEL one touch 986+ Build/C986-2SALCN1) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; AN10DG3 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; AN7FG3 Build/IML74K) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; AQUILA 080-1008 Build/ICS.g12refM805CMX.20120925) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.63 Safari/537.36 OPR/15.0.1162.61647
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; ARCHOS 97 XENON Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; ASUS Transformer Pad TF300T Build/IML74K) AppleWebKit/535.19 (KHTML
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; AT-AS43D2 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; Airpad-DS101M Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; AllviewSpeedi Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; Blueron TouchPad10 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; CJ-ThL V11 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; CnM-TOUCHPAD 7 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; DROID RAZR Build/6.7.1-42_DHD-15_M4-3) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; En-US; HTC S720t Build/IML74K) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; Explay Surfer 7.02 Build/ICS.g12refM703A1HZ1.20121009) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; F-11D Build/404030i_QCIR36B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; GFIVE Bravo Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36 OPR/20.0.1396.73172
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; GOCLEVER TAB T76 Build/MID) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; GT-I9100M Build/IML74K) AppleWebKit/535.19 (KHTML
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; GT-P3100 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; H6000 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; HTC Desire U dual sim Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; HTC EVA_UL Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; HTC Holiday Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; HTC One XL Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; HTC Pyramid Build/MIUI) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; HTC S720e Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; HTC Sensation XE with Beats Audio Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; HTC VLE_U Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; HTC Z710t Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; HTCEVODesign4G Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; HUAWEI Ascend G 300 Build/HuaweiU8815) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; HUAWEI U8666E Build/HuaweiU8666E) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; HUAWEI U8815N Build/HuaweiU8815NC02B943) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; IM-A830S Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; ISW13F Build/V51R37G) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; IdeaTabS2110AF Build/IML74K) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; Informer-702 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Sa
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; KM-S330 Build/IML74K) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Mobile Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; LG-E612f Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; LG-F160S Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; LG-P705f Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; LIFETAB_P9514 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; LT7052 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; Lenovo A750 ICS Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; M-MP917I Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; ME171 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; MID9042 Build/IML74K) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; MOMO15 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; MP1047 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; Maxwell Lite Build/1.0.2.20121120-17:05) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; N800 Build/MocorDroid2.3.5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.45 Mobile Safari/537.36 OPR/15.0.1162.59192
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; Next10P12 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; Nexus S Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; OnePAD 1100 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; PAPYRE Pad 712 Build/IML74K) AppleWebKit/537.36 (KHTML, Like Gecko) Chrome/29.0.1547.59 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; PLAYTAB Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; PMP3270B Build/IML74K) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; PantechP8010 Build/Flex Ice) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Tablet	Mozilla/5.0 (Linux; Android 4.0.3; Polaroid Tablet Build/IML74K) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; SAMSUNG-SGH-I717 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; SCH-I510 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; SGH-T989D Build/IML74K) AppleWebKit/535.19 (KHTML
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; SHV-E120L Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; SP-120 Build/IML74K) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.58201
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; STM726HN Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; Sensation XL with Beats Audio Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; SmartTabII10 Build/IML74K) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; T-01D Build/V09R40A) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; TAB-PLAYTABPRO(4R) Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; TAB-PROTAB2.4 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; TAB224 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; TM-7023 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; TOOKY T83 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; TREQ A10C Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; ThL W1 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; U18GT Build/IML74K) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; V700B Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; ViewPad97A Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
+Tablet	Mozilla/5.0 (Linux; Android 4.0.3; Woxter Tablet PC 75CXi Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; X9017 Build/IML74K) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; ZTE Grand X Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; ar-tn; SAMSUNG SM-N9005 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; en-US; HUAWEI C8812 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; i-mobile i-note WiFi Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; iBall Slide 3G 7307 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3; novo7_ELF Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.3;+ HTC One V Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4;  MALATA I8 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; 201HW Build/HuaweiU9201L) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; A111 Build/IMM76I) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; A5Classic Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; A90S Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; ALCATEL ONE TOUCH 5035D Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; ALCATEL ONE TOUCH 993D Build/ICECREAM) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; AMOI M8228 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; ARCHOS 80 COBALT Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; AX5 Build/IMM76D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; AllviewSpeed3HD Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Andi4.5h Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Aqua Style Build/IMM76D) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Avea InTouch 2 Build/IMM76D) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; BASE_Lutea_3 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; BLU Quattro 4.5 Build/IMM76D) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Mobile Safari/537.22
+TV	Mozilla/5.0 (Linux; Android 4.0.4; BNTV400 Build/IMM76L) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Bq Maxwell Plus Build/1.0.3 20121201-14:07) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; CAL21 Build/A1000091) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; CINK PEAX Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; CROSS A7S Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; CT710 Build/IMM76I) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Celkon A 200 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Celkon_A67 Build/IMM76I) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Mobile Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Cloudfone Excite 350g Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Cloudfone Thrill 500g Build/1.0.722_20121025) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; CnM Touchpad 9.7 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Ctrl_V1 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; DROID BIONIC Build/1.0) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Droid Razr Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; EBM727KC Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; En-US; Vivo S6T Build/IMM76D) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; F-05E Build/V12R34G) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; FONE 500 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; G1 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; GOCLEVER TAB A104.2 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; GSmart G1362 Build/IMM76I) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; GT-B5330 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; GT-I9210T Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; GT-N8005 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; GT-S5301 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; GT-S7560M Build/310) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; GT-i9505 Build/HuaweiM931) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Grand X IN Build/GXI_THUV1.0.0B04) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; H2000 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; HS-7DTB6-4GB Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; HTC Desire HD With Beats Audio Build/KCbuild2) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; HTC Desire XS Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; HTC PM36100 Build/IMM76I) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; HTC T329w Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.135 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; HUAWEI U8818 Build/IMM76) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; HW-01E Build/HuaweiU9501L) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Haier HW-W910 Build/IMM76I) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; I-Buddy 3 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; I9300 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; IM-A760S Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; IM-A775C Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; IM-A810S Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; IMO Y5 Build/IMM76D) AppleWebKit/537.36 (KHTML, Like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; IRIS_430 Build/LAVAIRIS430) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; IS15SH Build/S2201) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; IdeaTabA2109A Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Incredible 2 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Infinix X400 Build/IMM76I) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; JT-B1 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Joypad C74 Build/C74) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.40 Mobile Safari/537.31 OPR/14.0.1074.54070
+Tablet	Mozilla/5.0 (Linux; Android 4.0.4; KFJWA Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Karbonn A21 Build/IMM76I) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; L-01D Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; LC0720C Build/IMM76I) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; LG-D700 Build/IMM76L) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; LG-F100S Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; LG-F180L Build/IMM76L) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; LG-LS840 Build/ZVI.IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; LG-LU6500 Build/IMM76L) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; LG-P760 Build/IMM76L) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile S
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; LG-P895qb Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; LGL21 Build/IMM76L) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; LT18a Build/4.1.B.0.587) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; LT28at Build/6.1.C.1.105) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; LT30at Build/7.0.B.1.135) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Lemon Tab LT29 Build/IMM76D) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Lenco TAB-1014 Build/IMM76D) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Lenovo A390_ROW Build/IMM76I) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Lenovo Micromax A800 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Lenovo_A2105 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; M-MP706I Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; M11 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; MB886 Build/7.7.1Q-115_MB886_BELL_FFW-11) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; MEDION P4013 Build/IMM76I) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; MID1065 Build/ICS.MID1065.20121228) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; MIDC700PR001 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; MITO A222 Build/MITO-A222-V00.00.01) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; MOMO11 bird3 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; MOMO8 Xing ji Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; MP907C Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Safari/537.36 OPR/18.0.1290.67495
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; MT917 Build/6.7.2_GC-205-DNRTD-4) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; MZ608 Build/7.7.1-141-3-FLEM-UMTS-LA) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Mercury X Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Micromax P275 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; My Audio Build/RK2906) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; N-02E Build/A3000321) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; N9100 Build/IMM76I) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; NT-1710 Build/IMM76D) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22 OPR/14.0.1025.52315
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; NetTAB THOR-LE Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; NexusHD2 Build/IMM76I) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.58201
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Novo7Aurora Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; OnePAD 715 Build/IMM76D) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; P-02D Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.63 Mobile Safari/537.36 OPR/15.0.1162.61541
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; PAD 9715D Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; PAPYRE Pad 715 Build/IMM76D) AppleWebKit/537.36 (KHTML, Like Gecko) Chrome/30.0.1599.82 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; PICOpad GEW Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; PICOpad GHM Build/IMM76D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; PMID1000B Build/IMM76D) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; PMID705X Build/IMM76D) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; PMP5770D Build/IMM76I) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; PMP7170B3G Build/IMM76D) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; POV_P517-8GB Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.59 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; POV_TAB_NAVI7_3G_M Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.72 Safari/537.36 OPR/19.0.1340.69721
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; PantechP9090 Build/IMM76I) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Q-Smart S18 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; RAPAXSE080-0508 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; RK702 Build/2906) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SAMSUNG-SGH-I747 Build/IMM76D) AppleWebKit/535.19 (KHTML
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SBM107SHB Build/S0006) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SC-105MID Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SCH-R530C Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SCH-S735C Build/IMM76D) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SGH-I497 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SGH-I747M Build/IMM76D) AppleWebKit/535.19 (KHTML
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SGH-I9000 Build/EXTRAordinary_ICS) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SGH-T999V Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SH530U Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SHV-E140S Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SHW-M380S Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SMP45-210 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SO-02D Build/6.1.1.A.0.246) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SPH-D710 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SPH-M830 Build/IMM76I) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SPX-12 Build/IMM76D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.58201
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; ST21i2 Build/11.0.A.1.8) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; ST97216-1 Build/ST97216-1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.59 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Sensation Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; SmartQT20 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Spice_Mi-495 Build/SpiceSpice_Mi-495) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; T-900 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; TAB-PROTAB25XXL8 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; TAD-10021 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; TECNO N7 Build/TECNOTECNO_N7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.63 Mobile Safari/537.36 OPR/15.0.1162.61541
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; TM-MID720 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Safari/537.36 OPR/16.0.1212.64462
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; TOUCH90W Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; TP9.7-1200 Build/IMM76D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Tablet	Mozilla/5.0 (Linux; Android 4.0.4; Tablet-PC-4 Build/ICS.g08refem618.20121102) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; ThL W7 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Treq 3G Basic 2 Build/IMM76D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; U30GT-H Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; U705T Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.64 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; V8000_USA_Cricket Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; VOX Build/IMM76D) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Mobile Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; VSD220 Build/IMM76D.UI23E802_VSC) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Vip Racer III Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; WX435 Build/IMM76I) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; X10.mini Build/IMM76D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; XOLO A700 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Tablet	Mozilla/5.0 (Linux; Android 4.0.4; XOOM 2 Build/7.7.1-128_MZ615-12) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31 OPR/14.0.1074.57768
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; XT875 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; XT897 Build/7.7.1Q-6_SPR-125_ASA-10) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Mobile Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; XT925 Build/7.7.1Q-144_VQL_S3-49) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Tablet	Mozilla/5.0 (Linux; Android 4.0.4; Xoom Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; Xperia Pro Build/IMM76I) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; YP-G70 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; YPY_07FTB Build/IMM76I) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; ZP900S Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; ZTE Grand X Classic Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; ZTE T790 Build/IMM76D) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; ZTE U985 Build/IMM76L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; ZTE V880G Build/IMM76I) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; ZTE V955 Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; bq Aquaris Build/IMM76D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.58201
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; bq edison Build/1.1.1 bq_edison_c1006_20120905_user) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; e1909c_v77_jbl_9p017_6628 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; en-US; MI 1SC Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; i-mobile IQ 2 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; i-mobile i-STYLE Q 5A Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; i-mobile i-note 2 Build/ICS_IMM76I) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Mobile Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; i-mobile i-style Q3i Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; iBall Slide i6516 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; myTab10 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.4; vivo S7t Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.0.9; I9300A Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1 ALK8; SGH-T889 Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; 10BPEOH Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.64 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; A953 Build/JRO03L) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; ADM8000KP_A Build/JRO03H) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31 OPR/14.0.1074.57453
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; ALCATEL ONE TOUCH 4030E Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; ALCATEL ONE TOUCH 5020W Build/JRO03C) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; ALCATEL_ONE_TOUCH_5020X_Orange Build/JRO03C) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; AQUILA 097-1016 BT + 3G Build/JRO03C) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; ARCHOS 80 Platinum Build/MASTER) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31 OPR/14.0.1074.58201
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; ARCHOS 97B TITANIUM Build/JRO03H) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+Tablet	Mozilla/5.0 (Linux; Android 4.1.1; ASUS Tablet P1801-T Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+TV	Mozilla/5.0 (Linux; Android 4.1.1; AX123 Build/f101.nog.etv.20130928) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; Aqua Wonder Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; Archos Chefpad Build/JRO03H) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; CAPTIVA PAD 10.1 Build/JRO03H) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; CT920 Build/JRO03H) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; Celkon A119 Build/JRO03C) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Tablet	Mozilla/5.0 (Linux; Android 4.1.1; Connect-2G-2.0 Build/HCL ME Tablet V2) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; Desire L by HTC Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; EndeavorU Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; FUSION2IN1 Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.72 Safari/537.36 OPR/19.0.1340.69721
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; GOCLEVER TAB R70 Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.63 Safari/537.36 OPR/15.0.1162.61541
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; GT-I9260 Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; GT-N7105 Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; Galaxy SIII Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; HTC 603e Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; HTC EVA_UTL Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; HTC Z520e Build/JRO03C) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; HTL21 Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; HUAWEI G510-0200 Build/HuaweiU8951-1) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; HUAWEI Y300-0100 Build/HuaweiY300-0100) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; I-mobile IQ 4 Build/JRO03C) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; IQ442 Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.170 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; JOYPAD_C75 Build/IMM76D) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; LC1016C Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; Lenovo P770 Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; Luna TAB07-100 Build/JRO03C) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; M031 Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; MEDION E4002 Build/JRO03C) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; MI 2S Build/JRO03L) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; MID7052 Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; MP910I Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; MW0712 Build/JRO03H) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; Micromax P362 Build/JRO03H) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; NT-0709M Build/JRO03C) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; Novo 10 Hero QuadCore Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; ODYS-NOON Build/JRO03H) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31 OPR/14.0.1074.58201
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; ONE TOUCH TAB 7HD Build/JRO03H) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; One XL Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.64 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; PAD-FMD700P Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; PAP4055DUO Build/JRO03C) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; PLT7223G Build/JRO03H) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; PMID720 Build/JRO03C) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; PMP5097CPro Build/JRO03H) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; PMP7280C Build/PMP7280C_20130123_v1.0.0) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.172 YaBrowser/1.0.1364.172 Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; POV_TAB-PL1015 Build/JRO03H) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31 OPR/14.0.1074.58201
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; POV_TAB-PROTAB27 Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36 OPR/16.0.1212.64462
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; PRIMO8 Build/JRO03C) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; R8113 Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; SC-02E Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; SCH-I605 Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; SGH-I317M Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; SGH-L710 Build/JRO03L) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; SH930W Build/JRO03L) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; SHV-E250L Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; SN97T41W Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; SPH-P600 Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; ST70208-1 Build/JRO03C) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; SpiceMi1010 Build/SpiceMi1010) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31 OPR/14.0.1074.58201
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; TABLO Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Safari/537.36 OPR/16.0.1212.64462
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; TAGI MID 950 Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Safari/537.36 OPR/16.0.1212.65583
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; TM-7043XD Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; TM-MID730 Build/JRO03H) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Safari/537.22 OPR/14.0.1025.52315
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; TP10.1-1500DC-metal Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Safari/537.36 OPR/18.0.1290.67495
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; TP9.7-1200QC Retina Build/MASTER) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.72 Safari/537.36 OPR/19.0.1340.69721
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; Transformer Pad Infinity TF700T Build/JRO03L) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; VS TOUCHTAB 10.1DC Build/JRO03H) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31 OPR/14.0.1074.58201
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; VegaBean Beta 5 Build/JRO03L) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; WX04K Build/324.4.0000) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; X10.Dual Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; X210 Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; XOLO A1000 Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; XT926 Build/BWHD) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; Z120 Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; ZTE V807 Build/JRO03C) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; bq Curie Build/1.0.1 20121128-19:40) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.1; i-mobile IQ 3 Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; A19Q Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; ALCATEL ONE TOUCH 8000D Build/JZO54K) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; Andromax AD683J Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; Archos 80 Xenon Build/JZO54K) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; B1-710 Build/JZO54K) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; Barnes & Noble Nook HD Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; C6606 Build/10.1.1.B.0.108) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; CROSS AT1G Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; Connect-3G-2.0 Build/HCL) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; Cynus F5 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; Evo 3D GSM Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.31 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; G2S Build/JZO54K) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; GT-I8190N Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; GT-I8262B Build/JZO54K) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; GT-N5100 Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; GT-S5283B Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Mobile Safari/537.36 OPR/18.0.1290.67495
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; GT-S6310N Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; GT-S6810P Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; HD2 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; HTC Desire 500 dual sim Build/JZO54K) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; HTCSensation Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; HUAWEI A199 Build/HuaweiA199) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; HUAWEI G525-U00 Build/HuaweiG525-U00) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; HUAWEI P2-6011-orange Build/hwP2-6011C109B007) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; I-mobile I-STYLE 7.2 Build/JZO54K) AppleWebKit/537.36 (KHTML, Like Gecko) Chrome/30.0.1599.92 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; IM-A850 S/K Build/VEGAVIET.COM JELLYBEAN V1.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; IM-A860L Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; IMO S89 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; IdeaTabA1000-F Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; Infinix X530 Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; L-04E Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; LG-E410 Build/JZO54K) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; LG-E411g Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; LG-E975K Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; LG-F180 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; LG-F260S Build/JZO54K) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; LG-P659 Build/JZO54K) AppleWebKit/537.31 (KHTML, Like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; LG-P870h Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; Lenovo A706_ROW Build/JZO54K) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.172 YaBrowser/1.20.1364.172 Mobile Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; MB870 Build/4.5.1A-DTN-130) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; MITO t300 Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; MediaPad 7 Lite II Build/HuaweiMediaPad) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; My|Phone a898 duo Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; NT-1008T Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.102 YaBrowser/14.2.1700.12147.01 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; Nokia_XL Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36 NokiaBrowser/1.0.1.54
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; PHICOMM X100wEU Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; POV_TAB-P629(v1.0) Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; Primo-X1 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; SAMSUNG-SGH-I407 Build/JZO54K) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; SAMSUNG-SGH-T879 Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; SCH-R760X Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; SGH-I467M Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; SGH-T599N Build/JZO54K) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; SGP311 Build/10.1.C.0.291) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; SHV-E270K Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; SHW-M500W Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Tablet	Mozilla/5.0 (Linux; Android 4.1.2; SM-T211M Build/JZO54K) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; SO-04E Build/10.1.1.D.0.179) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; SPH-M840 Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; TP8-1500DC Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; Titanium S1 Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; VS870 4G Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; XT701 Build/PD200) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; XT919 Build/2_25B_2012) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; Xperia Live with Walkman Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; Xperia Neo V Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; Xperia Tipo Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; Z750C Build/JZO54K) AppleWebKit/537.31 (KHTML, Like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; ZP910 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; ZTE Blade III Pro Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; ZTE N909 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; a200 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; i-mobile IQ1-1 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) FlyFlow/2.2 Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; i-mobile i-note 3 Build/JB_JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.1.2; mito a322 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.1; M-MP720M Build/JZO54K) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; A240 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; AT-AS45qHD Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36 OPR/16.0.1212.64462
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; AT10PE-A Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; BLU Life View Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; Celkon A119Q Build/JOP40D) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22 OPR/14.0.1025.53463
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; DARKSIDE Build/JOP40D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; GFIVE G9 Build/Mlais) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; GSmart Guru G1 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; GT-I9502 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; HUAWEI G700-T00 Build/HuaweiG700-T00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; INSIGNIA 5 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; IQ446 Magic Build/JOP40D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; Iris_Xtreme V2 By Manik Build/iris504Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; Karbonn S2 Build/JOP40D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; Lenovo K860i Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; Lenovo P780_ROW Build/JOP40D) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; M-PP2G530 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; MID-750 Build/JOP40D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.58201
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; Micromax A116i Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.72 Mobile Safari/537.36 OPR/19.0.1340.69721
+Tablet	Mozilla/5.0 (Linux; Android 4.2.1; Nexus 10 Build/JDP50B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; PMP7480D3G_QUAD Build/PMP7480D3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; Panasonic P51 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.64 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; Q1000 Build/JOP40D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; Q800X Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; SCH-R970C Build/JOP40D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; Streak 7 Build/JOP40D) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Mobile Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; U707 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; W8s Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 YaBrowser/13.9.1500.3524 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; XT894 Build/JOP40D) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; ZP800H Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; ZTE V967S Build/JOP40D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.28 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; de-de; SAMSUNG GT-I8245 Build/JOP40D) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0.130303 Chrome/18.0.1025.308 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; i-mobile IQ 5.3 Build/JOP40D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; i-mobile IQ XA Build/JOP40D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; iris504Q Build/iris504Q) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; v89_jbl1a668 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.1; vivo X1St Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; A114 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; ALCATEL ONE TOUCH 5036X Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; ALCATEL ONE TOUCH Fierce Build/JDQ39) AppleWebKit/537.31 (KHTML, Like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; ARCHOS 101 CHILDPAD Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; ARCHOS 80b PLATINUM Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; AT-AS45D1 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; AX4Nano Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Archos 101 Cobalt Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Archos 40b Titanium Surround Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; B1-711 Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; BRAVIO Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; C6902 Build/14.1.G.1.518) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; CAPTIVA PAD 10.1 Quad FHD Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; CUBOT C9+ Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; CUBOT P9 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Mobile Safari/537.36 OPR/18.0.1290.67495
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Coolpad 7296 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Cynus T7 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; DROID X2 Build/JDQ39E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; E128 Build/E128) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.72 Mobile Safari/537.36 OPR/19.0.1340.69721
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Endeavour 1010 Build/ONDA_MID) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Safari/537.36 OPR/18.0.1290.67495
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; F-02F Build/V19R63A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Find 5 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; FreeTAB 1014 IPS X4 3G+ Build/JDQ39) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; GFIVE President(G7) Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; GT-I8200L Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; GT-I9195X Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; GT-N9000 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; GT-S7270 Build/JDQ39) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.172 YaBrowser/1.1.1364.172 Mobile Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; GT-S7275R Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Grand S Lite Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; HP Slate 10 HD Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; HP SlateBook 10 x2 PC Build/4.2.2-17r14-13-18) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; HTC 9060 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; HTC J butterfly Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.49 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; HTC One with MoDaCo.SWITCH Beta 8 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; HTC6500LVW Build/JDQ39) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.47 Mobile Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; HTC_V1 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; HUAWEI P6-C00 Build/HuaweiP6-C00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; HUAWEI Y320-U10 Build/HUAWEIY320-U10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.135 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; I-mobile I-STYLE 8.1 Build/JDQ39) AppleWebKit/537.36 (KHTML, Like Gecko) Chrome/30.0.1599.92 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; IEOS_QUAD Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Safari/537.36 OPR/18.0.1290.67495
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; IM-A890L Build/JDQ39) AppleWebKit/537.36 (KHTML, Like Gecko) Chrome/30.0.1599.92 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; IRIS402 Build/LAVAIRIS402) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; IdeaTab S6000-H Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; JY-F1 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; K00G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
+Tablet	Mozilla/5.0 (Linux; Android 4.2.2; KFAPWI Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Karbonn S5i Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; LG-D801 Build/JDQ39B) AppleWebKit/537.36 (KHTML, Like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; LG-F320K Build/JDQ39B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.72 Mobile Safari/537.36 OPR/19.0.1340.69721
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; LG-V500 Build/JDQ39B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Lenco KidzTab-70 Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Lenovo A680_ROW Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Lenovo B6000-H Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Lenovo S5000-H Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; M-MP1040S2 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; M723 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; MID802 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; MP108 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Motorola Photon Q LTE Build/JDQ39E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; NT-0909T Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Novo10 Captain QuadCore Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.12975 YaBrowser/13.12.1599.12975 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Novo8 Discover Quadcore Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.117 Safari/537.36 OPR/20.0.1396.72047
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; ONE TOUCH 4033E Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; One Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.64 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; P011 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; PAP5501 Build/PrestigioPAP5501) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; PEDI_PLUS_W Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; PMP7079E3G_QUAD Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; POMP_C6 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; POV_TAB-P825 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; PRIME_PLUS_3G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Philips W8510 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; QUANTUM 4 Build/GOCLEVER) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; SAMSUNG-GT-I9500 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; SAMSUNG-SM-N900A Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; SCH-R970 Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; SGH-I257M Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; SGH-M919V Build/JDQ39) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Mobile Safari/537.22
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; SH-07E Build/R7100) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; SHV-E310S Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; SM-G3502U Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; SM-N900P Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
+Tablet	Mozilla/5.0 (Linux; Android 4.2.2; SM-T310X Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; SP-704DC Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31 OPR/14.0.1074.58201
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; ST10416-1A Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Samsung Galaxy S4 Mini GT-I9505 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; TB-7000 Build/JTDA326V1.0) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22 OPR/14.0.1025.53463
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; TECNO P5 Build/JDQ39) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; TP7.85-1200QC-3G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Transformer Pad Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; U30GT C4 Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; U8 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.64 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Vodafone 785 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; WX10K Build/103.0.2f30) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; XELIO10EXTREME Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Safari/537.36 OPR/18.0.1290.67495
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; XT1052 Build/13.9.0Q2.X_117) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.64 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; XT1060 Build/13.9.0Q2.X-116-MX-12) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.64 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; Y511-U00 Build/HUAWEIY511-U00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; ZP810H DUAL SIM Build/JOP40D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; ZP998 by Swayer Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; ZTE V765M Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; ar-ae; SAMSUNG GT-I9195/I9195XXUAMF6 Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; ar-ae; SAMSUNG GT-S7270 Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; bg-bg; SAMSUNG GT-I9505X Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; cs-cz; SAMSUNG GT-I9195-ORANGE Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; de-de; SAMSUNG GT-I9
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; de-de; SAMSUNG GT-I9505XX Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; de-de; SAMSUNG Nexus S Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; de-de; SAMSUNG SHV-E300K/KKUAMDK Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; de-de; SAMSUNG SHV-E330K/KKUAMH3 Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; e1902_v72_jdt1_OV5645_fwvga Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; en-gb; SAMSUNG SHV-E300S/K Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; en-us; SAMSUNG SCH-R960 USCC Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; en-us; SAMSUNG SCH-R970X Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; en-us; SAMSUNG SPH-L520 Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; i-STYLE2.1 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; i-mobile i-STYLE 7.5 Build/i_style_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Mobile Safari/537.36 OPR/18.0.1290.67495
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; iP977 Build/iP977) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.131 YaBrowser/14.5.1847.18432.00 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; ko-kr; SAMSUNG SM-C105S Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.2; zh-cn; SAMSUNG-GT-I8558_TD/1.0 Android/4.2.2 Release/04.15.2013 Browser/AppleWebKit535.19 Build/JDQ39) ApplelWebkit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
+Phone	Mozilla/5.0 (Linux; Android 4.2.9; H9900 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3.1; ASUS Transformer Prime Build/JLS36I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3.1; GT-i9100G Build/JLS36I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3.1; Xperia Z1 Build/JLS36I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.32 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; D2005 Build/20.0.A.0.25) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; D5322 Build/19.0.D.0.253) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; En-us; SAMSUNG SM-N900P Build/JSS15J) AppleWebKit/537.36 (KHTML, Like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; GT-N7100T Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; HTC J One Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; HTC X920e Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; K-Touch Tou ch3 Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36 OPR/20.0.1396.73172
+Phone	Mozilla/5.0 (Linux; Android 4.3; PadFone T00C Build/JSS15Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; SM-G7102 Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; SM-N7502 Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; SM-N9008V Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; SM-N900R4 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; U9000 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.72 Mobile Safari/537.36 OPR/19.0.1340.69721
+Phone	Mozilla/5.0 (Linux; Android 4.3; XT1032 Build/14.10.0Q3.X-17) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; ar-ae; SAMSUNG SM-N7505 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; de-de; SAMSUNG GT-i9300 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; de-de; SAMSUNG SM-N7500Q Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; de-de; SAMSUNG SM-N900L Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; en-gb; SAMSUNG SGH-N075T Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; fr-fr; SAMSUNG SM-G7105-ORANGE Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.3; zh-cn; SAMSUNG-GT-I9308_TD/1.0 Android/4.3 Release/11.15.2013 Browser/AppleWebKit534.30 Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; Android 4.3; zh-cn; SAMSUNG-SM-N9009 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.1; HTC Butterfly S Build/KRT16M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; Amazon Otter Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; DROID RAZR HD Build/KDA20.62-10.1) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 ACHEETAHI/2100050068
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; GT-S8500 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; HTC 0P9C2 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; HTC One mini 2 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; HUAWEI P7-L10 Build/HuaweiP7-L10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; LG-D150 Build/KOT49I.A1396318826) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.103 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; LG-F350S Build/KOT49I.F350S10e) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 NAVER(inapp; search; 270; 5.3.2)
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; LG-gee Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; Moto X - 4.4.2 - API 19 - 720x1280 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; P6-U00 Build/HuaweiP6-U00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.72 Mobile Safari/537.36 OPR/19.0.1340.69721
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; SGP511 Build/17.1.A.2.36) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; SM-G900FQ Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; SM-G900P Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; SM-G900W8 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Tablet	Mozilla/5.0 (Linux; Android 4.4.2; SM-T320 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; U8860 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; XT1031 Build/KXB20.9-1.10-1.18-1.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; Xperia SP Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; ZTE Z830 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; ar-ae; SAMSUNG SM-G900H Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.6 Chrome/28.0.1500.94 Mobile Safari/537.36
+Tablet	Mozilla/5.0 (Linux; Android 4.4.2; de-at; SAMSUNG SM-T520 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; de-de; SAMSUNG SM-G900L Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.6 Chrome/28.0.1500.94 Mobile Safari/537.36
+Tablet	Mozilla/5.0 (Linux; Android 4.4.2; de-de; SAMSUNG SM-T320X Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36
+Tablet	Mozilla/5.0 (Linux; Android 4.4.2; en-us; SAMSUNG SM-T800 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; htc_memul Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 4.4.2; tr-tr; SAMSUNG SM-G900FQ Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.6 Chrome/28.0.1500.94 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 5.0.2; Redmi Note 2 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36 ssy={Android;ECalendar;V6.1.8;xiaomi;101181501;WIFI}
+Phone	Mozilla/5.0 (Linux; Android 5.1.1; F1f Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 5.1.1; R7sf Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.149 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/263.0.0.46.121;]
+Phone	Mozilla/5.0 (Linux; Android 5.1; A33w Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.162 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/264.0.0.44.111;]
+Phone	Mozilla/5.0 (Linux; Android 6.0.1; Nexus 6P Build/MHC19Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 6.0; DIG-L01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 7.0; EVA-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 7.0; SM-A520F Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 Flipboard-Briefing/2.7.28
+Phone	Mozilla/5.0 (Linux; Android 7.1.1; SM-J510FN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 8.0.0; PRA-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 8.0.0; TA-1032 Build/O00623; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.149 Mobile Safari/537.36 Zalo android/12100486
+Phone	Mozilla/5.0 (Linux; Android 8.1.0; itel A32F Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 9; Mi A2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 9; Pixel 2 XL Build/PPP5.180610.010; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.85 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; Android 9; TA-1053) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
+TV	Mozilla/5.0 (Linux; GoogleTV 3.2; NSZ-GS7/GX70 Build/MASTER) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.77 Safari/534.24
+Computer	Mozilla/5.0 (Linux; U; 2.3.4; en-us; DROID2 Build/4.5.1_57_DR4-52) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Safari/533.1 MyDealerApp
+Phone	Mozilla/5.0 (Linux; U; Android 0.0 by gasper; es-us; HUAWEI Y210-0151 Build/HuaweiY210-0151) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.0.0; de-de; A7EB Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 1.0.15; ar-eg; A70HB Build/CUPCAKE) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.0; en-us; HTC_Dream) AppleWebKit/525.10 (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2
+Phone	Mozilla/5.0 (Linux; U; Android 1.5.1.11-RT-20120416.222947; Zh-cn; K-Touch W650 Build/AliyunOs-2012) AppleWebKit/530.17 (KHTML, Like Gecko) Version/4.0 Mobile Safari/530.17 T5/1.0 Baiduboxapp/4.5.1 (Baidu; P1 1.5.1.11-RT-20120416.222947)
+Phone	Mozilla/5.0 (Linux; U; Android 1.5; En-au; Behold2 Build/CUPCAKE) AppleWebKit/528.5+ (KHTML, Like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.5; GT-I7500) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2
+Phone	Mozilla/5.0 (Linux; U; Android 1.5; cs-cz; GT-I5700 Build/CUPCAKE) AppleWebKit/528.5 (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.5; de-at; T-Mobile_G2_Touch Build/CUPCAKE) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1,gzip(gfe),gzip(gfe)
+Phone	Mozilla/5.0 (Linux; U; Android 1.5; de-ch; MB300 Build/CUPCAKE) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.5; de-de; Galaxy with MCR 1.2 Build/CUPCAKE) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.5; en-; LG GW620R Build/CUPCAKE) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2
+Phone	Mozilla/5.0 (Linux; U; Android 1.5; en-gb; LG GW620g Build/CUPCAKE) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.5; en-us; Dell Aero Build/MASTER) AppleWebKit/528.5 (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.5; en-us; HTC Click Build/CRB17) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.5; en-us; desirec) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2
+Phone	Mozilla/5.0 (Linux; U; Android 1.5; fr-fr, HTC Hero Build/CUPCAKE) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3/1/2 Mobile Safari/525.20.1,gzip(gfe),gzip(gfe)
+Phone	Mozilla/5.0 (Linux; U; Android 1.5; zh-cn; MT710 Build/CUPCAKE) AppleWebKit/525.10 (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2
+Phone	Mozilla/5.0 (Linux; U; Android 1.6; En-gb; Videocon-V7500 Build/DONUT) AppleWebKit/528.5+ (KHTML, Like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.6; Ja-jp; SH-10B Build/S1110) AppleWebKit/528.5+ (KHTML, Like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.6; bg-bg; SonyEricssonE10i Build/1.0.A.1.36) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.6; ca-es; SonyEricssonE15iv Build/1.3.A.0.50) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.6; cs-cz; SonyEricssonE10i-o Build/1.0.A.1.36) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.6; da-dk; Garmin-Asus A50 Build/DRC79) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1; A50-V4.1.23-user-20100514
+Phone	Mozilla/5.0 (Linux; U; Android 1.6; de-de; Garminfone Build/DRC79) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1; A50-V4.0.25-user-20100722
+Phone	Mozilla/5.0 (Linux; U; Android 1.6; de-de; SonyEricssonX10a Build/R2BA024) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.6; en-ca; E10a Build/1.1.A.0.8) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.6; en-gb; i-mobile IE 6010 Build/Donut) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.6; en-us; Motorola-XT502 Build/DONUT) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.6; en-us; Zio Build/DRC92) AppleWebKit/528.5  (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.6; fr-be; SonyEricssonE15i-o Build/1.3.A.0.50) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 1.6; zh-cn; Lenovo 3GC101/S-5-02;320*533;CTC/2.0) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 10.0.0; ko-kr; IM-A690L Build/JELLYBEAN) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.0.1; de-de; Milestone Build/SHOLS_U2_01.14.0) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.0.1; zh-cn; XT800 Build/TITA_M2_15.10.1) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-NEW_5P_MB502; zh-cn; MB502 Build/BASIL_U3_03.90.7) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1-1.0.0; Es-es; NXM901 Build/ECLAIR) AppleWebKit/530.17 (KHTML, Like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1-1.0.3; ru-ru; TB-805A Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1-2.1.13; de-de; PMP3084B Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1-corvusMODv6; en-us; SmartQ V7 Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; Ar-kw; EQ U8110 Build/ERE27) AppleWebKit/530.17 (KHTML, Like Gecko) Version/4.0 Mobile Safari/530.17
+Tablet	Mozilla/5.0 (Linux; U; Android 2.1-update1; De-de; Android For Telechips TCC8902 Tablet-PC (DE) Build/ECLAIR) AppleWebKit/530.17 (KHTML, Like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; En-US; Micromax_A60 Build/ERE27) AppleWebKit/528.5+ (KHTML, Like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.6.0.318 Mobile
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; En-ca; SmartQT7 Build/ECLAIR) AppleWebKit/530.17 (KHTML, Like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; En-us; EV-S110 Build/ERE27) AppleWebKit/530.17 (KHTML, Like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; En-us; SCH-R880 Build/ECLAIR) AppleWebKit/525.10+ (KHTML, Like Gecko) Version/3.0.4 Mobile Safari/523.12.2
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; En-us; WX445 Build/VZW) AppleWebKit/530.17 (KHTML, Like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; Pt-br ; XT300 Build/SESLA_U3_01.72.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.3.0.143/145/352
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; ar-eg; E400 Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; ar-il; Android for Telechips TCC8900 Evaluation Board (US) Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; bg-bg; Ideos S7 Build/ERE27) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; ch-ch; XT800W Build/TTSKT_U_80.10.28R) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; cs-cz; soft stone Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; de-; MotoMB511 Build/RUTEM_U3_01.14.20) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17 (Mobile; afma-sdk-a-v6.2.1)
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; de-at; GT-I5801 Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; de-at; SAMSUNG-SGH-I897/I897UCJH7 Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; de-de; A70S Build/ECLAIR) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; de-de; GT-I5500L Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; de-de; HTC Liberty Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; de-de; M860 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; de-de; SAMSUNG-SGH-I896 Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; de-de; U8120 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; en-; SKY IM-A630K Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; en-US; MB508 Build/SAGE_U3_10.23.20) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.3.1.344 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; en-US; ZTE-U_X850 Build/ERE27) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.2.0.242 Mobile
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; en-ca; GT-I9000M Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; en-gb; GT-I5801-ORANGE/I5801BVJD5 Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; en-gb; TCL A890 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; en-jp; HTCX06HT Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; en-us; A955 Build/1.13.5) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17 854X480 Motorola A955
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; en-us; GSmart-G1305 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; en-us; HTC Bravo_C Build/ERE27) AppleWebKit/530.17 (KHTML
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; en-us; Hero CDMA Build/EPE54B) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17,gzip(gfe),gzip(gfe)
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; en-us; LS670 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; en-us; MB810 Build/1.13.4) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17 480X854 motorola MB810,gzip(gfe),gzip(gfe)
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; en-us; SAMSUNG-SGH-I897 Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; en-us; T-Mobile_EspressoBuild/ERE27) AppleWebKit/530.17 (KHTML
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; en-us; XT702 Build/SGC02040) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; es-us; Motorola Titanium Build/ESE81) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; ja-jp; Panasonic SV-MV100 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; ru-ru; Motorola-XT502 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; zh-CN; SH8128U Build/ERE27) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.3.2.349 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; zh-cn; MOT-XT301/CNACT_X2_01.20.3; 240*320; CTC/2.0) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1-update1; zh-cn; ZTE-U X876 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1.1; zh-cn; u8800 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.1; T-Mobile G2 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 Mobio/4.1.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.1; en-in; MTS-SP101 Build/HuaweiC8511) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.1; en-us; HTC Glacier Build/ERD62) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1; en-us; LogicPD Zoom2 Build/ERD79) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1; es-es; T-Mobile MyTouch 3G Build/EPE54B) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.1; ko-kr; imx51_p3 Build/ERD79) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1 - GBTHEME 9.3.1 AERODKNG SGS4G; en-us; SGH-T959V Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; De-de; SP-40 Build/MASTER) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; En-jp; S31HT Build/FRG83) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; En-us; PICOpad-QGN Build/FRG83) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; Es-es; A502 Build/MASTER) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; Ja-jp; ISW11HT Build/FRG83) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; Ru-ru; SmartQT12 Build/MID) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; ar-ae; GT-P1010 Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; bg-bg; LG-P350 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; cs-cz; HTC_DesireZ_A7272 Build/FRG83D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; cs-cz; Xperia X8 Build/Nexus-X8 By Artoseven) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; de-at; HTC Desire Z  1.82.166.1 Build/FRG83D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; de-de; A35 Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; de-de; CT1002 Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; de-de; GT-S5570B Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; de-de; HTC Kaiser/Kaiser Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; de-de; IDEOS S7 Slim Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; de-de; LG-P350-Orange Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.0/1.2
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; de-de; MFC150DEX, Build/MASTER) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; de-de; Nokia N900 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; de-de; SHW-M130K Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; de-de; U8500 Build/HuaweiU8500) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; de-de; one touch 906 Build/FSR) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-; IS06 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-; ViewPad7 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-ca; HTC-A7275 Build/FRG83D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-gb; 3GC101 Build/FRG83) UC AppleWebKit/530+ (KHTML, like Gecko) Mobile Safari/530
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-gb; HTCA9191/1.0 Android/2.2 release/06.23.2010 Browser/WAP 2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-gb; X10minipro Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-us ; A853 Milestone Build/SHLA_U2_05.0C.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.6.1.262/145/355
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-us ; IVIO_DE38 Build/MASTER) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.4.1.204/145/444
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; A100 Build/MASTER) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; C771 Build/C771F415) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; GSmart G1317D Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; HUAWEI-M835 Build/FRG83) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; LG-LU3000 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; NABI-A Build/MASTER) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; SGH-T759 Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; T100 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; XT800+ Build/TTUPG_M6_2.200.15.1) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; u8820 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; es-us; XT865 Build/4.4.1_228) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; id; AD350 Build/ATHENA_00.03.68.10.45.H1007) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.7.0.315 Ponsel
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; ru-ru; A88 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; th-th; WellcoM-A99 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; zh-cn; HTC-A315c/1.13.1401.0) AndroidWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.1; zh-cn; SCH-I579 Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2 us-en; USCC-US760 Build/SlackerUA) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; Ar-eg; Alcatel_one_touch_908F_Orange Build/FRG83G) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; En-US; Andi2 Build/HERA_00.04.79.17.43.H1019) AppleWebKit/528.5+ (KHTML, Like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.7.0.315 Mobile
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; En-ca; ALCATEL_one_touch_908S Build/FRG83G) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; En-gb; I-mobile I691 Build/FRG83G) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; En-gr; U8350 Build/HuaweiU8350) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; En-us; C8600 Build/HuaweiC8600) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; En-us; SGH-T589 Build/FROYO) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; Es-hn; U8350-51 Build/HuaweiU8350) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; In-id; ZTE-U V859 Build/FRG83G) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; ar-; HUAWEI-U9000 Build/HuaweiU9000) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; ar-il; LG-P970h Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.0/1.2
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; ca-es; GT-I8000 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; da-dk; ALCATEL_one_touch_906Y Build/FSR) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; de-at; MotoMB525 Build/3.4.2-179) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; de-de; ALCATEL_one_touch_990A Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; de-de; EV-S100 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; de-de; HUAWEI-M860 Build/HuaweiM860) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; de-de; LG-P350g Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; de-de; Liquid Metal Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; en-; GSmart G1317 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; en-US; HUAWEI T8500 Build/13PPVB) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; en-US; ZTE_U_N720 Build/FRF91) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.2.0.242 Mobile
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; en-ca; LG-P505CH Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; en-gb; DesireA8181 Build/FRG83G) AppleWebKit/533.1 (KHTML like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; en-us ; BLU TOUCH BOOK 7.0 Build/1.0.8265.0448) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.4.0.181/145/352
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; ALCATEL_one_touch_908M Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; CIUS-7-AT Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; GT-B7510B Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; HUAWEI T8100 Build/T8100V100R001CHSC01B052) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; LG-MS690 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; MOTOROLA XT502 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; Triumph Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; ZTE-U N720 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; u8820 Build/HuaweiU8820) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; ko-kr; SK-S100 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; ru-ru; Huawei_8100-9 Build/HuaweiU8109) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; zh-cn; D5800 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; zh-cn; SH8158U Build/S3181) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; zh-cn; ZTE-C N700 Build/FRF91) UC AppleWebKit/530+ (KHTML, like Gecko) Mobile Safari/530
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.2; zh-cn; coolpad-Coolpad W706+ Build/FROYO) AppleWebKit/533.1 (KHTML,like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2.3; en-US; Droid-Bionic Build/70J1V2)AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 (Mobile; afma-sdk-a-v6.0.1)
+Phone	Mozilla/5.0 (Linux; U; Android 2.2; De-de; GT-I9010 Build/FROYO) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2; En-us; Sprint APA7373KT Build/FRF91) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2; In-id; IMO Y3 Build/FRF91) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2; ar-kw; SC-01C Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Tablet	Mozilla/5.0 (Linux; U; Android 2.2; de-DE; SAMSUNG GT-P1000 Tablet Build/MASTER) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Tablet	Mozilla/5.0 (Linux; U; Android 2.2; de-de; GT-P1000 Tablet Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2; de-de; HTCA3366/1.0 Android/2.2 release/06.23.2010 Browser/WAP 2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2; de-de; OliPad 100G Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2; en-US; Q-mobile S10 Build/FRF91) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.0.1.275 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 2.2; en-gb; GT-I9000/I9000XXJPO Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2; en-us; Droid 2 Global Build/S273) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2; en-us; HTC PLS7373ADR Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2; en-us; LG-E510 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2; en-us; Mi320 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2; en-us; U8150 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2; en-us; meizu_m9 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2; ja-jp; Hikari-iFrame/WDPF-701ME Build/2.0.0E) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.2; ru-ua; HTC_Gratia_A6380 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.1; -; NXM803HC Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.1; En-gb; NXM726HN Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.1; Es-es; GASEM900HC Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.1; SonyEricssonLT15i Build/3.0.A.0.326) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.1; ar-eg; PMP5080BRU Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.1; bg-bg; AN9G2 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.1; de-at; AN10BG2DT Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.1; de-de; AP-701 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.1; de-de; LUBM912HC Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.1; de-de; ST8000 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.1; de-li; MW0812 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.1; en-gb; NXM726 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.1; en-us ; Informer 901 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.6.1.262/145/355
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.1; en-us; CUBE K8GT Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.1; en-us; SonyEricssonR800a Build/3.0.A.0.326) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1,gzip(gfe),gzip(gfe),gzip(gfe)
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.1; es-es; CUBE U9GT Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.1; ru-ru; NetTAB PRIDE Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.2; bg-bg; SonyEricssonR800iv Build/3.0.A.2.184) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.2; de-de; HTC HD2 Gingerbread Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.2; en-US; A956 Build/E5EX0G)
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.2; en-us; SonyEricssonSO-01C Build/3.0.D.2.79) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; De-de; CatNova8 Build/GRI40) AppleWebKit/533.16 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; En-US; P-07C Build/GRI40) AppleWebKit/534.31 (KHTML, Like Gecko) UCBrowser/9.3.1.344 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; En-us; K080 Build/GRI40) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; En-us; TAB450 Build/GRI40) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; Ja-jp; IS11CA Build/01.09.00) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; ar-eg; CLIQ XT Build/GRH78) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; ar-eg; MID7012 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; bg-; U8650 Build/HuaweiU8650) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; bg-bg; SAMSUNG GT-S5830/S5830BUKPE Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; ca-es; SonyEricssonSK17a Build/4.0.A.2.335) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; cs-cz; SonyEricssonSK17iv Build/4.0.A.2.335) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; de-at; HTC/ChaCha/1.19.169.1 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; de-at; SonyEricssonX10i-o Build/3.0.1.G.0.75) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; de-de; HTC C510e Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; de-de; HTCS510e/1.0 Android/2.2 release/06.23.2010 Browser/WAP 2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; de-de; HTC_WildfireS-orange-LS Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; de-de; MP727 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; de-de; SAMSUNG VS910 4G/I9100BUKG2 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; de-de; SonyEricssonSK17i-o Build/4.0.A.2.335) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; de-de; U8510 Build/U8510-1V100R001C169B831) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; de-li; SonyEricssonWT19i Build/private) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-; Lenovo A60 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-au; HTC_S510b V1.36.841.2 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-au; SonyEricssonSO-03C Build/4.0.D.2.61) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-ca; SO-03C Build/4.0.D.2.61) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-cn; HTCA510e/1.0 Android/2.4 release/02.25.2011 Browser/WAP 2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-gb; MID7007 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-gb; TAB250 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-us ; ST18a Build/4.0.A.2.368) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.3.0.143/145/355
+TV	Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; Android for Techvision TV1T808 Board Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; Desire CDMA Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; Eris ADR6200 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; HTC Desire CDMA Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; HTC HD2x Build/GRI54) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; Huawei Ascend Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; LG-P699 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.0/1.2,gzip(gfe),gzip(gfe),gzip(gfe)
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; OnePAD 720 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; Sensation 4G HD Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; U8652 Build/HuaweiU8652) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; imx53_smd Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en_us; Celkon A88 Build/GINGERBREAD) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 NetFrontLifeBrowser/2.3 Mobile (Dragonfruit)
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en_us; N860 Build/GINGERBREAD) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 NetFrontLifeBrowser/2.3 Mobile (Dragonfruit)
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; en_us; ZTE-X500 Build/GINGERBREAD) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 NetFrontLifeBrowser/2.3 Mobile (Dragonfruit)
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; es-es; HTC_ChaCha-orange-LS Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; es_es; BLU DASH 3.5 Build/GINGERBREAD) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 NetFrontLifeBrowser/2.3 Mobile (Dragonfruit)
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr, HTC_WildfireS Build/GINGERBREAD) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; in_id; HS-E910 Build/GINGERBREAD) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 NetFrontLifeBrowser/2.3 Mobile (Dragonfruit)
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; pl-pl; Orange Monte Carlo Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; ru_ru; Fly IQ245 Build/GINGERBREAD) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 NetFrontLifeBrowser/2.3 Mobile (Dragonfruit)
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; zh-cn; C8800 Build/HuaweiC8800) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.3; zh-tw; HTC_Marvel Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; -mx; ALCATEL_one_touch_909B Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; Ar-ye; USCCADR6285US Build/GRJ22) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; En-US; GN170 Build/GRJ22) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; En-gb; ODYS-Chrono Build/GRJ22) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; En-us; 009Z Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; En-us; GN105 Build/GRJ22) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; En-us; SH-04D Build/S8100) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; Fr-fr; JXD V5200 Build/GRJ22) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; Pt-br ; LG-E510f Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.3.0.143/145/352
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; Ru-ru; IQ275 Build/GRJ22) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; ar-; LG-P698 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; ar-eg; XT311 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 (Mobile; afma-sdk-a-v6.4.1)
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; bg-bg; SonyEricssonLT18iv Build/4.0.2.A.0.42) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; ca-es; TAB360 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; de-at; HTC/EVO_3D/1.21.163.1 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; de-ch; SAMSUNG GT-S5660V/S5660VXXKQE Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; de-de; E50 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; de-de; GT-S5660M Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; de-de; HTC A810e Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 Maxthon
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; de-de; HTC_PH39100/1.63.502.4 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; de-de; LG-C800 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.0/1.2
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; de-de; LG-LS855 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; de-de; OPPOT703 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; de-de; SonyEricssonLT18 Build/4.0.2.A.0.62_2.0.4.4) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; de-de; SonyEricssonMT18i Build/4.0.2.A.0.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; de-de; TCL ONE TOUCH 990 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; de-de; e1102_v73_gq1001c Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; el-gr; Huawei Ideos Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; en-US; TCL_A909 Build/GINGERBREAD) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.7.0.315 Mobile
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; en-au; HTC_SensationXE_Beats_Z715a Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; en-ca; HTC_Flyer_P512_NA Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; en-gb; LT170 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; en-gb; bq DaVinci Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; en-us ; SPH-M930 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.2.2.139/145/355
+TV	Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; BNTV250A Build/GINGERBREAD) AppleWebKit/533.1 (KHTML
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; DROID2 GLOBAL A956 Build/4.5.1_57_D2GA-59) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; HTC ThunderBolt Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; HTC_Runnymede Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; Inspire 4g Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 androidAppVersion/2.0.3 AndroidWebkitWrapper
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; LG-E730 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.2
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; Lenovo A1-32AJ0 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; SAMSUNG GT-B5510 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; USCC-US855 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; e1107_v73_ddb1 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; es-es; ZTE-860U Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; ja-jp; 008Z Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; ko-kr; LG-su370 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; ru-ru; HTC_Flyer_P510e Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; ru-ru; USCCADR6230US Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; zh-cn; HTC Raider 4G with Beats Audio Build/GRJ22) UC AppleWebKit/530+ (KHTML, like Gecko) Mobile Safari/530
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; zh-cn; MOT-XT883/5.5.1-1_GC-49; 540*960; CTC/2.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.4; zh-cn; htccn_chs-HTC S610d Build/GINGERBREAD_MR1) AppleWebKit/533.1 (KHTML,like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5 us-en; USCC-ALCATEL-one-touch-988 Build/SlackerUA) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; -us; Mi363 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; En-US; Andi_4.3a Build/GRJ90) AppleWebKit/534.31 (KHTML, Like Gecko) UCBrowser/9.2.3.324 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; En-US; Coolpad 7019A Build/GRJ90) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; En-US; Lemon P9 Build/MocorDroid2.3.5) AppleWebKit/534.31 (KHTML, Like Gecko) UCBrowser/9.3.2.349 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; En-US; TCL_A966 Build/GRJ90) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; En-au; ZTE T28 Prepaid Build/GRJ22) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; En-in; Fly F40 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; En-us; Atlas W Build/GRJ22) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; En-us; Fly IQ238 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; En-us; Motorola Photon Build/4.5.1A_SUN_USC_19.0) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; En-us; Tmn Smart A7 Build/GRJ22) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; En-us; YL-Coolpad_7260 Build/GRJ90) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; Ja-jp; INFOBAR C01 Build/S1190) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; Pt-br ; GT-S5360B Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.3.0.143/145/352
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; Ug-; YL-Coolpad_5210S Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; Zh-cn; Coolpad 5210A Build/GRJ90) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1 Baiduboxapp/4.5.1 (Baidu; P1 2.3.5)
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; ar-eg; IQTALK Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; bn-bd; iris 401e Build/LAVA-iris401e-bengali-S103) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; de-ch; HTC/Explorer/1.29.166.3 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; de-de; ALCATEL ONE TOUCH 918N Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; de-de; Blade S Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; de-de; GT-S5570I Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; de-de; HTC ONE X Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; de-de; HTC-X315E Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; de-de; HTC_Desire_SMS Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; de-de; HUAWEI G7500 Build/HUAWEIG7500) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; de-de; Micromax A73 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; de-de; SGH-T679M Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; de-de; U8510 w/ EclipseROM Build/HuaweiU8510) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; de-de; V9A Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-; BLU Tigo Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-US; DROIDZ_Force Build/MocorDroid2.3.5) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.7.0.315 Mobile
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-US; PAP3500_DUO Build/GRJ90) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.7.0.337 Mobile
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-US; ZTE T12 Build/GRJ90) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.3.0.321 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-au; HTC_SensationXL_Beats_X315b Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-gb; Explay A350 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-gb; TCL A998 Build/TS-BF-AP-003) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-in; Micromax A54 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; Aqua T6 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; DASH MUSIC J101 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; DROID4 4G Build/6.5.1_73_DR4-218) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; HS-U2 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; HTC Inspire Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; Huawei-U8651 Build/HuaweiU8651B852) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; IQ238 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; MALATA Z100A Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; Motorola Atrix 4G MB860 Build/4.5.91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; VS8000 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; XT910K Build/6.5.1-8_SDK-31_LE-58) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; es-mx; ALCATEL_one_touch_995A Build/TS-BF-AP-003) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; pt-BR; Dell_Streak_Pro Build/GRJ90) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.7.0.315 Mobile
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; ru ; VitMod_ExtraLite 1.6.5.fullodex for HTC HD7 Pro Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.3.0.143/145/40
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; ru-ru; HTC_DesireS_S510e Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; ru-ru; TCL_A966_RUS Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; zh-CN; DOOV_D300 Build/MocorDroid2.3.5) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/8.8.3.278 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; A209 Build/GRJ90) AppleWebKit/530.17 (KHTML, like Gecko) FlyFlow/2.3 Version/4.0 Mobile Safari/530.17 baidubrowser/042_41.82.3.2_diordna_008_084/eebook_01_5.3.2_902A/1000346d/BE4726B724D7F6CCBA345CBFACA52008|
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; Coolpad 7005 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; HTC T9299+ Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; Light Tab 2W Build/GINGERBREAD) UC AppleWebKit/534.31 (KHTML, like Gecko) Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; YL-Coolpad 5218D Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; sprd-A1000/1.0 Android/2.3.5 Release/05.14.2013 Browser/AppleWebKit533.1 Build/MocorDroid2.3.5) AppleWebKit533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; sprd-iNote-mini/1.0 Android/2.3.5 Release/05.05.2013 Browser/AppleWebKit533.1 Build/MocorDroid2.3.5) AppleWebKit533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.5; zh-tw; XT532 Build/V4.240) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6 us-en; T-Mobile myTouch Q Build/SlackerUA) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; -gb; ALCATEL ONE TOUCH 985N Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; En-; SGH-T589W Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; En-IN; ZTE N788 Build/GRK39F) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; En-US; Aqua Trendy Build/GRK39F) AppleWebKit/534.31 (KHTML, Like Gecko) UCBrowser/9.0.2.299 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; En-US; E620 Build/GRK39F) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; En-US; IMO S78 Build/GRK39F) AppleWebKit/534.31 (KHTML, Like Gecko) UCBrowser/9.0.1.275 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; En-US; LEMON P7 Build/GRK39F) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; En-US; SCH-I919U Build/GRK39F) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; En-gb; ALCATEL ONE TOUCH 922 Build/GRK39F) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; En-us; Cloudfone ICE 2Gs Build/FSV06) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; En-us; HS-U820 Build/GRK39F) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; En-us; K-Touch_W610 Build/GRK39F) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; En-us; OPPOX9015 Build/GRK39F) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; En-us; Z788G Build/GRK39F) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; GT-S5830ide_DE Build/GINGERBREAD) AppleWebKit/ (KHTML, like Gecko) Version/ Mobile Safari/
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; Pt-pt; BLU_Elite_3.8 Build/GRK39F) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; ZTE V788D Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; Zh-tw; ZTE N789 Build/GRK39F) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; ar-; GT-S6802 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; ar-ae; YP-GI1 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; ar-eg; Aqua Sx Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; ar-eg; ONE TOUCH 4007D Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; bg-bg; GT-S5369 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; bg-bg; SAMSUNG GT-B5510/B5510XXLE1 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; bg-bg; SAMSUNG GT-I9070P/I9070PBOLK1 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; bg-bg; SAMSUNG GT-S5830i/S5830iXXLA4 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; bg-bg; XT389 Build/0C.03.05R_S) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; cs-cz; SAMSUNG GT-P1000/P1000BOJU3 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-; GT-I8160L Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-at; GT-S7500T Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-de; ALCATEL ONE TOUCH 918A Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-de; BLADEII Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-de; GT-B5512B Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-de; GT-I9070 Buile/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-de; GT-S5302B Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-de; GT-S5830C Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-de; GT-S5839i-ORANGE/S5839iBVLC3 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-de; HUAWEI U8661 Build/HuaweiU8661) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-de; LG-E400-Orange/V10g Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.2
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-de; MB626 Build/5.5.1Q-209) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-de; MyPhone A818 Slim Duo Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-de; SAMSUNG GT-I9070P/I9070PBOLE2 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-de; SAMSUNG SGH-I757M/I757MUGLCA Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-de; e1105_v73_gq1006_rtp Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-de; e1117_v73_jhgg Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; de-de; p720 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.0/1.2
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-; GT-S5690L Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-; ZTE N790 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-US; Andi 3.5i Build/GRK39F) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.0.1.275 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-US; HUAWEI_U8661 Build/HuaweiU8661) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.2.0.242 Mobile
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-US; Iris 349+ Build/MocorDroid2.3.5) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.0.1.275 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-US; Q-Smart S1 Build/GRK39F) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.2.3.324 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-US; VS8000 XL Build/GRK39F) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.0.1.275 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-ca; LG-E400b Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-gb; ALCATEL ONE TOUCH 916D Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-gb; Lenovo A60+ Build/LenovoLePhone) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-gb; U8185 Build/r0_dr-brand_hwu8185) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-us ; Andi4d Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.4.1.204/145/444
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-us ; HUAWEI Y210-0251 Build/HuaweiY210-0251) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.6.0.230/145/352
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-us ; M865C Build/HuaweiM865C) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.3.0.143/145/444
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; ALCATEL ONE TOUCH 991A Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; BLU-DASH 3.2 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; HS-U860 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; LG L38C Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; OPPOR803 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; Photon Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; T-Mobile myTouch Build/HuaweiU8680) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; ZTE N790S Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; i-mobile i-STYLE 2 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; es-mx; ALCATEL ONE TOUCH 985A Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; es-us; LG-LS696 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; in-id; HS-e910 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; pt-br; LG-E405f Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.2
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; ru-ru; Desire HD Build/HuaweiU8800pro) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; ru-ru; SAMSUNG GT-S5830i Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; ru-ru; USCCADR3305 Build/HuaweiM865) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; tr_TR; GT-S5360 BUILD/GINGERBREAD) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; zh-CN; HTC Touch S01 Build/GRK39F) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.1.0.297 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; ALCATEL OT 919 HelloKitty Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; HS-U930 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; JXD_P200 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) FlyFlow/2.5 Version/4.0 Mobile Safari/533.1 baidubrowser/061_3.9.5.2_diordna_084_023/spla_01_6.3.2_002P-DXJ/1000910i/858FDAE29653FD6589B2DC2FD0054B9E
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; OPPOLenovo P70 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; vivo S1 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7-Jeremy; zh-CN; Lenovo A668t Build/GWK74) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.2.4.329 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; En-US; HUAWEI T8828 Build/GWK74) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; Pt-br; XT560 Build/V1.66A) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; ar-; SonyEricssonST25i Build/6.0.B.3.184) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; ar-eg; u8600 Build/GWK74; CyanogenMod-7.2.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; de-; MOT-XT535 Build/V1.50A) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; de-de; DesireS Build/MIUI) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; de-de; HTC DESIRE HD Build/GRI40; SUNDAWG CM7) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; de-de; Huawei u8650 Build/Cyanogen for U8650; CyanogenMod-7.2.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; de-de; Liquid Mt Build/GRI40; CyanogenMod-7) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; de-de; SMP35-100 Build/3.0.1398_20130529) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; de-de; SonyEricssonST27a Build/6.0.B.3.184) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; de-de; ViewPhone3 Build/GWK74) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; en-; Micromax A51 Build/REL_2.3.12) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; en-au; LG-P940h Build/GWK74) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; en-gb; SonyEricssonSO-03D Build/6.0.A.5.12) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; HTC Evo 3D Build/GRJ22; CyanogenMod-7.1.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; U8665 Build/HuaweiU8665; CyanogenMod 7.2 Unofficial) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; XT502 Build/GRJ22; LeWa_V45_XT502_by_DuoDuo) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; es-es; lg-p350 Build/GRJ90; arc xp v1.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; fr-fr; U8818 Build/HuaweiU8818; CyanogenMod-7) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; it-it; X35 Build/REL_2.3.12) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; ru-ru; Sensation XE G18 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; zh-cn; HTC Droid Incredible 2 Build/MIUI) UC AppleWebKit/530+ (KHTML, like Gecko) Mobile Safari/530
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; zh-cn; S1-37AH0 Build/MIUI) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.7; zh-cn; lenovo a60 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.9; En-US; Celkon_A_85 Build/MocorDroid2.2.2) AppleWebKit/528.5+ (KHTML, Like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.7.0.315 Mobile
+Phone	Mozilla/5.0 (Linux; U; Android 2.3.ics by oscar ac zapata; es-ve; CM980 Build/SuperICSHuaweiCM980) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3; En-us; GIONEE A9 Build/FRF91) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3; Es-es; OnePAD 730 Build/GRH55) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3; en-gb; OnePAD 725 Build/GRH55) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3; en-us; Micromax A52 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 2.3;en-us; ViewSonic-ViewPad7e Build/ERE27) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 3.0.1; en-gb; VegaComb Build/HRI66) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
+Phone	Mozilla/5.0 (Linux; U; Android 3.0.1; ko-kr; LG-KU6900 Build/HRI61) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
+Phone	Mozilla/5.0 (Linux; U; Android 3.0.1; ru-ru; HTC Rhyme S510a Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 3.0; en-us; SPH-M828C Build/HONEYCOMB; HONEYCOMB PRECEDENT) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 3.1; En-us; Videocon A27i Build/HMJ25) AppleWebKit/534.13 (KHTML, Like Gecko) Version/4.0 Safari/534.13
+Phone	Mozilla/5.0 (Linux; U; Android 3.1; de-de; GT-P7500R Build/HMJ37) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
+Phone	Mozilla/5.0 (Linux; U; Android 3.1; el-gr; Dell Streak 10 Pro Build/HMJ37) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
+Phone	Mozilla/5.0 (Linux; U; Android 3.1; en-gb; ViewPad7x Build/HMJ29) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.13
+Phone	Mozilla/5.0 (Linux; U; Android 3.1; en-us; LG-V909 Build/HMJ37) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
+Tablet	Mozilla/5.0 (Linux; U; Android 3.1; fr-fr; Archos 80 Internet Tablet Build/HMJ37) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
+Phone	Mozilla/5.0 (Linux; U; Android 3.1; ru-ru; LG Optimus Pad L-06C Build/HMJ37) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
+Phone	Mozilla/5.0 (Linux; U; Android 3.2.1; en-us; Thrive Build/unknown) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
+Phone	Mozilla/5.0 (Linux; U; Android 3.2.1; ru-ru; ENOTJ145 Build/HTK75) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
+Phone	Mozilla/5.0 (Linux; U; Android 3.2; En-US; IdeaTab S2007A-D Build/XMFUK) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 3.2; bg-bg; MediaPad Build/HuaweiMediaPad) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
+Phone	Mozilla/5.0 (Linux; U; Android 3.2; de-de; SAMSUNG-GT-P7501/P7501BOLA1 Build/HTJ85B) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
+Phone	Mozilla/5.0 (Linux; U; Android 3.2; en-gb; GT-P7320-ORANGE/P7320BVLE1 Build/MASTER) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
+Phone	Mozilla/5.0 (Linux; U; Android 3.2; en-us; IdeaTab S2007A-F Build/MASTER) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
+Phone	Mozilla/5.0 (Linux; U; Android 3.2; en-us; Transformer TF201G Build/HTJ85B) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
+Phone	Mozilla/5.0 (Linux; U; Android 3.2; zh-cn; SCH-P739 Build/HTJ85B) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.13
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.1; de-de; S3 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.1; en-us; SPH-L700 Build/ICL23D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.1; ru-ru; HTC Inspire 4G For Vodafone Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.1; zh-cn; HTC HD7 Inspire 4G For Vodafone Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.2; ru-ru; HTC EVO 4G For Sprint Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; -; OPPOX907 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; Ar-eg; HTC_T120C Build/IML74K) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; En-US; DOOV_D7 Build/IML74K) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; En-US; SmartTab1 Build/IML74K) AppleWebKit/528.5+ (KHTML, Like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.7.0.315 Mobile
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; En-us; GIONEE S101 Build/IML74K) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; En-us; MFC270EN_09 Build/IML74K) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; En-us; SmartTab2 Build/IML74K) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; Pt-br; IBAK-796CAP Build/IML74K) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; Zh-cn; U10GT-A Build/IML74K) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; ar-eg; HTC_Desire_C/2.00.111.3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; ar-eg; PAD711 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; ar-eg; U18GT-W Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; bg-bg; AN7CG3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; bg-bg; SAMSUNG GT-P5100/P5100BUALD5 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; ca-es; T-701 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) FlyFlow/2.5 Version/4.0 Safari/534.30 baidubrowser/021_3.9.5.2_diordna_467_084/nwonknu_51_3.0.4_107-T/1000437a/5242F981109FFAA5A3719A53DF09C271|690194100718853/1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; da-dk; TAC-7028 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-at; HTC_One_S_pj40200/1.11.169.132 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-ch; HTC_One_V-orange-LS Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; AN10BG2I Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; AN8BG3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; DATAM819HD_A Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; GT-I9300-ORANGE/I9300BVALC2 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; H9000 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; HTC one S Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; HTC_EVO_3D_GSM_X515m Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; HTC_One_X/1.26.161.2 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; Haier HW-W718 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; Lenovo S868t Build/S-2-02) UC AppleWebKit/534.31 (KHTML, like Gecko) Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; MID06S Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; Micromax A90 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; SAMSUNG GT-I9100P/I9100PXXLPP Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; SonyEricssonGT-I9300 Build/4.1.A.0.562) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; TAB275 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; X825a Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; sprd-GT-N9300/1.0 Android/4.0.3 Release/04.11.2013 Browser/AppleWebKit533.1 Build/MocorDroid2.3.5) AppleWebKit533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; en-; MID7047(3G)-4G Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; en-US; HUAWEI_T8808D Build/HuaweiT8808D) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.7.0.315 Mobile
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; en-US; U9500E Build/HuaweiU9500E) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.2.0.308 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; en-au; T7038 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; en-gb; HTC ENR_U Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; en-gb; MID7047C 3G Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; en-in; iBall Slide 3G 7316 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; ASUS Transformer TF300T Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; B-Tab711 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; GOCLEVER TAB A101 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; HTC MyTouch 4G Slide Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Tablet	Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; KFOT Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; MFC155EN_09 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; SGH-I9000B Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+TV	Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; ZTE V970T Build/TMO_US_PV970TV1.0.0B10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; es-es; I9300 Galaxy SIII Build/MocorDroid4.0.3) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; GT-I9300= Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; ST8001 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-SU-760 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; ro-ro; AllviewSpeedSatelite Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; Acer E330 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; Sensation XL G21 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; tr-tr; SCH-I929 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 MYI/1.10
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; vi-vn; HTC_EVO 4G plus Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; zh-CN; TM-7037W Build/IML74K) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.1.0.297 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; HTC HD7S T9899+ Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; HTC X720d) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Mobile Safari/534.30; 360browser(securitypay,securityinstalled); 360(android,uppayplugin); 360 Aphone Browser (5.1.5)
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; MOTIN A9 Build/GRK39F) UC AppleWebKit/534.31 (KHTML, like Gecko) Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; Novo7_Aurora Build/IML74K; 1024*552) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.3\\n; de-de; SonyST23i Build/11.0.A.5.8) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4.purwanto; id-id; Andromax-C.purwanto Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; -us; SonyST21i Build/11.0.A.0.16) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; En-US; Celkon A62 Build/IMM76D) AppleWebKit/534.31 (KHTML, Like Gecko) UCBrowser/9.0.1.275 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; En-US; HUAWEI U8825D Build/IMM76D) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; En-in; GIONEE_Ctrl_V3 Build/IMM76D) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; En-us; I-mobile I-STYLE Q6 Build/IMM76D) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; En-us; USCC-US730 Build/IMM76L) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; Fr-fr; MID77C Build/IMM76D) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; Zh-cn; DOOV D360 Build/IMM76D) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; am-et; PHICOMM i370 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; ar-ae; SAMSUNG GT-S5301/S5301XXAMA3 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; ar-eg; M-MP715I Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; ar-eg; QMobile_A12 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; ar-eg; SonyEricssonLT28h Build/6.1.E.0.233) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; ar-lb; IncredibleS_S710e Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; bg-bg; M-MP707I Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; cs-cz; HTC_Desire_X/1.18.113.3 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; cs-cz; SAMSUNG GT-P7500/P7500BULP5 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-; Lenovo_A2107A-H Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-at; SonyST26iv Build/11.0.A.3.18) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-ch; SAMSUNG GT-I9300/I9300BUALF1 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; A702 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; AN7SP Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; BIRD A11C Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; BLU VIVO 4.3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Tablet	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; Cat Tablet Galactica 9.7CA Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Tablet	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; Cat Tablet StarGate 2 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; Dslide 704 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; Fly IQ440; Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; GT-N7005 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; GT-S7560M-parrot Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; HTC Explorer A310 Build/IMLK74; CyanogenMod-9) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; HTC_Desire_S_s510e Build/GRJ90) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; HTC_K2_UL/1.16.111.5 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; Iconia A501 Build/IMM76L; CyanogenMod-Tegraowners ICS ROM v170 (thor & digetx)) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; K-Touch W700+ Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; LENOVO A789-orange Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; Luna TAB374 Build/LunaTAB374) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; MID7117CM Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; MOT-GT-I9300 Build/6.7.2-180_SPU-19-TA-5) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; MOT-XT925 Build/7.7.1Q-78_VQU_LE-23) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; NXM727KC_CN Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; PAP5430 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; QMobile A8 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; SAMSUNG GT-P7320/P7320XXLPM Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; SP-100 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; Sony Xperia Z Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; SonyEricssonGT-I9000 Build/GINGERBREAD) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; SonyEricssonMk16i Build/4.1.B.0.587) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; SonyEricssonST27iv Build/6.1.1.B.1.10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; SonyLT30at Build/7.0.B.1.152) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; SonySOL21 Build/9.0.F.2.128) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; TOOKY T1981PLUS Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; ThL W1+ Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; U23GT Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; X-5 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; X920e Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; p707 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-; GIONEE_Gpad_G1 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Tablet	Mozilla/5.0 (Linux; U; Android 4.0.4; en-US; CONNECT 2G Build/HCL+ME+Tablet+CONNECT+2G) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.0.1.275 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-US; Cloudfone_Thrill_430g Build/IMM76D) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.7.0.315 Mobile
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-US; Lemon_Tab_LT29 Build/IMM76D) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.7.0.315 Mobile
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-US; Treq_3G_Basic_2 Build/IMM76D) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.8.1.351 Ponsel
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-US; iBall_Slide_3G_7334 Build/IMM76D) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.2.0.242 Mobile
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-ca; HS-7DTB6-8GB Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-en; HTC desire V Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; SCH-I705 4G Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; iBuddyConnectu2161_3G Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-ph; A898 duo Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; ADR6410LVW Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 TwonkyBeamBrowser/3.2.1-65 (Android 4.0.4; HTC ADR6410LVW Build/IMM76D)
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; ALCATEL ONE TOUCH 997A Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; BLU VIVO 4.65 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; DROIDZ Drive+ Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; GFIVE Glory Build/IMM76D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.4.1.362 U3/0.8.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; GT-S7568 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Glass 1 Build/IMM76L; 786362) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; HTC6435LVW 4G Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; IQ285 Turbo Build/Barvik) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; LG-p505 Build/IMM76L; CyanogenMod-1) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Lenovo p700i Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Dolphin/INT-1.0.9 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Micromax A89 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Novo 7 Aurora Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; PantechP8010 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 TwonkyBeamBrowser/3.4.5-300 (Android 4.0.4; PANTECH PantechP8010 Build/IMM76D)
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; SCH-L710 4G Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; SPH-L710 4G Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; TCL S800 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; X50 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; ZTE V9800 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; iris_430_Android Build/LAVAiris430) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; en-us;GiONEE-GN205H/S217 Build/IMM76D) AppleWebKit534.30(KHTML,like Gecko)Version/4.0 Mobile Safari/534.30 Id/5EC2CD1FCF4A3E4362966709A01FB7F3 RV/4.0.2 GNBR/1.2.1007 (securitypay,securityinstalled)
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; PAD705 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; fr-be; MIDC970 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; hr-hr; TPC-7121 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; id; Axioo_PICOpad_GIM Build/IMM76D) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.7.0.315 Ponsel
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; ja-jp; N-08D Build/A5001911) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; ko-kr; km-S220 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; pl-pl; Sony Xperia Neo V Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; pt-br; SK351 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; AP-102 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; Explay Informer 702 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0.4 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; One xs Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; ZTE V9 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; tr-tr; MIDC408 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; vi-vn; Q-Smart S20 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; zh-CN; MT788 Build/IRPMTD_6_02.47.00RPS) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.5.2.394 U3/0.8.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; Coolpad 5213 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; Dell streak 10 Pro Build/Dell streak 10 Pro) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; GN700W Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; HS-EG909 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baiduboxapp/042_1.4_diordna_008_084/esnesiH_51_4.0.4_909GE-SH/7300017a/2B2A31D51C3A89E23BD82625429734D0|E1aa2ed3300001a/1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; HUAWEI T8833 Build/HuaweiT8833) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; LG-lu6200/V20e Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; MOMO9_STAR Build/IMM76D; 800*432) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; SAMSUNG-SCH-I699I Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; ZTE N881E Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; lenovo-A1 pad Build/IMM76D) UC AppleWebKit/534.31 (KHTML, like Gecko) Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn;GiONEE-GN136/S239 Build/IMM76D) AppleWebKit534.30(KHTML,like Gecko)Version/4.0 Mobile Safari/534.30 Id/0A6A14A8FEDB062AFB97E16E63499BF3 RV/4.0.2 GNBR/1.2.1008 (securitypay,securityinstalled)
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.4; zh-tw; GN360 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) FlyFlow/2.3 Version/4.0 Mobile Safari/534.30 baidubrowser/042_1.41.3.2_diordna_008_084/SULPG_51_4.0.4_063NG/1000133d/D2576A9EED63E90DBD5F014FFA10F1EF|935900010992668/1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.6; en-us; GT-i9260 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.8; zh-cn; HTC Inspire 4G (LTE) Build/GRJ23) UC AppleWebKit/530+ (KHTML, like Gecko) Mobile Safari/530
+Phone	Mozilla/5.0 (Linux; U; Android 4.0.9; zh-cn; HTC X515e Build/HTC X515e) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.0; zh-cn; K-Touch W719 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 MicroMessenger/4.5.1.261
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; Ar-eg; POV_TAB-PROTAB26XL Build/JRO03C) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; En-US; HUAWEI Y300-0000 Build/JRO03C) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; En-us; SC-97JB Build/JRO03C) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; Fr-fr; ARCHOS 70b TITANIUM Build/JRO03H) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; ar-ae; SAMSUNG GT-I8190/I8190XXALJL Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; ar-eg; IMAGINE 7 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; ar-eg; QMobile_A7 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; bg-bg; GT-N7100-ORANGE/N7100XXALIJ Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; bg-bg; SonyEricssonC1505 Build/11.3.A.2.23) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; cs-cz; GOCLEVER TAB R76.1 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; cs-cz; TP10.1-1500DC kb Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-; Touchlet X10.dual+ Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-at; BLADE 90 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-ch; POV_TAB-P701(V1.0) Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; AT-AS45IPS Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; CnM TouchPad 7DC Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; E821 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; GT-I8190 DUO Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; Galaxy Ace Build/JELLYBEAN) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; HTC Saga Build/JRO03R; CyanogenMod-10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; HTC_OneXplus/1.14.161.1 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; Luna TAB10-150 Build/Luna TAB10-150) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; MI 2SC Build/JRO03L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; MK808 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; MOMO19 Build/MASTER) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; MT7007 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; NT-0901S Build/MASTER) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; Next800K Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; P530 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; POV_TAB-P1325 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; POV_TAB-PROTAB30-IPS10(V1.3) Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; RAPAX 070LE Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; SAMSUNG EK-GC100/GC100XXALJF Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; ST7001 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; Samsung-GT-I9150/1.0 Android/4.1.1 Release/06.09.2013 Browser/AppleWebKit533.1 Build/MocorDroid2.3.5) AppleWebKit533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; T-1006 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; TAC-90012 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; TP8-1200QC Build/MASTER) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; U1 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; U30GT mini Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; Woxter 97 IPS DUAL 3G Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; Z710 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; e1902_v77_jblw005 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; myTab 10 Dual Core Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; el-gr; MID9120 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; en-ca; SC-71MID Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; en-gb; Novo 7 Crystal Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; en-gb; TM-MID101N Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; en-sg; Nokia N9 Superphone Build/JRO03L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; AllviewCity Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; Galaxy S3 - 4.1.1 - API 16 - 720x1280 Build/JRO03S) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; JXD-P1000() Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; My|Phone A898 Duo Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; SCH-I605 4G Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; SGH-I535 4G Build/JRO03L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; es-es; HUAWEI U8950 Build/HuaweiU8950) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; es-es; SAMSUNG-I9505 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; es-es; bq Maxwell 2 Build/1.0.1_20130809-15:52) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; fa-ir; G4 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MID1014 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; hr-hr; SonyC1505v Build/11.3.A.2.13) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; it-it; ONE TOUCH EVO 7HD Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; ja-jp; HTX21 Build/JRO03C; KDDI; mediatap) 720X1184 HTC HTX21 AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; pl-pl; GOCLEVER HYBRID Build/GOCLEVER HYBRID) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; pt-pt; bq Maxwell 2 Plus Build/1.0.1_20130806-09:33) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; AP-803 Build/AP-803) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; Explay surfer 8.01 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; FreeTAB 1331 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; ImPAD 1412 rev2 Build/FR-MX68) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; POV_TAB-PROTAB30IPS10-3G_V1 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; U30GT2 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; uk-ua; AP704 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; zh-CN; HTC J Butterfly Build/JRO03C) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.3.0.321 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; zh-cn; HUAWEI G510-0010 Build/HuaweiU8951D Anzhi) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; zh-cn; SAMSUNG-GT-I9268_TD/1.0 Android/4.1.1 Release/08.30.2012 Browser/AppleWebKit534.30 Build/JRO03C) ApplelWebkit/534.30 (KHTML,like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.1; zh-tw; A08 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) FlyFlow/2.5 Version/4.0 Safari/534.30 baidubrowser/061_3.9.5.2_diordna_276_0821/moCobA_61_1.1.4_80A/1000286q/EFC05CC24A962AEF1610BC91E6FC6946|0/1
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; En-us ; I-mobile I-STYLE 7A Build/JZO54K) AppleWebKit/533.1 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.4.1.204/145/444
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; SM-T211de_DE Build/JZO54K) AppleWebKit/ (KHTML, like Gecko) Version/ Mobile Safari/
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; ar-; SonyLT22i Build/6.2.A.1.100) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; ar-ae; SAMSUNG GT-I8190N/I8190NXXALL4 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; ar-eg; MT6517 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; ar-eg; SonyLT28h Build/6.2.B.0.211) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; bg-bg; P400 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; cs-cz; GT-S6810P-ORANGE/S6810PXXAMB3 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-; HUAWEI G520-5000 Build/HuaweiG520-5000) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-ch; SAMSUNG GT-N5120/N5120XXBME1 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; ASUS A80 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; Connect-V3 Build/HCL) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; GT-I8730-ORANGE/I8730XWAMC2 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; GT-I9505+ Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; GT-S6310N-ORANGE/S6310NXXAME1 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; HTC-One/1.02.1401.1 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; HTC_PN07120/1.26.502.10 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; LG-D682TR Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; LG-E975-Orange Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; M-PPG700 Build/PhonePad) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; N-04E Build/A1000401) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; SAMSUNG GT-I8260/I8260XXAMG2 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; SCH-I829 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baiduboxapp/4.5.1 (Baidu; P1 4.1.2)
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; SonyEricssonC6503 Build/10.1.1.A.1.253) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; SonyLT26i-o Build/6.2.B.0.197) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; SonySGP321 Build/10.1.1.A.1.307) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; SonyXperia T Build/9.1.A.1.141) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; Xperia E Build/JZO54K; CyanogenMod-10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; ZP900s Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; i-mobile IQ5.1A Pro Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; en-US; Celkon_CT_910+ Build/JZO54K) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.2.0.242 Mobile
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; en-US; Xperia neo L Build/JZO54K) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.3.1.344 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; en-ca; SonyC6506 Build/10.1.A.1.308) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; en-gb; Panasonic T11 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; en-id; Picopad GFI Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; A57 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; Celkon CT 910 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; GT-I8268 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; HTC Desire 600c dual sim Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; Karbonn A10 Build/JZO54K) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.5.0.360 U3/0.8.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; MITO T330 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) FlyFlow/1.0 Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; PantechP8010 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 ACHEETAHI/2100050072
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; SGP312 Build/10.1.C.0.370) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 TwonkyBeamBrowser/3.4.3-103 (Android 4.1.2; Sony SGP312 Build/10.1.C.0.370)
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; Spice Mi-515 Build/4.1.003.130301.7295+; 540*960; CUCC/2.0) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; Xolo QC800 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; imo s99 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; es-cl; LG-E425j Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; es-es;Coolpad Flo Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.1 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; es-ve; CM990 Build/HuaweiCM990) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; in-id; SonyLT30p Build/9.1.A.0.489) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; ja-jp; dtab01 Build/HuaweiMediaPad) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; pl-pl; MT7013 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; ru-ru; Fly IQ4411 Quad Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; ru-ru; NT-3509M Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; us-en; Huawei Y301A2 Build/SlackerUA) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; zh-CN; Coolpad 5890 Build/JZO54K) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.4.2.365 U3/0.8.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; zh-CN; Lenovo A706 Build/JZO54K) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.5.0.360 U3/0.8.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; GT-S7562C Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; HS-EG929 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; HTC HD7S T9899pro For AT&T Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; HUAWEI C8813Q Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baidubrowser/4.0.7.10 (Baidu; P1 4.1.2)
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; HUAWEI Y321-C00 Build/HuaweiY321-C00) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; SAMSUNG-SM-G3508I_TD/1.0 Android/4.1.2 Release/10.15.2013 Browser/AppleWebKit534.30 Build/JZO54K) AppleWebkit/534.30 (KHTML,like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; SonyM35h Build/12.0.A.1.211) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn;GiONEE-GN181/GN181 Build/IMM76D) AppleWebKit534.30(KHTML,like Gecko)Version/4.0 Mobile Safari/534.30 Id/FCB3EE82B1D8E8F12C98794F18A7F1A5 RV/4.1.2 GNBR/1.5.6.ae (securitypay,securityinstalled)
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.8; en-us; HTC inspire 4G LTE Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.1.9; zh-cn; HTC Inspire 4G For AT&T Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.0 - Rus; es-es; CUBE U9GT 2--Nvidia Tegra T20 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.0; es-us; alcatel one touch 5035a Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; bg-bg; TOOKY K1 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; de-; DROIDZ Quad Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; de-de; AT-AS45q2 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; de-de; GT-I8245 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; de-de; Lenovo A656 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; de-de; MT6589 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; de-de; PAP7600DUO Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; de-de; ThL W9 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; de-de; i-mobile IQ 9A Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; de-de; v89_gq2002sc Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; Aqua HD Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; Motorola Photon 4G Build/4.5.1A_SUN_USC_19.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; Qmobile A500 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; ThL W100 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; ZTE Blade G2 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; es-es; AMOI N828 - Port to THL W100 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; hr-hr; v89_yp1hd_s4_true Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; M-PP2S500C Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; ru-ru; Fly IQ4412 Quad Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; vi-vn; iocean x7 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; HTC Rezound/G26 HD Build/GRK39F) UC AppleWebKit/534.31 (KHTML, like Gecko) Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; U707T Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn;GiONEE-E3T/E3T Build/IMM76D) AppleWebKit 534.30 (KHTML,like Gecko) Version/4.0 Mobile Safari/534.30 Id/5E2ED11B914BCE852962ADAF5620BE77 GNBR/2.1.2.h (securitypay,securityinstalled)
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; ar-ae; SAMSUNG SM-G350/G350XXUAMKB Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; ar-eg; GT-I9600 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; cs-cz; PAP3350DUO Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-; ZP820 Build/JDQ39) AppleWebKit/534.24 (KHTML, like Gecko) FlyFlow/3.1 Version/4.0 Mobile Safari/534.24 T5/2.0
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; A102 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; AT-AS40D2 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; Allview_Viva_H8 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; C1000 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; Find5 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 Maxthon
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; GT-B9150 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; GT-i9000 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; HTC ONE S Build/JDQ39E; CyanogenMod-10.1) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; HTC6500LVW 4G Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; IDEOS S7-10X Build/JDQ39E; CyanogenMod-10.1.1) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; JY-G3C Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; Lenovo A5500-H Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; M1013 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; MP707 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 (Mobile; afma-sdk-a-v6.4.1)
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; MyPhone Agua Storm Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; NT-0907S Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; PMP5785C3G_QUAD Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; POV_TAB-P925(V1.0) Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; RK3188 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Tablet	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; SAMSUNG SM-T311/T311XXUAMED Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; SonyC6833 Build/14.1.B.1.406) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; TAD-70091 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; U25GT_PRO Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; U9508 Build/JDQ39E) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 CyanogenMod/10.1/hwu9508
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; Xperia acro S Build/JDQ39E; CyanogenMod-10.1) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; Zopo 980 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; htc one Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; i-mobile i-STYLE 2.2 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; de-us; RC0719H Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-US; LAVA iRIS 504q Build/JOP40D) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.3.1.344 U3/0.8.0 Mobile Safari/534.31
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-ca; HUAWEI G730-U00 Build/HuaweiG730-U00) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+TV	Mozilla/5.0 (Linux; U; Android 4.2.2; en-gb; CloudPad 701tv Build/FSV01) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-gb; N9599 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-gb; SonyC6903 Build/14.1.G.2.257) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-in; Celkon A105+ Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-us ; TECNO H5 Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.4.1.204/145/33567
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; BLU STUDIO 5.0 II Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Celkon A15 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; GT-I9082) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.4.0.347 U3/0.8.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; HD2_LEO Build/JDQ39E) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 CyanogenMod/10.1.0/htcleo
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Karbonn A1* Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30/4.05d.1002.m7
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Lenovo S898t Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Micromax A47 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+TV	Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; POV_TV-HDMI-210 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; QMobile A170 Build/QMobileA170) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; SCH-R760ro.product.brand=Samsung Build/JDQ39; CyanogenMod-10.1) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; SonyM36h Build/10.3.1.A.0.244) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; TECNO M5 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Xperia A888 Duo Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; iris402P Build/iris402P) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; en-us;GiONEE-GN137/GN137 Build/IMM76D) AppleWebKit534.30(KHTML,like Gecko)Version/4.0 Mobile Safari/534.30 Id/95FAB51601ADC6E6E764E0A986D4EACC RV/4.2.1 GNBR/1.7.1.ao (securitypay,securityinstalled)
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; es-es; Woxter Funny Tab 80 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; es-es; bq Elcano 2 Quad Core Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; MFC181FR Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; id-id; MITO A50 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; TAB210 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; ko-kr; IM-A900S Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; ko-kr; SHW-M570S Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; Enjoy TE1 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; myTab 7 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; ro-ro; Malata SMBA9701 Build/JDQ39; CyanogenMod-10.1) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; IQ447 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; ViewPad 7Q Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; sr-rs; TPC-7100 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; uk-ua; AP-106 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; uk-ua; S3pro Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; HTC HTL22 Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.0.378 U3/0.8.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Coolpad 7231 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; GT-I9128E Build/JDQ39) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/4.9 (Baidu; P1 4.2.2)
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; HTC X515E 4GS Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; HUAWEI Y511-T00 Build/HUAWEIY511-T00) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Philips W8560 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; ViewPad 100Q Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; vivo Y11t Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.2.4; en-us; Nokia 3210 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.3.0; en-us; Andromax C Sulthan Rafi XPERIA Mod Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.3.1; de-de; Samsung Galaxy S4 Mega GT-I9200 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.3; de-de; ALCATEL ONETOUCH 6036Y Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.3; de-de; Galaxy S3 - 4.3 - API 18 - 720x1280 Build/JLS36G) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.3; de-de; PHICOMM CLUE C230 Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.3; de-us; HTC0P3P7 Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.3; en-us; ASUS K00S Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.3; en-us; SCH-I545L Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.3; ko-kr; SM-N750S Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.3; zh-CN; SM-N9009 Build/JSS15J) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.4.2.365 U3/0.8.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; MI 3C Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 XiaoMi/MiuiBrowser/1.0
+Phone	Mozilla/5.0 (Linux; U; Android 4.4.2; de-ch; HTC_One_M8/1.54.166.5 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.4.2; de-de; SM-G9008 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 4.4.2; ko-kr; LG-F350L Build/KOT49I.F350L10g) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.1599.103 Mobile Safari/537.36
+Phone	Mozilla/5.0 (Linux; U; Android 4.5.0 - Eng/Rus; ru-ru; U30GT-Nvidia Tegra3 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 5.0 - Eng/Rus; ru-ru; U20GT -Nvidia Tegra3 Build/U20GT) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 5.0.9; ar-eg; E701 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android 8.0.0; zh-cn; MIX 2 Build/OPR1.170623.027) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/MiuiBrowser/10.1.1
+Phone	Mozilla/5.0 (Linux; U; Android Cricket Eclair 2.1-update1; en-us; SAMSUNG Intercept SPH-M910 Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
+Phone	Mozilla/5.0 (Linux; U; Android Froyo 2.2.2 (V10F) by Snegovik; ru-ru; LG-P350 Optimus Me Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android GFIVE-4.0; de-de; GFIVE Blade (F500) Build/F500-V1.0-2013.01.28) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android Ice Cream Sandwich; in-id; SonyEricssonXperia neo L Build/4.1.B.0.587) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0 (Linux; U; Android WP7; de-de; GT-S5830 - Forum: http://forumgalaxyace.fora24.pl Build/GRWK74; WP7 by maniaczek1111) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	Mozilla/5.0 (Linux; U; Android4.1.1; de_DE; Vodafone 975N; Build/JRO03C) coolcherrytrees.games.reactor/59
+Phone	Mozilla/5.0 (Linux; U; Anfroid 2.3.6; es-us; GT-S5570L Bukld/GINGERBREAD)"AppleWebKit/533,1 (KHTML, like Eecko) Version/4,0 Mobile Safari-533.1
+Tablet	Mozilla/5.0 (Linux; U; en-us; KFAPWA Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.6 Safari/535.19 Silk-Accelerated=true
+Tablet	Mozilla/5.0 (Linux; U; en-us; KFTHWA Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.6 Safari/535.19 Silk-Accelerated=true
+Phone	Mozilla/5.0 (Linux; webOS/2.1.2; U; en-US) AppleWebKit/534.6 (KHTML, like Gecko) webOSBrowser/221.14 Safari/534.6 Pre/3.0
+Phone	Mozilla/5.0 (Linux;U;Android 2.3.5;en-us;TECNO T3 Build/master) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Computer	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36
+Computer	Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_7; HTC/DesireHD/1.39.161.1) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Safari/530.17
+Computer	Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; HTC_PH39100/%ROM_VERSION%; en-us) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16
+Computer	Mozilla/5.0 (Macintosh; U; Intel Mac OS X; de-AT; rv:1.8.1.4) Gecko/20070515 LG/481586400 Firefox/2.0.0.4
+Phone	Mozilla/5.0 (MeeGo; NokiaN950-00/00) AppleWebKit/534.13 (KHTML, Like Gecko) NokiaBrowser/8.5.0 Mobile Safari/534.13
+Phone	Mozilla/5.0 (Mobile; LYF/F300B/LYF-F300B-001-01-34-070519; Android; rv:48.0) Gecko/48.0 Firefox/48.0 KAIOS/2.5
+Unknown	Mozilla/5.0 (Mozilla/4.08 (frontbed;FOMA;like Gecko),gzip(gfe),gzip(gfe)
+Console	Mozilla/5.0 (Nintendo 3DS; U; ; En) Version/1.7552.EU
+Unknown	Mozilla/5.0 (Nokia N96)UC AppleWebkit(like Gecko) Safari/530
+Unknown	Mozilla/5.0 (Nokia5800 XpressMusic)UC AppleWebkit(like Gecko) Safari/530
+Unknown	Mozilla/5.0 (P01A;FOMA;like Gecko),gzip(gfe),gzip(gfe),gzip(gfe)
+Console	Mozilla/5.0 (PlayStation 3 1.50) AppleWebKit/536.26 (KHTML, like Gecko)
+Phone	Mozilla/5.0 (S60V3; U; Pt-br; NOKIA5500) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.6.0.199/28/352/UCWEB Mobile
+Phone	Mozilla/5.0 (S60V3; U; Pt-br; NOKIA6700s-1c)/UC Browser8.2.0.132/28/444/UCWEB Mobile
+Phone	Mozilla/5.0 (S60V3; U; Pt-br; NOKIA6760s-1) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.7.1.234/28/444/UCWEB Mobile
+Phone	Mozilla/5.0 (S60V3; U; Pt-br; NOKIAE62)/UC Browser8.2.0.132/28/352/UCWEB Mobile
+Unknown	Mozilla/5.0 (S60V3; U; Pt-br; NOKIAN85)/UC Browser8.4.0.159/28/352/UCWEB
+Phone	Mozilla/5.0 (S60V3; U; Pt-br; NOKIANokia N81 8GB)/UC Browser8.4.0.159/28/444/UCWEB Mobile
+Phone	Mozilla/5.0 (S60V3; U; ar-sa; NOKIA6720c) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.6.0.199/28/444/UCWEB Mobile
+Phone	Mozilla/5.0 (S60V3; U; en-in; NOKIA6700s)/UC Browser8.4.0.159/28/351/UCWEB Mobile
+Phone	Mozilla/5.0 (S60V3; U; en-in; NOKIAN92)/UC Browser8.2.0.132/28/444/UCWEB Mobile
+Phone	Mozilla/5.0 (S60V3; U; en-us; NOKIA6790s-1c) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.6.0.199/28/352/UCWEB Mobile
+Phone	Mozilla/5.0 (S60V3; U; es-la; NOKIA6790s-1b) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.6.0.199/28/352/UCWEB Mobile
+Phone	Mozilla/5.0 (S60V5; U; Pt-br; Nokia500)/UC Browser8.2.0.132/50/351/UCWEB Mobile
+Phone	Mozilla/5.0 (S60V5; U; Pt-br; Nokia808 PureView) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.7.1.234/50/444/UCWEB Mobile
+Phone	Mozilla/5.0 (S60V5; U; en-us; Nokia5230-c) AppleWebKit/530.13 (KHTML, like Gecko) UCBrowser/8.6.0.199/50/352/UCWEB Mobile
+Phone	Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5250/1.0; U; Bada/1.0; en-us) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WVGA SMM-MMS/1.2.0 OPN-B,gzip(gfe),gzip(gfe)
+Phone	Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5330/S5330XEJI8; U; Bada/1.0; ru-ru) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 NexPlayer/3.0 profile
+Phone	Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5380D/1.0; U; Bada/2.0; en-us) AppleWebKit/534.20 (KHTML, like Gecko) Dolfin/3.0 Mobile HVG
+Phone	Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5750E-Orange/S5750EAFKA2; U; Bada/1.0; fr-fr) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 NexPlayer/3.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B
+Phone	Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5753E/1.0; U; Bada/1.0; en-us) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 NexPlayer/3.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B
+Phone	Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5780D/S5780DXEKG2; U; Bada/1.1; ru-ru) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 NexPlayer/3.0 profi
+Phone	Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S7230E-BOUYGUES/S723EAGJK1; U; Bada/1.0; fr-fr) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 NexPlayer/3.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B
+Phone	Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S7230L/1.0; U; Bada/1.0; es) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 OPN-B
+Phone	Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S7250D/S7250DDDKK1; U; Bada/2.0; en-us) AppleWebKit/534.20 (KHTML, like Gecko) Dolfin/3.0 Mobile HVGA SMM-MMS/1.2.0 OPN-B
+Phone	Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S8500-VODAFONE/S8500AEJF1; U; Bada/1.0; en-us) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WVGA SMM-MMS/1.2.0 NexPlayer/3.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B
+Phone	Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S8500R/S8500RUXJF3; U; Bada/1.0; en-ca) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WVGA SMM-MMS/1.2.0 OPN-B
+Phone	Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S8530-VODAFONE/1.0; U; Bada/2.0; de-de) AppleWebKit/534.20 (KHTML, like Gecko) Dolfin/3.0 Mobile WVGA SMM-MMS/1.2.0 OPN-B
+TV	Mozilla/5.0 (SAMSUNG; SAMSUNG-SMART-TV; U; Linux/SmartTV) AppleWebKit/531.2+ (KHTML, like Gecko) WebBrowser/1.0 SmartTV Safari/531.2+
+Unknown	Mozilla/5.0 (Series30Plus; Nokia206a/01.19.11; Profile/Series30Plus Configuration/Series30Plus) Gecko/20100401 S40OviBrowser/3.8.0.8.1
+Unknown	Mozilla/5.0 (Series40/3.0FP1; Nokia3110c/07.30; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/null
+Unknown	Mozilla/5.0 (Series40/3.0FP1; Nokia5610d-1/06.60; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/0.8.3
+Unknown	Mozilla/5.0 (Series40/3.0FP1; SonyEricssonW300i/R4GB001; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/null
+Unknown	Mozilla/5.0 (Series40; Nokia113/03.09; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40Ov
+Unknown	Mozilla/5.0 (Series40; Nokia301.1/02.03b; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/2.3.0.0.48
+Unknown	Mozilla/5.0 (Series40; Nokia3720c/09.10; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/1.5.0.34.11
+Unknown	Mozilla/5.0 (Series40; Nokia502/11.1.1/java_runtime_version=Nokia_Asha_1_1_1; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/3.1.1.0.27
+Unknown	Mozilla/5.0 (Series40; Nokia6500s-1/04.81; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/1.8.0.50.5
+Unknown	Mozilla/5.0 (Series40; NokiaAsha230SingleSIM/13.5.2/java_runtime_version=Nokia_Asha_1_1_1; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/3.1.1.0.27
+Unknown	Mozilla/5.0 (Series40; NokiaC2-02.1/06.52; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/1.8.0.50.5
+Unknown	Mozilla/5.0 (Series40; NokiaX2-01.1/07.10; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/1.0.2.26.6
+Unknown	Mozilla/5.0 (Symbian/3; Series60/5.2 Nokia808PureView/112.020.0309; Profile/MIDP-2.1 Configuration/C
+Phone	Mozilla/5.0 (Symbian/3; U; 500; ar-AE) AppleWebKit/534.3 (KHTML, like Gecko) Shazam Mobile Safari/534.3
+Phone	Mozilla/5.0 (Symbian/3; U; E7-00; de-DE) AppleWebKit/534.3 (KHTML, like Gecko) Qt/4.7.4 Mobile Safari/534.3
+Phone	Mozilla/5.0 (Symbian; U; 603; de-DE) AppleWebKit/534.3 (KHTML, like Gecko) Shazam Mobile Safari/534.3
+Phone	Mozilla/5.0 (Symbian; U; de-DE) AppleWebKit/534.3 (KHTML, like Gecko) GPSInfoQtApp148/1.0 (Nokia; Qt) Mobile Safari/534.3
+Unknown	Mozilla/5.0 (SymbianOS/9.1; Series60/3.0 NokiaN80-1/3.0; Profile/MIDP-2.0 Configuration/CLDC-1.1) AppleWebKit/413 (KHTML, like Gecko) Safari/413
+Unknown	Mozilla/5.0 (SymbianOS/9.2 U Series60/3.1 NokiaN76-1/20.0.041 Profile/MIDP-2.0 Configuration/CLDC-1.1 ) AppleWebKit/413 (KHTML, like Gecko) Safari/413
+Unknown	Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 1.0/SamsungSGHi560/I560DFHC1 Profile/MIDP-2.0 Configuration/CLDC-1.1 ) AppleWebKit/413 (KHTML, like Gecko) Safari/413
+Unknown	Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 NOKIAN81 8GB/1.0; Profile/MIDP-2.0 Configuration/CLDC-1.1) AppleWebKit/413 (KHTML, like Gecko) Safari/413
+Unknown	Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 NokiaE51-1/007.26.04; Profile/MIDP-2.0 Configuration/CLDC-1.1 ) AppleWebKit/413 (KHTML, like Gecko)
+Unknown	Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 Samsung-SGH-i550/AOGL2 Profile/MIDP-2.0 Configuration/CLDC-1.1 ) AppleWebKit/413 (KHTML, like Gecko) Safari/413
+Unknown	Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 Samsung/SGH-i450/XEGK5 Profile/MIDP-2.0 Configuration/CLDC-1.1 ) AppleWebKit/413 (KHTML, like Gecko) Safari/413
+Unknown	Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 Samsung/SGH-i520V/BUGD9 Profile/MIDP-2.0 Configuration/CLDC-1.1 ) AppleWebKit/413 (KHTML, like Gecko) Safari/413
+Unknown	Mozilla/5.0 (SymbianOS/9.3 U Series60/3.2 Nokia5730s-1/1.00.000 Profile/MIDP-2.1 Configuration/CLDC-1.1) AppleWebKit/413(KHTML, like Gecko)Safari/413
+Unknown	Mozilla/5.0 (SymbianOS/9.3; Series60/3.2 NokiaE52-2/031.012; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/525 (KHTML, like Gecko) Version/3.0 BrowserNG/7.1.5
+Unknown	Mozilla/5.0 (SymbianOS/9.3; U; Ser ies60/3.2 NokiaN85-3/1.00 Profile/MIDP-2.0 Configurat ion/CLDC-1.1) AppleWebKit/413 (KHTML, like Gecko) Saf ari/413
+Unknown	Mozilla/5.0 (SymbianOS/9.3; U; Series60/3.2 Nokia6210Navigator/03.03.1; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/413 (KHTML, like Gecko) Safari/413
+Unknown	Mozilla/5.0 (SymbianOS/9.3; U; Series60/3.2 NokiaN78-2/1.00 Profile/MIDP-2.0 Configuration/CLDC-1.1) AppleWebKit/413 (KHTML, like Gecko) Safari/413
+Unknown	Mozilla/5.0 (SymbianOS/9.3; U; Series60/3.2 Samsung/I8510L/UBHL3 Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/413 (KHTML, like Gecko) Safari/413
+Unknown	Mozilla/5.0 (SymbianOS/9.4 U Series60/5.0 SonyEricssonP100/01 Profile/MIDP-2.1 Configuration/CLDC-1.1) AppleWebKit/525 (KHTML, like Gecko) Version/3.0 Safari/525
+Unknown	Mozilla/5.0 (SymbianOS/9.4; Series60/5.0 Nokia5230-1d/20.4.005; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/525 (KHTML, like Gecko) Version/3.0 BrowserNG/7.2.3
+Unknown	Mozilla/5.0 (SymbianOS/9.4; Series60/5.0 NokiaC5-p3/11.0.024; Profile/MIDP-2.1 Configuration/CLDCm1.1 ) AppleWebKit/525 (KHTML, like Gecko) Version/3.0 BrowserNGo7.2.6.9 3gpp-gba
+Unknown	Mozilla/5.0 (SymbianOS/9.4; Series60/5.0 Nokiae63-1/12.0.024; Profile/MIDP-2.1 Configuration/CLDC-1.1; en-us) AppleWebKit/525 (KHTML, like Gecko) BrowserNG/7.1.12344
+Unknown	Mozilla/5.0 (SymbianOS/9.4; U; Series60/5.0 Nokia5800-1/40.0.001 Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/525 (KHTML, like Gecko) Version/3.0 Safari/525
+Unknown	Mozilla/5.0 (SymbianOS/9.4; U; Series60/5.0 SonyEricssonU1i/R1BB; Profile/MIDP-2.1 Configuration/CLDC-1.1) AppleWebKit/525 (KHTML, like Gecko) Version/3.0 Safari/525
+Tablet	Mozilla/5.0 (Tablet; rv:29.0) Gecko/29.0 Firefox/29.0
+Unknown	Mozilla/5.0 (Vodafone/1.0/LG-BL40/V10a Browser/Obigo-Q7.3 MMS/LG-MMS-V1.0/1.2 MediaPlayer/LGPlayer/1.0 Java/ASVM/1.1 Profile/MIDP-2.1 Configuration/CLDC-1.1)
+Unknown	Mozilla/5.0 (Vodafone/1.0/LG-GT400/V10c Browser/Teleca-Q7.1 MMS/LG-MMS-V1.0/1.2 MediaPlayer/LGPlayer/1.0 Java/ASVM/1.1 Profil
+Unknown	Mozilla/5.0 (Vodafone/1.0/LG-KM900/V10l Browser/Obigo-Q7.1 MMS/LG-MMS-V1.0/1.2
+Phone	Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 630) like Gecko
+TV	Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.47 Safari/537.36 CrKey/1.36.159268
+Computer	Mozilla/5.0 (X11; Linux x86_64; HTC_DesireHD_Beats_X315e; de-de) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.34 Safari/534.24
+Computer	Mozilla/5.0 (X11; Linux x86_64; Quest 2) AppleWebKit/537.36 (KHTML, like Gecko) OculusBrowser/26.2.0.0.10 SamsungBrowser/4.0 Chrome/110.0.5481.192 VR Safari/537.36
+Computer	Mozilla/5.0 (X11; Linux) AppleWebKit/534.34 (KHTML, like Gecko) QtCarBrowser Safari/534.34
+TV	Mozilla/5.0 (X11; U; Linux i686; en-US) AppleWebKit/534.0 (KHTML, like Gecko) HbbTV/1.1.1 (+DL+PVR; inverto; IDL-6650N Volksbox; 1.0; 1.0;) hdplusinteraktiv/1.0 (NETRANGEMMH;)  CE-HTML/1.0
+Computer	Mozilla/5.0 (X11; U; SunOS i86pc; en-US; rv:1.8.0.5) Gecko/20060728 Firefox/1.5.0.5
+Phone	Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch)
+Unknown	Mozilla/5.0 (compatible; MSIE 6.0; BREW 4.0.3; en )/800x480 Samsung sam-r900
+Phone	Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; Acer; Allegro)
+Phone	Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; HTC; X310e)
+Phone	Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; LG; lg-e900)
+Phone	Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; SUMSUNG; OMNIA 7)
+Phone	Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; ZTE; Windows Phone - Internet 7; SFR)
+Computer	Mozilla/5.0 (compatible; OSS/1.0; Chameleon; Linux) MOT-E8/R6713_G_71.02.07R BER/2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	Mozilla/5.0 (compatible; Teleca Q7; Brew 3.1.5; U; en) 240X400 LGE AX840
+Phone	Mozilla/5.0 (compatible; msie 9.0; windows phone os 7.5; trident/5.0; iemobile/9.0; samsung; sgh-i917)
+Tablet	Mozilla/5.0 (iPad2,7; iOS 7.0.3) FreeWheelAdManager/5.8.3-r10206-201309100316;com.vevo.iphone VEVO/6025
+Tablet	Mozilla/5.0 (iPad; CPU OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Mobile/11A465 [FBAN/FBIOS;FBAV/8.0.0.28.18;FBBV/1665515;FBDV/iPad2,3;FBMD/iPad;FBSN/iPhone OS;FBSV/7.0;FBSS/1; FBCR/Verizon;FBID/tablet;FBLC/de_DE;FBOP/1]
+Phone	Mozilla/5.0 (iPhone3,1; iOS 6.1.3) FreeWheelAdManager/5.3.0-r9485-201301220720;com.cnn.iphone CNN/4254
+Phone	Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Pandora/1904.1.1
+Phone	Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1 like Mac OS X; HW iPhone1,1; de_de) AppleWebKit/525.18.1 (KHTML, like Gecko) (AdMob-iSDK-20090617)
+Tablet	Mozilla/5.0 (iPod touch; CPU iPhone OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13F69
+Computer	Mozilla/5.0 LG-GM750 Browser/IE8.12 MMS/LGMMSv1.0/1.2 Java/LGVM/1.1 Profile/MIDP-2.1 Configuration/CLDC-1.1 (compatible; MSIE 4.01; Windows CE; PPC)/UC Browser7.8.0.95
+Unknown	Mozilla/5.0 SAMSUNG-GT-S8003/1.0 SHP/VPP/R5 Bada/1.0 Nextreaming SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1
+Phone	Mozilla/5.0(Linux;U; Android 4.0.4; de-de;NEC-0912 Build/A8212300)AppleWebKit/534.30(KHTML, Like Gecko)Version/4.0 Mobile Safari/534.30
+Phone	Mozilla/5.0(Linux;U;Android2.1-update1;de-de;SonyEricssonE10iBuild/2.1.1.C.0.0)AppleWebKit/530.17(KHTML,likeGecko)Version/4.0MobileSafari/530.17
+Phone	Mozilla/5.0(Linux;U;Android2.2.1;Zh_cn;SAMSUNG-SGH-I997;480*800;)AppleWebKit/528.5+ (KHTML) Version/3.1.2/UCWEB7.8.0.95/139/352
+Phone	Mozilla/5.0(YAdSDK; 1.9.2.1); (Linux; U; Android 4.0.3; SAMSUNG GT-I9100 Build/ICE_CREAM_SANDWICH_MR1);
+Unknown	Mozilla/5.0+(Series40;+Nokia311/03.81;+Profile/MIDP-2.1+Configuration/CLDC-1.1)+Gecko/20100401+S40OviBrowser/2.0.2.68.13.1
+Unknown	Mozilla/5.0_(SymbianOS/9.4;_U;_Series60/5.0_Samsung/I8910;_Profile/MIDP-2.1_Configuration/CLDC-1.1_)_AppleWebKit/525_(KHTML,_like_Gecko)_Version/3.0_Safari/525
+Phone	Mozzila/5.0(Linux; U; Android 2.3.5; ru-ru; Fly IQ239 Build/JZ054K) AppleWebKit/533.1(KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
+Phone	NANaverNDrive/3.0.0(Android OS 4.2.2;samsung SHV-E300L)
+Unknown	NOKIA /C13JBIB2 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0
+Unknown	NOKIA-2320 CLASSIC
+Unknown	NOKIA-6236i UP.Browser/6.2.3.2 (GUI) MMP/2.0
+Unknown	NOKIA-RH-17/V F100V0400.nep.0 UP.Browser/4.1.26l1
+Unknown	NOKIA-RH-48/V J100V0700.nep.0 UP.Browser/6.2.2.1.c.1.102 (GUI) MMP/2.0
+Unknown	NOKIA2630/2.0 (05.61) PROFILE/MIDP-2.1 CONFIGURATION/CLDC-1.1
+Phone	NaverCafe/3.1.6 (Android OS 4.0.4; samsung SHW-M380S; NaverCafe; 3.1.6)
+Unknown	NetFront/3.5.1 (BREW 3.1.5; U; en-us; LG; NetFront/3.5.1/WAP) Sprint LN240 MMP/2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	NetFront/3.5.1(BREW 3.1.5; U; en-us; SAMSUNG; NetFront/3.1.5/WAP) PLS-M350 MMP/2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	Nokia 1680 classic
+Unknown	Nokia 3555
+Unknown	Nokia 6122c
+Unknown	Nokia 7100 Supernova
+Unknown	Nokia Booklet Software Updater
+Unknown	Nokia N-Gage
+Unknown	Nokia PC Suite Update Manager
+Unknown	Nokia-1606 UP.Browser/6.3.0.8.c.1.101 (GUI) MMP/2.0
+Unknown	Nokia100/2.0 (2.0423.0_rc02) SymbianOS/7.0s Series60/2.1 Profile/MIDP-2.0 Configuration/CLDC-1.0
+Unknown	Nokia1680c-2b/06.82 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	Nokia2112/1.0 (O100V0300.nep) UP.Browser/4.1.26l1 UP.Link/1.1
+Unknown	Nokia2322c_CMCC/2.0 (08.20) Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	Nokia2692_CMCC/2.0 (10.10) Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	Nokia2855i/2.0 (VR125C0001.nep) UP.Browser/6.2.3.8 MMP/2.0
+Unknown	Nokia3120b/1.0 (05.01) Profile/MIDP-1.0 Configuration/CLDC-1.0
+Unknown	Nokia3510iB/1.0 (03.40) Profile/MIDP-1.0 Configuration/CLDC-1.0 UP.Link/5.1.1a
+Unknown	Nokia3720classic/2.0 (cor6.53SSC) Profile/MIDP-2.1 Configuration/CLDC-1.1 Mozilla/5.0 AppleWebKit/420+ (KHTML, like Gecko) Safari/420+
+Unknown	Nokia5330-1d/5.0 (06.80) Profile/MIDP-2.1 Configuration/CLDC-1.1 Mozilla/5.0 AppleWebKit/420+ (KHTML, like Gecko) Safari/420+
+Unknown	Nokia5630XpressMusic/GoBrowser/1.6.91
+Unknown	Nokia5800XpressMusic-0176293f18c1d81faf42f9dde2aa0ad8 3gpp-gba
+Unknown	Nokia6120cAP01.02/SymbianOS/9.1 Series60/3.0
+Unknown	Nokia6165i/2.0 (AZ125V1100.nep) UP.Browser/6.2.3.8 MMP/2.0
+Unknown	Nokia6235i/1.0 (S190V0200.nep) UP.Browser/6.2.3.2 MMP/2.0
+Unknown	Nokia6340i/1.2.1 (8.04.1) Profile/MIDP-1.0 Configuration/CLDC-1.0 UP.Link/5.1.2.1
+Unknown	Nokia6650x/1.0 Profile/MIDP-1.0 Configuration/CLDC-1.0
+Unknown	Nokia7210c/2.0 (05.60) Profile/MIDP-2.1 Configuration/CLDC-1.1 UNTRUSTED/1.0
+Unknown	Nokia8800a/2.0 (09.45) Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	Nokia9210/1.0 Symbian-Crystal/6.0
+Unknown	NokiaC5002/3.00(0)ActiveSync 3gpp-gba
+Unknown	NokiaE65-1 Orange/1.0 (1.0633.18.02) SymbianOS/9.1 Series60/3.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Computer	NokiaMapsWP7/1.0.45.86 (Microsoft Windows CE 7.10.81077.10.8107; NOKIA; Lumia 800; de-DE)
+Unknown	NokiaN73-5/3.0628.0.0.6 Series60/3.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	NokiaN86_8MP/GoBrowser/1.6.0.4868.208.92;
+Unknown	NokiaN97_mini/GoBrowser/1.6.0.48
+Unknown	NokiaX3-02i/5.0 (p) Profile/MIDP-2.1 Configuration/CLDC-1.1 Mozilla/5.0 AppleWebKit/420+ (KHTML, like Gecko) Safari/420+
+Unknown	Nokia_C5-03_NokiaQTShop 3gpp-gba
+Unknown	OneBrowser/3.0 (SAMSUNG GT-E2152L)
+Unknown	OneBrowser/3.0 (SonyEricssonK310a/R4DA044)
+Unknown	OneBrowser/3.0 (SonyEricssonZ610i/R1KH001)
+Unknown	OneBrowser/3.1 (SAMSUNG SGH-D780)
+Unknown	OneBrowser/3.1 (SAMSUNG-GT-C3313T)
+Unknown	OneBrowser/3.1 (SAMSUNG-GT-I6230/I6230VOJD2)
+Unknown	OneBrowser/3.1 (SAMSUNG-GT-S7350i/S735IJPJE6)
+Unknown	OneBrowser/3.1 (SAMSUNG-SGH-A847M/A847BMJK4)
+Unknown	OneBrowser/3.1 (SonyEricssonC905/R1FA035)
+Unknown	OneBrowser/3.1 (SonyEricssonK790c/R8BA024)
+Unknown	OneBrowser/3.1 (SonyEricssonU100i/R7AA076)
+Unknown	OneBrowser/3.1 (SonyEricssonZ310a/R1JC002)
+Unknown	OneBrowser/3.2 (SonyEricssonW800c/R1AA008)
+Computer	Opera (Linux; U; 4.0.4; zh-cn; PantechP8010; 540*888) UCWEB7.9.0.94/139/444
+Unknown	Opera Mini 4/SonyEricssonK800iv/R1ED Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+TV	Opera/10.60 (Linux sh4 ; U; HbbTV/1.1.1 (+PVR; Loewe; SL121; LOH/3.10;;) CE-HTML/1.0 Config(L:deu,CC:DEU); en) Presto/2.6.33 Version/10.60
+Console	Opera/9.00 (Nintendo Wii; U; ; 1038-58; Wii Internet Channel/1.0; en)
+Computer	Opera/9.02 (Linux armv7l; U; ARCHOS; GOGI; G6S; Version 1.1.1    (WMDRMPD: 10.1); en)
+Computer	Opera/9.5 (Windows CE 5.2; SAMSUNG-GT-i8000/BOIL4 profile/MIDP-2.0 configuration/CLDC-1.1 (Windows CE; Opera Mobi; U; en) Opera 9.5; U; de)
+Unknown	Opera/9.60 (J2ME/MIDP;Opera Mini/4.2.13337/503; U; ru)Presto/2.2.0;SAMSUNG-GT-S3600i/S3600iXXIL2 Profile/MIDP-2.0 Configuration/CLDC-1.1 Untrusted/1.0
+Unknown	Opera/9.80 (BREW; Opera Mini/5.0.0043/18.1318; U; en) Presto/2.4.15 240X320 Samsung SCH-U380
+Unknown	Opera/9.80 (BREW; Opera Mini/5.0/27.2338; U; en) Presto/2.8.119 240X320 LG VN250g SCH-U485
+Unknown	Opera/9.80 (BREW; Opera Mini/5.1.180/26.1474; U; en) Presto/2.8.119 320X240 Pantech TXT8045
+Unknown	Opera/9.80 (BREW; Opera Mini/5.1.191/26.1521; U; en) Presto/2.8.119 400X240 LG VN2710U380
+Unknown	Opera/9.80 (BREW; Opera Mini/5.1.191/27.1591; U; en) Presto/2.8.119 400X240 LG VN271roid
+Unknown	Opera/9.80 (BREW; Opera Mini/5.1/27.2213; U; en) Presto/2.8.119 240X400 LG VN27181
+Unknown	Opera/9.80 (BREW; Opera Mini/5.1/27.2213; U; en) Presto/2.8.119 240X400 Pantech CDM8992d
+Unknown	Opera/9.80 (BREW; Opera Mini/5.1/27.2213; U; en) Presto/2.8.119 400X240 LG VN271C781U38085
+Unknown	Opera/9.80 (BREW; Opera Mini/5.1/27.2329; U; en) Presto/2.8.119 240X400 Pantech CDM8992485son J108i
+Phone	Opera/9.80 (BREW; Opera Mini/6.0.3/27.2314; U; en) Presto/2.8.119 240X320 Samsung SCH-U380Phone
+TV	Opera/9.80 (Linux 7405b0-smp; U; HbbTV/1.1.1 (; Humax; HD-FOX C; 1.00.01; 1.0; ); ce-html/1.0; en) Presto/2.9.167 Version/11.50
+TV	Opera/9.80 (Linux armv6l; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;IKEA LF1V362; en) Presto/2.10.250 Version/11.60
+TV	Opera/9.80 (Linux armv7l;  HbbTV/1.1.1 (; Philips; ; ; PHILIPSTV; ) CE-HTML/1.0 NETTV/4.3.1 PHILIPSTV/2.1.1 Firmware/003.001.000.001 (PhilipsTV, 2.1.1,) en) Presto/2.12.362 Version/12.11
+TV	Opera/9.80 (Linux armv7l; InettvBrowser/2.2 (00014A;SonyDTV115;0002;0100) KD55X9005A; CC/DEU) Presto/2.12.362 Version/12.11
+TV	Opera/9.80 (Linux armv7l; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;Vendor/THOM;SW-Version/V8-MT51F01-LF1V307;Cnt/DEU;Lan/bul) Presto/2.12.362 Version/12.11
+TV	Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL22EX320; PKG4.017EUA; 2011;);; en) Presto/2.7.61 Version/11.00
+TV	Opera/9.80 (Linux sh4; HbbTV/1.2.1 (+PVR; Loewe; SL220; LOH/2.1.36.0;;) CE-HTML/1.0 Config(L:deu,CC:DEU) NETRANGEMMH) Presto/2.12.362 Version/12.10
+TV	Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (; INTEK; Vantage Full HD Model;;;) hdplusSmartTV/1.0 (NETRANGEMMH;) Bee/3.2 CE-HTML/1.0; FXM-U2FsdGVkX19Qg/USD6FU3img+tXTDE7V5tSiPuMpHRrd3vp0JyPLfoYS/+dL6w/H-END; en) Presto/2.10.250 Version/11.60
+TV	Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (;;;;;); CE-HTML; TechniSat Digit ISIO S International; de) Presto/2.9.167 Version/11.50
+Phone	Orca-Android/2.0.4-release OS/2.3.5 Model/HTC_Desire_HD_A9191 VersionCode/59200 Product/Messenger Carrier/o2_-_de
+Phone	Orca-Android/2.2.5-release OS/4.0.3 Model/IdeaTab_A2107A-H VersionCode/108531 Product/Messenger Carrier/o2_-_de Manufacturer/LENOVO Brand/Lenovo
+Unknown	PANTECH-C180/R01 Browser/Obigo/Q03c
+Unknown	PANTECH-C570/R01 Browser/Obigo/Q05A Profile/MIDP-2.0 Configuration/CLDC-1.1,gzip(gfe)
+Unknown	PANTECH-P1010/R01 Browser/Obigo/Q03C Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	PIAWindows/1.0 Name/HTC-Kaiser Software/5.2.19214 appMode/2
+Phone	Palm680/RC1 (iPhone; U; CPU iPhone OS 2_2_1 like Mac OS X; zh-cn) AppleWebKit/525.18.1 (KHTML, like Gecko) Version/3.1.1 Mobile/5G77 Safari/525.20/UCWEB7.9.0.94/41/800
+Unknown	PantechP5000/JTUS07082013 BMP/1.0.2 DeviceId/141025 NetFront/4.1 OMC/1.5.3 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	PantechP7040/JLUS04042011 Browser/Obigo/Q05A OMC/1.5.3 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	Philips E210/Obigo Browser wap2.0
+Unknown	Philips X503/MTK 6235.09A 09.32/WAP-2.0/MIDP-2.0/CLDC-1.1
+Unknown	PhilipsK700/Obigo Browser 2.0
+Unknown	PhilipsX503/MTK 6235.09A 09.32/WAP-2.0/MIDP-2.0/CLDC-1.1
+Unknown	PhilipsX703/Obigo Browser 2.0
+Computer	QQBrowser (Linux; U; zh-cn; HTC Hero Build/FRF91)
+Phone	RhythmDisplayAdSDK-E-Android HTC One X-4.0.3-43074
+Phone	RhythmDisplayAdSDK-E-Android LG-E739-2.3.6-43074
+Phone	RhythmDisplayAdSDK-E-Android LG-VS700-2.3.4-43074
+TV	Roku/DVP-5.0 (025.00E08043A)
+Unknown	SAMSUNG E1360
+Unknown	SAMSUNG GT-S3570
+Unknown	SAMSUNG SCH-I920
+Unknown	SAMSUNG SGH-E251, SAMSUNG-SGH-E251/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.102 (GUI) MMP/2.0 Untrusted/1.0
+Unknown	SAMSUNG SGH-M200 UCWEB/6.0,SAMSUNG-SGH-M200/M200DDHK1 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.102 (GUI) MMP/2.0 Untrusted/1.0
+Phone	SAMSUNG-ANDROID-MMS/GT-I8190N
+Unknown	SAMSUNG-B2100MIDP/2.0CLDC/1.1
+Unknown	SAMSUNG-C5212i/C5212
+Unknown	SAMSUNG-E1310M/E1310MBAID6 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0
+Unknown	SAMSUNG-E2100L/1.0 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0
+Unknown	SAMSUNG-GT-B2100i/B2100iXXMD5 NetFront/4.2 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SAMSUNG-GT-B3410-Bouygues/B3410XXIL2 NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SAMSUNG-GT-B5722C/1.0 RTK-E/1.0 DF/1.0 Release/10.14.2009 Browser/NetFront3.4 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Tablet	SAMSUNG-GT-B7330B/1.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0)
+Unknown	SAMSUNG-GT-C3050C/1.0 Release/1.19.2009 Browser/Openwave6.2.3 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0
+Unknown	SAMSUNG-GT-C3300K-ORANGE/C3300KAFKA3 NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SAMSUNG-GT-C3510-Bouygues/C3510POIL2 NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SAMSUNG-GT-C3595/C3595XAMG1 NetFront/4.2 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SAMSUNG-GT-C3782-ORANGE/C3782BVLF3 NetFront/4.2 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SAMSUNG-GT-C5130S-Vodafone/SBAIJ4 SHP/VPP/R5 NetFront/3.5 SMM-MMS/1.2.0 profile/MIDP-2.0 configuration/CLDC-1.1
+Unknown	SAMSUNG-GT-E1130B-ORANGE/E1130BABIL2 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0
+Unknown	SAMSUNG-GT-E2120-ORANGE/E2120BVII2 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0
+Unknown	SAMSUNG-GT-E2222L/1.0 NetFront/4.1 Profile/MIDP-2.0 Configuration/CLDC-1.1
+TV	SAMSUNG-GT-I7410/I7410XXIF2 SHP/VPP/R5 Jasmine/1.0 Qtv5.3 SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1
+Computer	SAMSUNG-GT-I8330-Vodafone/I8330BUJF8 Opera/9.8 (SLP; Linux/SLP/R1; U; en) Presto/2.4.21 Version/10.00 SMM-MMS/1.2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Phone	SAMSUNG-GT-I9108_TD/1.0 Android/2.3.3 Release/03.15.2011 Browser/AppleWebKit533.1 Profile/MIDP-2.1 Configuration/CLDC-1.1
+TV	SAMSUNG-GT-M8800-ORANGE/M8800BVHJ2 SHP/VPP/R5 NetFront/3.5 Qtv5.3 SMM-MMS/1.2.0 profile/MIDP-2.0 configuration/CLDC-1.1
+Unknown	SAMSUNG-GT-M8910H/1.0 SHP/VPP/R5 Mozilla/5.0 (rv:1.3) NetFront/3.5 Nextreaming SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1
+Unknown	SAMSUNG-GT-P5110/101.40202
+TV	SAMSUNG-GT-S3370B/S3370DO SHP/VPP/R5 Dolfin/1.5 Qtv/5.3 SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-N
+Unknown	SAMSUNG-GT-S3570-ORANGE/S3570BVLI4 NetFront/4.2 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SAMSUNG-GT-S3650H/1.0 SHP/VPP/R5 NetFront/3.5 Nextreaming SMM-MMS/1.2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	SAMSUNG-GT-S3770M/1.0 NetFront/4.1 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SAMSUNG-GT-S3850/1.0 SHP/VPP/R5 Dolfin/2.0 NexPlayer/3.0 SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B
+Unknown	SAMSUNG-GT-S5230-Vodafone/S5230XFIJ2 SHP/VPP/R5 Jasmine/0.8 Nextreaming SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1
+Unknown	SAMSUNG-GT-S5260-ORANGE/S5260BVJL1 SHP/VPP/R5 Dolfin/2.0 NexPlayer/3.0 SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B
+Unknown	SAMSUNG-GT-S5280/100.40102
+Unknown	SAMSUNG-GT-S5500H/1.0 SHP/VPP/R5 NetFront/3.5 SMM-MMS/1.2.0 profile/MIDP-2.0 configuration/CLDC-1.1/*MA==
+Unknown	SAMSUNG-GT-S5560i-BOUYGUES/S5560IAGKD1 SHP/VPP/R5 Dolfin/2.0 NexPlayer/3.0 SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B
+TV	SAMSUNG-GT-S5600-Vodafone/S5600BUIE2 SHP/VPP/R5 Jasmine/0.8 Qtv5.3 SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1
+Unknown	SAMSUNG-GT-S5611 Opera/9.80 (J2ME/MIDP; Opera Mini/7.1.34793/34.1624; U; de) Presto/2.8.119 Version/11.10
+Unknown	SAMSUNG-GT-S5620L/1.0 SHP/VPP/R5 Dolfin/1.5 Nextreaming SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1 UP.Link/6.3.0.0.0
+Phone	SAMSUNG-GT-S6818_TD/1.0 Android/4.1.2 Release/02.03.2013 Browser/ApplelWebkit/534.30
+Unknown	SAMSUNG-GT-S8000B/1.0 SHP/VPP/R5 Jasmine/1.0 Nextreaming SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1
+Unknown	SAMSUNG-GT-S8500C/1.0 SHP/VPP/R5 Dolfin/2.0 Nextreaming SMM-MMS/1.2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Tablet	SAMSUNG-GT-i8000T Mozilla (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0)
+Unknown	SAMSUNG-M7600-Vodafone/M7600BUIF2 SHP/VPP/R5 NetFront/3.5 NexPlayer/2.9.1 SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1
+Unknown	SAMSUNG-S5200-Orange/S5200BVIH2 NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SAMSUNG-S8000-ORANGE/S8000BVIF5 SHP/VPP/R5 Jasmine/1.0 Nextreaming SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1
+Unknown	SAMSUNG-S8300/1.0 SHP/VPP/R5 NetFront/3.5 NexPlayer/2.9.1 SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1
+Computer	SAMSUNG-SCH-M710/(null)ID4 (compatible; MSIE 6.0; Windows CE; PPC) Opera 9.5 Presto/2.2.1
+Unknown	SAMSUNG-SGH-A110/1.0 UP/4.1.19j UP.Browser/4.1.19j-XXXX
+Unknown	SAMSUNG-SGH-A637/A637UCHH2 SHP/VPP/R5 NetFront/3.4 SMM-MMS/1.2.0 profile/MIDP-2.0 configuration/CLDC-1.1
+Unknown	SAMSUNG-SGH-A800/1.0 UP.Browser/5.0.3.3 (GUI)
+Unknown	SAMSUNG-SGH-A947/A947UCJF3 Mozilla/5.0 (BREW 5.0.3; BP251/162; U; en; rv:1.8.1) Gecko/20061208 Firefox/2.0.0 profile/MIDP-2.1 configuration/CLDC-1.1
+Unknown	SAMSUNG-SGH-B460/1.0 SHP/VPP/R5 NetFront/3.4 SMM-MMS/1.2.0
+Unknown	SAMSUNG-SGH-C238/RAINBOW 3.0/WAP1.2 Profile/MIDP-2.0 Configuration/CLDC-1.0*MzU2NzU4MDAwMzA0MTY1
+Unknown	SAMSUNG-SGH-C327 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0
+Unknown	SAMSUNG-SGH-C414R/C414UXKD1 SHP/VPP/R5 NetFront/3.5 SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1
+Unknown	SAMSUNG-SGH-C425/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0
+Unknown	SAMSUNG-SGH-D728/Series60 2.1/WAP2.0 Profile/MIDP-2.0 Configuration/CLDC-1.0
+Unknown	SAMSUNG-SGH-D900i-ORANGE/D900iABGF2 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0
+Unknown	SAMSUNG-SGH-E200-ORANGE/E200EBVIB2/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0
+Unknown	SAMSUNG-SGH-E335/E335UVEE1 UP.Browser/6.2.2.6 (GUI) MMP/1.0
+Unknown	SAMSUNG-SGH-E538/TSS 2.5.0/WAP2.0 Profile/MIDP-2.0 Configuration/CLDC-1.0/*MDAwMDAwMDAwMDAwMDA
+Unknown	SAMSUNG-SGH-E848i/1.0 RTK-E/1.0 DF/1.0 Release/04.14.2007 Browser/OpenWave6.2.3.3.c.1.101 Profile/MIDP-2.0 Configuration/CLDC-1.1/*MzU0NjI4MDIwNDk3NzQ5 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0
+TV	SAMSUNG-SGH-F330-TEN/F330AFHB1 SHP/VPP/R5 NetFront/3.4 Qtv5.3 SMM-MMS/1.2.0 profile/MIDP-2.0 configuration/CLDC-1.1
+Unknown	SAMSUNG-SGH-F480I-Bouygues/AGIG6 SHP/VPP/R5 NetFront/3.5 SMM-MMS/1.2.0 profile/MIDP-2.0 configuration/CLDC-1.1
+Unknown	SAMSUNG-SGH-F488E/1.0 RTK-E/1.0 DF/1.0 Release/08.03.2007 Browser/NetFront3.4  Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SAMSUNG-SGH-I308/Browser 1.0.0.23/WAP-2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SAMSUNG-SGH-J700-ORANGE/J700ABHB2 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0
+Unknown	SAMSUNG-SGH-J750MJGK4/1.0 SHP/VPP/R5 NetFront/3.4 SMM-MMS/1.2.0 profile/MIDP-2.0 configuration/CLDC-1.1
+Unknown	SAMSUNG-SGH-L760-Vodafone/AEGG1 SHP/VPP/R5 NetFront/3.4 SMM-MMS/1.2.0 profile/MIDP-2.0 configuration/CLDC-1.1
+TV	SAMSUNG-SGH-L810-Vodafone/L810ACIB1 SHP/VPP/R5 Opera/9.5 Qtv5.3 SMM-MMS/1.2.0 profile/MIDP-2.0 configuration/CLDC-1.1
+Unknown	SAMSUNG-SGH-N188/1.0 UP/4.1.19k
+Unknown	SAMSUNG-SGH-N600/1.0 UP.Browser/4.1.26b
+Unknown	SAMSUNG-SGH-P318/NetFront 3.2/WAP2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1/*MzUxODEzMDEwMDAwNzAy
+Unknown	SAMSUNG-SGH-R200/1.0 UP/4.1.19k
+Unknown	SAMSUNG-SGH-S508/1.0*MzU0NTMxMDA2MDczMzYx UP.Browser/5.0.5.1 (GUI) UP.Link/1.1
+Unknown	SAMSUNG-SGH-T119/T119UVHL2 NetFront/3.4 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SAMSUNG-SGH-T209R/T209UVFG1 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0
+Unknown	SAMSUNG-SGH-T249R/ NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SAMSUNG-SGH-T330G NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1[TFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX]
+Unknown	SAMSUNG-SGH-T369R/1.0 NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SAMSUNG-SGH-T409/T409UVGE3 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0
+Unknown	SAMSUNG-SGH-T469W/T469UQIK5 SHP/VPP/R5 NetFront/3.5 SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1
+Unknown	SAMSUNG-SGH-T629R/T629UVFL2 Profile/MIDP-2.0 Configuration/CLDC-1.1 NetFront/3.2
+Unknown	SAMSUNG-SGH-T749-MKB/T749UEJJ7 SHP/VPP/R5 NetFront/3.5 SMM-MMS/1.2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	SAMSUNG-SGH-U908/1.0 SHP/VPP/R5 NetFront/3.4 SMM-MMS/1.2.0 profile/MIDP-2.0 configuration/CLDC-1.1
+Unknown	SAMSUNG-SGH-X496/X496UZEI1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0
+Unknown	SAMSUNG-SGH-X628/1.0/WAP2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1/*MDAwMDAwMDAwMDAwMDAw UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0
+Unknown	SAMSUNG-SGH-X808/NF3 3.2/WAP2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1/*MzU3MzQwMDAwMDExMjUz
+Unknown	SAMSUNG-SGH-Z560-Vodafone/1.0 SHP/VPP/R5 NetFront/3.3 SMM-MMS/1.2.0 profile/MIDP-2.0 configuration/CLDC-1.1
+Tablet	SAMSUNG-SGH-i600TIM/1.0 (compatible; MSIE 6.0; Windows CE; IEMobile 6.8)
+Computer	SAMSUNG-SGH-i718plus_CMCC/1.0 Release/03.07 Browser/IE6 Profile/MIDP-2.0 Configuration/CLDC-1.1 (compatible; MSIE 4.01; Windows CE; PPC)
+Tablet	SAMSUNG-SGH-i780TIM/AIHA3 (compatible; MSIE 6.0; Windows CE; IEMobile 7.7)
+Unknown	SAMSUNG-SGHC260/
+Unknown	SAMSUNG-SPHM500 AU-
+Unknown	SAMSUNG-SPHM620 AU-MIC-M620/20 MMP/20 PROFILE/MIDP-20 CONFIGURATION/CLDC-11
+Unknown	SAMSUNG/SGHE860V
+Unknown	SIE-A31/05 Profile/MIDP-1.0 Configuration/CLDC-1.0 UP.Browser/6.1.0.7.3.102 (GUI) MMP/1.0
+Unknown	SIE-A57/03 UP.Browser/5.0.3.3.1.e.4 (GUI)
+Unknown	SIE-A75/20 Profile/MIDP-1.0 Configuration/CLDC-1.0 UP.Browser/6.1.0.5.c.6 (GUI) MMP/1.0
+Unknown	SIE-AX76/44 Profile/MIDP-1.0 Configuration/CLDC-1.0 UP.Browser/6.1.0.7.3.102 (GUI) MMP/1.0
+Unknown	SIE-C60A/24 Profile/MIDP-1.0 Configuration/CLDC-1.0 UP.Browser/6.1.0.7.3 (GUI) MMP/1.0
+Unknown	SIE-CF6C/07 Profile/MIDP-1.0 Configuration/CLDC-1.0 UP.Browser/6.1.0.7.3 (GUI) MMP/1.0
+Unknown	SIE-CX6V/00 UP.Browser/7.0.0.1.121 (GUI) MMP/2.0
+Unknown	SIE-ELC1/36 UP.Browser/7.1.0.e.24(GUI) MMP/2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SIE-M55Z/11 Profile/MIDP-1.0 Configuration/CLDC-1.0 UP.Browser/6.1.0.7.3 (GUI) MMP/1.0
+Unknown	SIE-MC6C/07 Profile/MIDP-1.0 Configuration/CLDC-1.0 UP.Browser/6.1.0.7.3 (GUI) MMP/1.0
+Unknown	SIE-S40/2.3 UP/4.1.16r
+Unknown	SIE-S68/17 UP.Browser/7.1.0.e.10(GUI) MMP/2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SIE-S6V/25 UP.Browser/7.0.0.1.c.3 (GUI) MMP/2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SIE-SL7C/44 UP.Browser/7.1.0.e.24(GUI) MMP/2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Computer	SIE-SX66/01 (compatible; MSIE 4.01; Windows CE; PPC; 240x320)
+Unknown	SMB3.1(Z105)/Samsung,SMB3.1(Z105)/Samsung
+Phone	SV1 Android Application (13, sv1 v2.1) - HUAWEI U8500 Huawei - 00000000-67C6-4CD4-FFFF-FFFFB5804451
+Phone	SV1 Android Application (13, sv1 v2.1) - Motorola MZ601 MOTO - FFFFFFFF-DD75-2B37-01B0-23B41451058E
+Phone	SV1 Android Application (13, sv1 v2.1) - Sony Ericsson SK17i SEMC - 00000000-2F2B-5B02-FFFF-FFFFA63F25EE
+Phone	SV1 Android Application (13, sv1 v2.1) - YIFANG POM727MC MID - FFFFFFFF-FC86-1B92-1BCE-54530033C587
+Phone	SV1 Android Application (16, sv1 v2.2.2) - LGE LG-E410i lge - FFFFFFFF-901B-D8D4-78CF-32FF3C17DB5B
+Unknown	Samsung AllShare
+Phone	Samsung Exhibit 4G Android_SDK
+Unknown	Samsung GT-S3030
+Unknown	Samsung Magician
+Unknown	Samsung SGH-C510
+Unknown	Samsung SGH-J600E
+Unknown	Samsung SPH-D600
+Phone	Samsung Stratosphere Android_SDK
+Phone	Samsung mobiles/android
+Unknown	Samsung-SGH-B320/1.0 Openwave/6.2.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	Samsung-SPHA900P AU-MIC-A900P/2.0 MMP/2.0 Profile/MIDP-2.0
+Unknown	Samsung-SPHM540BST Polaris/6.0 MMP/2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	Samsung/SGH-i550V/BUGL2 Series60/3.1 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyC1505 Build/
+Unknown	SonyC5303 Build/12.0.A.1.211 UpdateCenter/1.3.4.A.0.8
+Unknown	SonyC6903 Build/14.1.G.1.518 UEP/0.1 com.sonyericsson.updatecenter/2.0.0.B.0.4
+Unknown	SonyEricssonA200i/R1CA Browser/NetFront/3.4 Profile/MIDP-2.1 Configuration/CLDC-1.1 JavaPlatform/JP-8.4.0
+Unknown	SonyEricssonAmFiTaMiN/R8BF Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonC702c/R3BA Browser/NetFront/3.4 Profile/MIDP-2.1 Configuration/CLDC-1.1 JavaPlatform/JP-8.3.0
+Unknown	SonyEricssonD750i/R1A Browser/SEMC-Browser/4.2 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonF500i/R1A SEMC-Browser/4.0 Profile/MIDP-1.0 MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonJ200i/R101
+Unknown	SonyEricssonJ220i/R5C TelecaBrowser/4.08
+Unknown	SonyEricssonJ300c/R2AL SEMC-Browser/4.0.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonK300/R2AJ SEMC-Browser/4.0.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonK310iv/R4DA Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonK500/R1 UP.Browser/5.0.3.3 (GUI)
+Unknown	SonyEricssonK510/R10CA Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonK550i//R6BC Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonK610a/R1CB
+Unknown	SonyEricssonK618iv/R1ED Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonK700v/R10BA Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonK790/R2B Release/Feb-07-2007 Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonK810c/R1KC Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonK850i/BR1EA Browser/NetFront/3.4 Profil/MIDP-2.1 Configuration/CLDC-1.1
+Phone	SonyEricssonLT15a Build/3.0.A.2.184 stagefright/1.1 (Linux;Android 2.3.2)
+Unknown	SonyEricssonMODEL/R1JC Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonNW910i/R1EA Browser/NetFront/3.4 Profil/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	SonyEricssonP900/
+Unknown	SonyEricssonP910i/R1A SEMC-Browser/Symbian/3.0 Profile/MIDP-2.0 Configuration/CLDC-1.0
+Unknown	SonyEricssonR306/R1AB002 Browser/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonS302c/R1BB Browser/OpenWave/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1, SonyEricssonS302c/R1BB Browser/OpenWave/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonS700c/R3B SEMC-Browser/4.0.1 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonT123i/R1DA Browser/NetFront/3.4 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	SonyEricssonT280i/R1BA003 TelecaBrowser/Q04C1-1 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonT303a/R2BA005 TelecaBrowser/Q04C1-1 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonT658c/R8BA Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonT818/R1FA Browser/NetFront/3.4 Profile/MIDP-2.1 Configuration/CLDC-1.1 JavaPlatform/JP-8.4.3
+Unknown	SonyEricssonU10i/R1A Browser/NetFront/3.5 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	SonyEricssonU20i/2.0.2.A.0.24 PNC/38006
+Unknown	SonyEricssonU5iv/R2AA; Mozilla/5.0 (SymbianOS/9.4; U; Series60/5.0 Profile/MIDP-2.1 Configuration/CLDC-1.1) AppleWebKit/525 (KHTML, like Gecko) Version/3.0 Safari/525
+Unknown	SonyEricssonV800/R1A Browser/SEMC-Browser/4.1 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonW150a/R2AD027 TelecaBrowser/Q07C1-1 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonW200iv/R4GB Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonW300c/R4EA Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonW350c/R10BA Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonW395/1217-55
+Unknown	SonyEricssonW580c/R6BC
+Unknown	SonyEricssonW600c/R7B Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonW660iv/R6AA Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonW705u/R1CA Browser/NetFront/3.4 Profile/MIDP-2.1 Configuration/CLDC-1.1 model-orange JavaPlatform/JP-8.4.1
+Unknown	SonyEricssonW760c/R3CA
+Unknown	SonyEricssonW830c/R1GB Release/Nov-30-2006 Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonW880iv/R1JC Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonW958c/R100 Mozilla/4.0 (compatible; MSIE 6.0; Symbian OS; 405) Opera 8.65 [en]
+Tablet	SonyEricssonX2a/R2AA Browser/Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	SonyEricssonZ200/R101
+Unknown	SonyEricssonZ310av/R6BC Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonZ500a/R1A SEMC-Browser/4.0.1 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonZ530c/R6AB Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonZ558i/R4FA Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssondigivice/R8BE Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Unknown	SonyEricssonsakamoto/R1GA Browser/NetFront/3.4 Profile/MIDP-2.1 Configuration/CLDC-1.1 JavaPlatform/JP-8.4.4
+Unknown	SonyEricssonw300i/R4GB Browser/NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1,gzip(gfe)
+Phone	SonyL36h Build/10.3.1.A.2.67 stagefright/1.2 (Linux;Android 4.2.2)
+Phone	SonyLT26w Build/6.2.B.1.96 stagefright/1.2 (Linux;Android 4.1.2)
+Unknown	SonySGP311 Build/10.3.1.C.0.136 UEP/0.1 com.sonyericsson.updatecenter/2.0.1.A.0.3
+Phone	SonyST21a Build/11.0.A.0.16 stagefright/1.2 (Linux;Android 4.0.4)
+Unknown	SonyricssonK850i/R1EA Browser/NetFront/3.4 Profile/MIDP-2.1 Configuration/CLDC-1.1
+Unknown	Tagged/3.8.4/an GT-P3100(samsung/espressorfxx/espressorf:4.1.1/JRO03C/P3100XXCLJ3:user/release-keys)
+Unknown	Tagged/3.9.7/an LG-E610v(lge/m4_vdf_com/m4:4.0.3/IML74K/lge610v-V10g.20130211.093327:user/release-keys)
+Phone	TeleTrader/2.1/Android/samsung-hlte-hltexx-SM-N9005/4.3
+Phone	TopApps/Android/de/HTC/HTC Sensation/4.0.3/1.9.0.12/1/A/3g/widget/441b85d369c46c5d5a1ab3a2b736a7b2/48
+Phone	TopApps/Android/de/samsung/GT-S6310N/4.1.2/2.0.2.5/0/A/3g/widget/0/0
+Phone	TransperaSDK v3.4.0.461 : vodafone_de : HTC Sensation Z710e : Android OS : 4.0.3
+Tablet	Treo800w/v0100 Mozilla/4.0 (compatible; MSIE 4.01; Windows CE, PPC; 320x320) (compatible; MSIE 6.0; Windows CE; IEMobile 7.11)
+Phone	TwitterAndroid/2.0.0 (119) HTC Flyer P510e/10 (HTC;flyer;o2_de;htc_flyer;)
+Phone	UCWEB/2.0 (Java; U; MIDP-2.0; En-US; LG-A133) U2/1.0.0 UCBrowser/9.3.0.326 U2/1.0.0 Mobile UNTRUSTED/1.0
+Phone	UCWEB/2.0 (Java; U; MIDP-2.0; de-DE; LG-T300) U2/1.0.0 UCBrowser/9.4.0.342 U2/1.0.0 Mobile UNTRUSTED/1.0
+Phone	UCWEB/2.0 (Java; U; MIDP-2.0; en-US; LG-C395) U2/1.0.0 UCBrowser/9.3.0.326 U2/1.0.0 Mobile
+Phone	UCWEB/2.0 (Java; U; MIDP-2.0; en-US; LG-GS390) U2/1.0.0 UCBrowser/9.3.0.326 U2/1.0.0 Mobile UNTRUSTED/1.0
+Phone	UCWEB/2.0 (Java; U; MIDP-2.0; en-US; LG-GX200) U2/1.0.0 UCBrowser/9.3.0.326 U2/1.0.0 Mobile UNTRUSTED/1.0
+Phone	UCWEB/2.0 (Java; U; MIDP-2.0; en-US; LG-TE365 Teleca) U2/1.0.0 UCBrowser/9.3.0.326 U2/1.0.0 Mobile UNTRUSTED/1.0
+Phone	UCWEB/2.0 (Java; U; MIDP-2.0; en-US; htc_touch_3g_t3232-orange) U2/1.0.0 UCBrowser/8.9.0.251 U2/1.0.0 Mobile UNTRUSTED/1.0
+Phone	UCWEB/2.0 (Java; U; MIDP-2.0; en-US; samsung-gt-b7330) U2/1.0.0 UCBrowser/9.0.0.260 U2/1.0.0 Mobile, SAMSUNG-GT-B7330/1.0 UNTRUSTED/1.0
+Phone	UCWEB/2.0 (Java; U; MIDP-2.0; en-US; samsung-sgh-c414y) U2/1.0.0 UCBrowser/9.0.1.303 U2/1.0.0 Mobile UNTRUSTED/1.0
+Phone	UCWEB/2.0 (Java; U; MIDP-2.0; es-LA; LG-GD570) U2/1.0.0 UCBrowser/9.3.0.326 U2/1.0.0 Mobile
+Phone	UCWEB/2.0 (Java; U; MIDP-2.0; es-LA; lg-km555) U2/1.0.0 UCBrowser/8.9.0.251 U2/1.0.0 Mobile UNTRUSTED/1.0
+Phone	UCWEB/2.0 (Java; U; MIDP-2.0; ru; GT-S5233T) U2/1.0.0 UCBrowser/9.3.0.326 U2/1.0.0 Mobile UNTRUSTED/1.0
+Phone	UCWEB/2.0 (Java; U; MIDP-2.0; ru; samsung-c6112) U2/1.0.0 UCBrowser/8.9.0.251 U2/1.0.0 Mobile,SAMSUNG-GT-C6112/C6112XXJC1 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.102 (GUI) MMP/2
+Phone	UCWEB/2.0 (Linux; U; Adr 2.3.6; en-US; I9250) U2/1.0.0 UCBrowser/8.7.0.315 U2/1.0.0 Mobile
+Phone	UCWEB/2.0 (Linux; U; Adr 4.0.4; en-US; HUAWEI-M931) U2/1.0.0 UCBrowser/8.6.0.276 U2/1.0.0 Mobile
+Phone	UCWEB/2.0 (Linux; U; Adr 4.2.2; en-US; iris505) U2/1.0.0 UCBrowser/9.3.1.344 U2/1.0.0 Mobile
+Phone	UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; Archos_50_Titanium) U2/1.0.0 UCBrowser/9.0.2.389 U2/1.0.0 Mobile
+Phone	UCWEB/2.0 (Symbian; U; S60 V5; en-US; Nokia Blooded.v3) U2/1.0.0 UCBrowser/9.0.1.317 U2/1.0.0 Mobile
+Phone	UCWEB/2.0 (Symbian; U; S60 V5; en-US; SonyEricssonU8i) U2/1.0.0 UCBrowser/8.9.0.277 U2/1.0.0 Mobile
+Phone	UCWEB/2.0 (Windows; U; wds 7.10; en-US; NOKIA; Nokia 610) U2/1.0.0 UCBrowser/3.1.1.343 U2/1.0.0 Mobile
+Phone	UCWEB/2.0(Java; U; MIDP-2.0; en-us; samsung sch-i910) U2/1.0.0 UCBrowser/8.7.1.234 U2/1.0.0 Mobile UNTRUSTED/1.0
+Phone	UCWEB/2.0(Java; U; MIDP-2.0; es-la; htc kaiser) U2/1.0.0 UCBrowser/8.7.1.234 U2/1.0.0 Mobile UNTRUSTED/1.0
+Phone	UCWEB/2.0(Java; U; MIDP-2.0; es-la; samsung m3510l) U2/1.0.0 UCBrowser/8.7.0.218 U2/1.0.0 Mobile,SAMSUNG-M3510L/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.102 (GUI) MMP/2.0 Untrusted/1.0
+Unknown	UNTRUSTED10 HTC-ST6356
+Phone	VKAndroidApp/3.0-120 (Android 4.0.4; SDK 15; armeabi-v7a; Philips Philips W536; ru)
+Phone	VKAndroidApp/3.2.1-196 (Android 2.3.5; SDK 10; armeabi; samsung GT-S5570I; ru)
+Phone	VKAndroidApp/3.3.2-249 (Android 4.2.2; SDK 17; armeabi-v7a; asus K00F; ru)
+Phone	VKAndroidApp/3.3.3-266 (Android 4.3.1; SDK 18; armeabi-v7a; HTC EndeavorU; de)
+Phone	VKAndroidApp/3.4.1-298 (Android 4.3; SDK 18; armeabi-v7a; samsung SM-P601; uk)
+Phone	VMVID Android Application (13, vmvid v2.1) - HUAWEI HUAWEI U8666E Huawei - FFFFFFFF-D691-EF56-1609-2D8F00000000
+Phone	VMVID Android Application (13, vmvid v2.1) - Lenovo SmartTabII10 Lenovo - 00000000-0B14-5E0F-FD85-74DE7356D522
+Phone	VMVID Android Application (13, vmvid v2.1) - TCT ALCATEL ONE TOUCH 6033X TCT - FFFFFFFF-E131-705E-FFFF-FFFFD5B64CAB
+Phone	VMVID Android Application (13, vmvid v2.1) - alps Cynus T2 Cynus - 00000000-37DB-E1C2-FFFF-FFFF9C80BBF7
+Phone	VMVID Android Application (13, vmvid v2.1) - wind RACERII ZTE - FFFFFFFF-B8CC-5A5D-FFFF-FFFFDDB6EDFB
+Phone	VMVID Android Application (16, vmvid v2.2.2) - samsung GT-S6500D samsung - FFFFFFFF-C608-1CC3-FFFF-FFFFDEAEAE40
+Unknown	Vodafone/1.0/0vodafone810/B626 Browser/Obigo-browser/Q05A MMS/Obigo-MMS/Q05A SyncML/HW-SyncML/1.0 Java/HWJA/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
+Tablet	Vodafone/1.0/HTC_Diamond Opera/9.50 (Windows Mobile 6.1; U; de)[b][/b]
+Computer	Vodafone/1.0/HTC_wizard/2.21.3.102/Mozilla/4.0 (compatible; MSIE 4.01; Windows CE; PPC; 240x320)
+Phone	WhatsApp/2.11.102 Android/2.3.3 Device/HUAWEI-U8510
+Tablet	WhatsApp/2.11.102 Android/4.0.4 Device/Motorola-XOOM_2
+Phone	WhatsApp/2.11.106 Android/4.0.4 Device/HTC-HTC_Desire
+Unknown	WhatsApp/2.11.107 S60Version/3.2 Device/Nokia-N86-8MP
+Phone	WhatsApp/2.11.112 Android/4.2.1 Device/asus-ASUS_Transformer_Pad_TF300TG
+Phone	WhatsApp/2.11.136 Android/2.3.5 Device/HTC-HTC_Explorer_A310e
+Phone	WhatsApp/2.11.145 Android/4.1.1 Device/samsung-GT-P3110
+Phone	WhatsApp/2.11.152 Android/2.3.5 Device/HTC-HTC_Wildfire_S_A510e
+Tablet	WhatsApp/2.11.157 Android/4_1_2 Device/samsung-SM-T210
+Phone	WhatsApp/2.11.164 Android/4_2_2 Device/samsung-GT-I9152
+Phone	WhatsApp/2.11.181 Android/4.2.2 Device/HTC-HTC_802w
+Unknown	WhatsApp/2.11.356 WP7/7.10.8107 Device/SAMSUNG-GT-I8350-H23.15.0.8
+Unknown	WhatsApp/2.11.80 S60Version/3.2 Device/Nokia-6760s-1-(02.01)
+Phone	Windows Phone Search (Windows Phone OS 8.0;NOKIA;Nokia 520;8.0;10328)
+Phone	WindowsPhoneMMS/1.0 WindowsPhoneOS/8.0-9903 NOKIA-RM-825
+Phone	XCON Android Application (13, xcon v2.1) - TCT ALCATEL ONE TOUCH 5020D TCT - 00000000-371B-F780-4F29-A3BD1FD31B59
+Phone	XCON Android Application (16, xcon v2.2.2) - Sony C6833 Sony - FFFFFFFF-B1A7-5AF0-7199-6F7E06444AA8
+Phone	YahooJMobileApp/1.1 (Android emg; 1.3.4) (samsung; SC-02E; samsung; SC-02E; 4.1.1/JRO03C)
+Phone	YahooMobile/1.0 (im; 1.8.3.13903); (Linux; U; Android 2.3.5; ZTE_BP_GER Build/GINGERBREAD_MR1);
+Phone	YahooMobile/1.0 (im; 1.8.4.15957); (Linux; U; Android 4.0.4; AllviewAX2 Build/Unknown);
+Phone	YahooMobile/1.0 (mail; 1.3.8.9816); (Linux; U; Android 2.3.4; htc_glacier Build/GINGERBREAD_MR1);
+Phone	YahooMobile/1.0 (mail; 3.0.5.1311380); (Linux; U; Android 4.0.3; htc_runnymede Build/ICE_CREAM_SANDWICH_MR1);
+Phone	YahooMobileMail/1.0 (Android Mail; 3.0.5) (runnymede;HTC;Sensation XL with Beats Audio;4.0.3/IML74K)
+Phone	YahooMobileMessenger/1.0 (Android Mail; 1.3.4) (mecha; HTC; ADR6400L; 2.2.1/FRG83D)
+Phone	YahooMobileMessenger/1.0 (Android Mail; 1.4.6) (jaspervzw; samsung; SCH-I200; 4.0.4/IMM76D)
+Phone	YahooMobileMessenger/1.0 (Android Messenger; 1.8.3) (SHW-M340K; samsung; SHW-M340K; 2.3.6/GINGERBREAD)
+Phone	YahooMobileMessenger/1.0 (Android Messenger; 1.8.4) (t0lteskt; samsung; SHV-E250S; 4.1.2/JZO54K)
+Phone	ZDF 2.1.1 (HTC Flyer P510e; Android 3.2.1; de_DE)
+Phone	android 4.3; SAMSUNG-SM-N900A
+Phone	avast/1.0.6913 (6913;de_DE) ID/3e89b6e05f804a19 HW/HTC EVO 3D X515m Android/4.0.3 (IML74K)
+Phone	avast/2.0.3917 (3917;en_GB) ID/null HW/Garmin-Asus A50 Android/2.1-update1 (ERE27)
+Phone	com.abc.mobile/5.7.14/Mozilla/5.0 (Linux; Android 9; Google Pixelbook Go Build/R99-14469.59.0; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/99.0.4844.73 Safari/537.36
+Phone	com.eurosport.news.android/3.5.9/Android/4.0.3/HUAWEI-U9200
+Phone	com.eurosport.news.android/3.7.3/Android/4.1.2/HTC-HTC Desire 500
+Phone	com.google.android.youtube/5.3.32(Linux; U; Android 4.0.3; ro_RO; GOCLEVER NETBOOK R103 Build/IML74K) gzip
+Wearable	com.sdgtl.watch.flyer/2.1.2120412326.191140 (build:201191140; model:HTC Flyer; device:flyer; mcc:262; mnc:07; modeLite:true; fp:tmo_de/htc_flyer/flyer:3.2.1/HTK75C/205068.1:user/release-keys; cid:T-MOB101; appId:com.sdgtl.watch.flyer_hc)
+Computer	dopod HTC BlueAngel/5.2.21139/WAP1.2 Profile/MIDP2.0 Configuration/CLDC1.0 Mozilla/4.0 Mozilla/4.0 (compatible; MSIE 4.01; Windows CE; PPC)/UC Browser7.8.0.95
+Unknown	htc s740 UNTRUSTED/1.0
+Phone	htc touch viva t2223 UNTRUSTED/1.0
+Unknown	iBrowser/Mini2.5 (SAMSUNG-GT-S5753E/S5753EDDKF1)
+Phone	kinApp/1.0.0 (Android OS 4.1.2;LGE LG-F240S)
+Unknown	lg-a255/UC Browser7.9.0.102/69/352 UNTRUSTED/1.0
+Unknown	lg-kp260 UNTRUSTED/1.0
+Phone	mgg3.4.2.20011/Android8/samsung/GT-B7510/2.2.2
+Phone	org.xyz.mobile/5.7.09/Mozilla/5.0 (Linux; Android 11; GM1917 Build/RKQ1.201022.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/99.0.4844.88 Mobile Safari/537.36
+Phone	radio.de/1.1.22 (Android 2.3.4) LGE/LG-P690
+Unknown	samsung SAMSUNG-SM-G900A SyncML_DM Client
+Unknown	samsung c3300, SAMSUNG-C3300/C3300DDDJF9 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.102 (GUI) MMP/2.0
+Unknown	samsung sgh-e250i, SAMSUNG-SGH-E250i/E250iJBKA1 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.102 (GUI) MMP/2.0 Untrusted/1.0
+Phone	samsung-GT-9192/1.0 Linux/2.6.35.7 Android/4.2.2 Release/11.14.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
+Phone	samsung-I9300/1.0 Linux/2.6.35.7 Android/4.0.4 Release/11.23.2012 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
+Unknown	samsung-c5212i/UC Browser8.0.3.107/69/352,SAMSUNG-GT-C5212i/C5212iXEJH3 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.102 (GUI) MMP/2.0 Untrusted/1.0
+Unknown	samsung-gt-s3650c/UCWEB8.0.3.99/69/999 UNTRUSTED/1.0
+Unknown	samsung-sgh-c414/UC Browser8.0.3.107/69/444 UNTRUSTED/1.0\n
+Unknown	samsung/p4noterfxx/p4noterf:4.1.2/JZO54K/N8000XXCMJ3:user/com.comedyclub/1.9.2.92
+Phone	sprd-A760/1.0 Linux/2.6.35.7 Android/2.3.5 Release/07.26.2012 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
+Phone	sprd-Byond-B54/1.0 Linux/2.6.35.7 Android/2.3.6 Release/01.07.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
+Phone	sprd-G500/1.0 Linux/2.6.35.7 Android/2.3.5 Release/04.16.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
+Phone	sprd-GT-T9500/1.0 Linux/2.6.35.7 Android/4.2.0 Release/05.29.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
+Phone	sprd-I8750/1.0 Linux/2.6.35.7 Android/4.0.4 Release/05.07.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
+Phone	sprd-MINI/1.0 Linux/2.6.35.7 Android/4.0.3 Release/03.06.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
+Phone	sprd-N7000/1.0 Linux/2.6.35.7 Android/4.0.1 Release/01.31.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
+Phone	sprd-Q101/1.0 Linux/2.6.35.7 Android/4.2.2 Release/09.16.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
+Phone	sprd-SKING/1.0 Linux/2.6.35.7 Android/4.0 Release 06.03.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
+Phone	sprd-YUSUN-T22/1.0 Linux/2.6.35.7 Android/2.3.5 Release/01.23.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
+Phone	sprd-note-III/1.0 Linux/2.6.35.7 Android/4.1.2 Release/07.12.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
+Phone	stagefright/1.2 (Linux;Android NexPlayer LG-E410i10c-EUR-XX)
+Phone	stagefright/1.2 (Linux;Android NexPlayer LG-E43010b-214-07)
+Phone	stagefright/1.2 (Linux;Android NexPlayer LG-E61020b-EUR-XX)
+Phone	stagefright/1.2 (Linux;Android NexPlayer LG-E61220b-AME-XX)
+Phone	stagefright/1.2 (Linux;Android NexPlayer LG-P71010d-EUR-XX)
+Phone	stagefright/1.2 (Linux;Android NexPlayer LG-P71010j-EUR-XX)
+Unknown	stamhub 1.7.0(MD02, 1113513)/SGH-T999; 606; 1.7.0(MD02, 1113513); com.samsung.mediahub; d2tmo; samsung/d2tmo/d2tmo:4.1.2/JZO54K/T999UVDMD5:user/release-keys

--- a/testdata/tv.tsv
+++ b/testdata/tv.tsv
@@ -1,0 +1,1091 @@
+# Connected TV fixtures: <expected device>\t<expected OS>\t<agent>.
+#
+# Every row is a television, a stick or a set top box. The OS expectation comes
+# from the platform token the agent states about itself - "Tizen 6.0", "Web0S",
+# "Roku/DVP-", "AppleTV6,2" - or from Android where the device is an Android TV
+# or a Fire TV, which is what makes these rows worth asserting: the device type
+# and the OS have to survive together.
+#
+# Agent strings collected from the sources credited in testdata/NOTICE.md and
+# redistributed under their licences. The expectations beside them are this
+# project's own: a row is a claim about what the agent means, not a snapshot of
+# whatever the parser said the day it was written.
+
+TV	TvOS	AppleCoreMedia/1.0.0.12F69 (Apple TV; U; CPU OS 8_3 like Mac OS X; en_us)
+TV	TvOS	AppleTV/1.1
+TV	Unknown	GoogleTV/092754 youtube.com/tv#
+TV	Android	GoogleTV/234.0 AndroidTV/234.0
+TV	Unknown	GoogleTV/b70199 Silk-Accelerated=true
+TV	Unknown	HbbTV/1.1.1 (+PVR;Humax;HD FOX+;1.00.12;1.0)CE-HTML/1.0 ANTGalio/3.1.1.23.04.09
+TV	Unknown	HbbTV/1.1.1 (+PVR;Panasonic;DIGA WebKit M8158;3.300;;)
+TV	Unknown	HbbTV/1.1.1 (; ; ; 1.0; 1.0;) NetFront/4.1
+TV	Unknown	HbbTV/1.1.1 (; CUS:; MB70; 1.0; 1.0;) LOH; Opera; CE-HTML/1.0 NetFront/4.1
+TV	Unknown	HbbTV/1.1.1 (; CUS:MEDION; MB70; 1.0; 1.0;) LOH; Opera; CE-HTML/1.0 NetFront/4.1 NETRANGEMMH
+TV	Unknown	HbbTV/1.1.1 (; CUS:OEM; MB70; 1.0; 1.0;) LOH; Opera; CE-HTML/1.0 NetFront/4.1 NETRANGEMMH iplayerV3
+TV	Unknown	HbbTV/1.1.1 (; CUS:PEAQ; MB70; 1.0; 1.0;) LOH; Opera; CE-HTML/1.0 NetFront/4.1 NETRANGEMMH
+TV	Unknown	HbbTV/1.1.1 (; CUS:VESTEL; MB70; 1.0; 1.0;) LOH; Opera; CE-HTML/1.0 NetFront/4.1 NETRANGEMMH iplayerV3
+TV	Unknown	HbbTV/1.1.1 (; ST; FLTk3D; 1.0; 1.0;) NetFront/3.5
+TV	Unknown	HbbTV/1.1.1 (;;;;;) Maple_2011
+TV	Unknown	HbbTV/1.1.1 (;;;;;) firetv-firefox-plugin 1.1.20
+TV	Unknown	HbbTV/1.1.1 (;HyperPanel;hytv;;;) NetFront/3.5
+TV	Unknown	HbbTV/1.1.1 (;Metz;MMS;;;) CE-HTML/1.0
+TV	Unknown	HbbTV/1.1.1 (;Panasonic;VIERA 2011;f.532;0071-0802 2000-0000;)
+TV	Unknown	HbbTV/1.1.1 (;Panasonic;VIERA 2012;1.261;0071-3103 2000-0000;)
+TV	Unknown	HbbTV/1.1.1 (;Samsung;SmartTV2012;;;) WebKit
+TV	Unknown	HbbTV/1.1.1 (;Samsung;SmartTV2013;T-FXPDEUC-1102.2;;) WebKit
+TV	Unknown	HbbTV/1.1.1 (;Samsung;SmartTV2013;T-MST12DEUC-1102.1;;) WebKit
+TV	Unknown	HbbTV/1.1.1 (;TechnoTrend Goerler/Kathrein;S-855/S-955/UFS-925;3.2.0.25.08;;) CE-HTML/1.0 (<profilelist><ui_profile name=\
+TV	Unknown	HbbTV/1.2.1 (;Panasonic;VIERA 2013;3.672;4101-0003 0002-0000;)
+TV	Unknown	Mozilla/4.0 (DTV;TSBNetTV/T0C.0102.18E)NetFront/3.1 InettvBrowser/1.0 (000039;T0C;0102;18E)
+TV	Unknown	Mozilla/4.08 (DTV;NetTV/1.0) NetFront/3.1 InettvBrowser/1.0(0050C9;010;001;000)
+TV	Unknown	Mozilla/5.0 (;;;) AppleWebKit/534.6 HbbTV/1.1.1 (+DL+PVR; inverto; IDL-6640N Volksbox Essential; 1.0; 1.0;) hdplusinteraktiv/1.0 (NETRANGEMMH;)  CE-HTML/1.0
+TV	Unknown	Mozilla/5.0 (;;;) AppleWebKit/534.6 HbbTV/1.1.1 (+DL+PVR; inverto; IDL-6651N Volksbox Web Edition; 1.0; 1.0;) hdplusinteraktiv/1.0 (NETRANGEMMH;)  CE-HTML/1.0
+TV	Unknown	Mozilla/5.0 (;;;) AppleWebKit/534.6 HbbTV/1.1.1 (+DL+PVR; smart; VX10; 1.0; 1.0;)  CE-HTML/1.0
+TV	Unknown	Mozilla/5.0 (;;;) AppleWebKit/534.6 HbbTV/1.1.1 (+DL+PVR; smart; ZAPPIX HD+; 1.0; 1.0;)  CE-HTML/1.0
+TV	Linux	Mozilla/5.0 (AAC; Linux; U; ja-JP) (KHTML, like Gecko) InettvBrowser/2.2 (000087;IP07-04;0100;0000)
+TV	Unknown	Mozilla/5.0 (CrKey armv7l 1.5.16041) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.0 Safari/537.36
+TV	Unknown	Mozilla/5.0 (DTV) NetFront/3.4 InettvBrowser/2.2 (08001F;DTV03VSFC;0002;0001)
+TV	Unknown	Mozilla/5.0 (DTV; TSBNetTV/T29.0203.1DD; like Gecko) NetFront/3.4 InettvBrowser/2.2 (000039;T29;0203;1DD)
+TV	Unknown	Mozilla/5.0 (DTV; TSBNetTV/T32013713.0203.7DD; TVwithVideoPlayer; like Gecko) NetFront/4.1 DTVNetBrowser/2.2 (000039;T32013713;0203;7DD) InettvBrowser/2.2 (000039;T32013713;0203;7DD) YahooDTV/2.0 (Video=0x03;Audio=0x01;Screen=0x01;Device=0x00;Remote=0x10)
+TV	Unknown	Mozilla/5.0 (DTV; TSBNetTV/T33010302.0203.3DD; like Gecko) NetFront/3.4 DTVNetBrowser/2.2 (000039;T33010302;0203;3DD) InettvBrowser/2.2 (000039;T33010302;0203;3DD) YahooDTV/1.1 (Video=0x03;Audio=0x01;Screen=0x01;Device=0x00;Remote=0x10)
+TV	Unknown	Mozilla/5.0 (DTV; TSBNetTV/T34013906.0203.9DD; TVwithVideoPlayer; like Gecko) NetFront/4.1 DTVNetBrowser/2.2 (000039;T34013906;0203;9DD) InettvBrowser/2.2 (000039;T34013906;0203;9DD)
+TV	Unknown	Mozilla/5.0 (DTV; TSBNetTV/T35013A0C.0203.ADD; TVwithVideoPlayer; like Gecko) NetFront/4.1 DTVNetBrowser/2.2 (000039;T35013A0C;0203;ADD) InettvBrowser/2.2 (000039;T35013A0C;0203;ADD) YahooDTV/2.0 (Video=0x03;Audio=0x01;Screen=0x01;Device=0x00;Remote=0x10)
+TV	Unknown	Mozilla/5.0 (DTV; TSBNetTV/T38014006.0203.0DD; TVwithVideoPlayer; like Gecko) NetFront/4.1 DTVNetBrowser/2.2 (000039;T38014006;0203;0DD) InettvBrowser/2.2 (000039;T38014006;0203;0DD)
+TV	Unknown	Mozilla/5.0 (DTV; TSBNetTV/T3B014613.0203.6DD; TVwithVideoPlayer; like Gecko) NetFront/4.1 DTVNetBrowser/2.2 (000039;T3B014613;0203;6DD) InettvBrowser/2.2 (000039;T3B014613;0203;6DD) YahooDTV/2.0 (Video=0x03;Audio=0x01;Screen=0x01;Device=0x00;Remote=0x10)
+TV	Unknown	Mozilla/5.0 (DTV; TVwithVideoPlayer) NetFront/4.1 InettvBrowser/2.2 (08001F;DTV04VSFC3;0001;0001)
+TV	Unknown	Mozilla/5.0 (DTV; TVwithVideoPlayer) NetFront/4.1 InettvBrowser/2.2 (08001F;DTV05VSFC3;0003;0001)
+TV	Unknown	Mozilla/5.0 (DTV; TVwithVideoPlayer) NetFront/4.1 InettvBrowser/2.2 (08001F;DTV06VSFC;0004;0001)
+TV	Linux	Mozilla/5.0 (DirectFB; Linux 35230) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/4.1.4(+mouse+3D+PORTAL_KEY+SCREEN+TUNER; LGE; GLOBAL-PLAT3; 09.00.00; 0x00000001;); LG NetCast.TV-2011
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ HbbTV/1.1.1 ( ;LGE ;NetCast 3.0 ;1.0 ;1.0M ;)
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.0.0(+SCREEN+TUNER; LGE; GP4; s/w; h/w); LG NetCast.TV-2012
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.00.00(+mouse+3D+SCREEN+TUNER; LGE; 32LM620S-ZE; 04.10.37; 0x00000001;); LG NetCast.TV-2012
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.00.00(+mouse+3D+SCREEN+TUNER; LGE; 42LM620S-ZE; 04.01.73; 0x00000001;); LG NetCast.TV-2012
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.00.00(+mouse+3D+SCREEN+TUNER; LGE; 42LM640S-ZA; 04.10.23; 0x00000001;); LG NetCast.TV-2012
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.00.00(+mouse+3D+SCREEN+TUNER; LGE; 42LM660S-ZA; 04.10.23; 0x00000001;); LG NetCast.TV-2012
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.00.00(+mouse+3D+SCREEN+TUNER; LGE; 47LM620S-ZE; 04.10.37; 0x00000001;); LG NetCast.TV-2012
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.00.00(+mouse+3D+SCREEN+TUNER; LGE; 47LM640S-ZA; 04.10.37; 0x00000001;); LG NetCast.TV-2012
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.00.00(+mouse+3D+SCREEN+TUNER; LGE; 47LM669S-ZC; 04.01.63; 0x00000001;); LG NetCast.TV-2012
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.00.00(+mouse+3D+SCREEN+TUNER; LGE; 47LM671S-ZB; 04.10.23; 0x00000001;); LG NetCast.TV-2012
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.00.00(+mouse+3D+SCREEN+TUNER; LGE; 47LM760S-ZB; 04.10.37; 0x00000001;); LG NetCast.TV-2012
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.00.00(+mouse+3D+SCREEN+TUNER; LGE; 47LM860V-ZB; 04.10.26; 0x00000001;); LG NetCast.TV-2012 0
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.00.00(+mouse+3D+SCREEN+TUNER; LGE; 55LM620S-ZE; 04.10.23; 0x00000001;); LG NetCast.TV-2012
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.00.00(+mouse+3D+SCREEN+TUNER; LGE; 55LM660S-ZA; 04.10.37; 0x00000001;); LG NetCast.TV-2012
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.00.00(+mouse+3D+SCREEN+TUNER; LGE; 55LM671S-ZB; 04.10.37; 0x00000001;); LG NetCast.TV-2012
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.00.00(+mouse+3D+SCREEN+TUNER; LGE; 55LM760S-ZB; 04.10.23; 0x00000001;); LG NetCast.TV-2012
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.00.00(+mouse+3D+SCREEN+TUNER; LGE; 55LM860V-ZB; 04.10.26; 0x00000001;); LG NetCast.TV-2012
+TV	Linux	Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+; CNS_UA; LG Browser/4.05; AD_LOGON=4C47452E4E4554; HbbTV/1.1.1 (;LG Electronics;;;)
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux 35230; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ HbbTV/1.1.1 ( ;LGE ;GLOBAL_PLAT3 ;1.0 ;1.0 ;)
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux 35230; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+mouse+3D+PORTAL_KEY+SCREEN+TUNER; LGE; 42LW5590-ZE; 06.01.04; 0x00000001;); LG NetCast.TV-2011
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux 35230; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+mouse+3D+PORTAL_KEY+SCREEN+TUNER; LGE; 42LW570S-ZD; 06.01.04; 0x00000001;); LG NetCast.TV-2011
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux 35230; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+mouse+3D+PORTAL_KEY+SCREEN+TUNER; LGE; 47LK950S-ZA; 06.01.04; 0x00000001;); LG NetCast.TV-2011
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux 35230; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+mouse+3D+PORTAL_KEY+SCREEN+TUNER; LGE; 47LW570S-ZD; 06.01.04; 0x00000001;); LG NetCast.TV-2011
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux 35230; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+mouse+3D+PORTAL_KEY+SCREEN+TUNER; LGE; 47LW579S-ZD; 06.01.04; 0x00000001;); LG NetCast.TV-2011
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux 35230; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+mouse+3D+PORTAL_KEY+SCREEN+TUNER; LGE; 47LW659S-ZC; 05.11.08; 0x00000001;); LG NetCast.TV-2011
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux 35230; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+mouse+3D+PORTAL_KEY+SCREEN+TUNER; LGE; 55LW5500-ZE; 06.01.04; 0x00000001;); LG NetCast.TV-2011
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux 35230; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+mouse+PORTAL_KEY+SCREEN+TUNER; LGE; 37LV5500-ZC; 09.00.00; 0x00000001;); LG NetCast.TV-2011 0
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux 35230; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+mouse+PORTAL_KEY+SCREEN+TUNER; LGE; 37LV5590-ZC; 06.01.04; 0x00000001;); LG NetCast.TV-2011
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux 35230; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+mouse+PORTAL_KEY+SCREEN+TUNER; LGE; 37LV570S-ZB; 06.01.04; 0x00000001;); LG NetCast.TV-2011
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux 35230; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+mouse+PORTAL_KEY+SCREEN+TUNER; LGE; 42LV470S-ZC; 06.01.04; 0x00000001;); LG NetCast.TV-2011
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux 7630; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+3D+BDP; LGE; Media/BD670; BD.8.97.413.E; 0x00000001;); LG NetCast.Media-2011
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux 7630; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+3D+BDP; LGE; Media/HB906; HB.8.97.404.E; 0x00000001;); LG NetCast.Media-2011
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux 7631; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+NO_NUM; LGE; Media/ST600; ST.8.79.207.F; 0x00000001;); LG NetCast.Media-2011
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux armv5tejl; c) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ HbbTV/1.1.1 (;RT-RK;TV;1.0;1.0;),gzip(gfe),gzip(gfe),gzip(gfe)
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux armv6l; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+3D+PORTAL_KEY+BDP; LGE; Media/BH5320; 7697; abc;); LG NetCast.Media-2011
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux armv6l; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+3D+PORTAL_KEY+BDP; LGE; Media/BH6520; 7574; abc;); LG NetCast.Media-2011
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux armv6l; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.1.4(+3D+PORTAL_KEY+BDP; LGE; Media/BP520; 7697; abc;); LG NetCast.Media-2011
+TV	Linux	Mozilla/5.0 (DirectFB; U; Linux mips; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.0.10(+SCREEN+TUNER; LGE; 32LD650-SA; 06.00.00; 0x00000001;); LG NetCast.TV-2010
+TV	Unknown	Mozilla/5.0 (FreeBSD; U; Viera; de-DE) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.21 Chrome/23.0.1271.97 Safari/537.11 SmartTvA/3.0.0
+TV	Unknown	Mozilla/5.0 (FreeBSD; U; Viera; en-GB) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.19.8 Chrome/23.0.1271.97 Safari/537.11 SmartTvA/3.0.0
+TV	Unknown	Mozilla/5.0 (FreeBSD; U; Viera; es-ES) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.3.3 Chrome/23.0.1271.97 Safari/537.11
+TV	Unknown	Mozilla/5.0 (FreeBSD; U; Viera; it-IT) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.17 Chrome/23.0.1271.97 Safari/537.11 SmartTvA/3.0.0
+TV	Unknown	Mozilla/5.0 (FreeBSD; U; Viera; it-IT) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.3.3 Chrome/23.0.1271.97 Safari/537.11
+TV	Unknown	Mozilla/5.0 (FreeBSD; U; Viera; pt-BR) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.18.1 Chrome/23.0.1271.97 Safari/537.11 SmartTvA/3.0.0
+TV	Unknown	Mozilla/5.0 (FreeBSD; U; Viera; ru-RU) AppleWebKit/535.1 (KHTML, like Gecko) Viera/1.5.2 Chrome/14.0.835.202 Safari/535.1
+TV	Unknown	Mozilla/5.0 (FreeBSD; U; Viera; ru-RU) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.20 Chrome/23.0.1271.97 Safari/537.11 SmartTvA/3.0.0
+TV	Unknown	Mozilla/5.0 (FreeBSD; U; Viera; ru-RU) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.21 Chrome/23.0.1271.97 Safari/537.11 SmartTvA/3.0.0
+TV	Unknown	Mozilla/5.0 (FreeBSD; U; Viera; ru-RU) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.18.1 Chrome/23.0.1271.97 Safari/537.11 SmartTvA/3.0.0
+TV	Unknown	Mozilla/5.0 (FreeBSD; U; Viera; ru-RU) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.3.3 Chrome/23.0.1271.97 Safari/537.11
+TV	Unknown	Mozilla/5.0 (FreeBSD; Viera; ru:34.0) Gecko/20100101 Firefox/34.0
+TV	Unknown	Mozilla/5.0 (FreeBSD; Viera; ru:66.0) Gecko/20100101 Firefox/66.0
+TV	Unknown	Mozilla/5.0 (FreeBSD; Viera; ru:68.0) Gecko/68.0 Firefox/68.0
+TV	Unknown	Mozilla/5.0 (FreeBSD; Viera; rv:34.0) Gecko/20100101 Firefox/34.0
+TV	Unknown	Mozilla/5.0 (Fuchsia) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 CrKey/1.56.500000
+TV	Unknown	Mozilla/5.0 (LG smartTV)
+TV	Linux	Mozilla/5.0 (Linux mips; U;HbbTV/1.1.1 (+RTSP;DMM;Dreambox;0.1a;1.0;) CE-HTML/1.0; en) AppleWebKit/535.19 no/Volksbox QtWebkit/2.2
+TV	Linux	Mozilla/5.0 (Linux mipsel; U; HbbTV/1.1.1 (; TOSHIBA; DTV_L7363; 7.1.90.34.01.1; a5; ) ; ToshibaTP/2.0.0 (+DRM+3D) ; de) AppleWebKit/537.4 (KHTML, like Gecko) TOSHIBA-DTV (DTV_L7363; 7.1.90.34.01.1; 2013A; EU)
+TV	Linux	Mozilla/5.0 (Linux mipsel; U; HbbTV/1.1.1 (; TOSHIBA; DTV_RL838; 55.4.02.0; t12; ) ; ToshibaTP/1.3.0 (+VIDEO_MP4+VIDEO_X_MS_ASF+AUDIO_MPEG+AUDIO_MP4+DRM) ; pl) AppleWebKit/534.1 (KHTML, like Gecko)
+TV	Linux	Mozilla/5.0 (Linux mipsel; U; HbbTV/1.1.1 (; TOSHIBA; DTV_RL933; 56.2.00.0; t12; ) ; ToshibaTP/1.3.0 (+VIDEO_MP4+VIDEO_X_MS_ASF+AUDIO_MPEG+AUDIO_MP4+DRM+NATIVELAUNCH) ; de) AppleWebKit/534.1 (KHTML, like Gecko)
+TV	Linux	Mozilla/5.0 (Linux mipsel; U; HbbTV/1.1.1 (; TOSHIBA; DTV_RL938; 7.0.21.6; a5; ) ; ToshibaTP/1.3.0 (+VIDEO_MP4+VIDEO_X_MS_ASF+AUDIO_MPEG+AUDIO_MP4+DRM+NATIVELAUNCH+WEBSTORAGE+OFFLINEAPP+HAS_CMD_HTTP_SERVER) ; de) AppleWebKit/534.1 (KHTML, like
+TV	Linux	Mozilla/5.0 (Linux mipsel; U; HbbTV/1.1.1 (; TOSHIBA; DTV_TL838; 55.4.02.0; t12; ) ; ToshibaTP/1.3.0 (+VIDEO_MP4+VIDEO_X_MS_ASF+AUDIO_MPEG+AUDIO_MP4+DRM+3D) ; pl) AppleWebKit/534.1 (KHTML, like Gecko)
+TV	Linux	Mozilla/5.0 (Linux mipsel; U; HbbTV/1.1.1 (; TOSHIBA; DTV_TL933; 64.4.08.7; t12; ) ; ToshibaTP/1.3.0 (+VIDEO_MP4+VIDEO_X_MS_ASF+AUDIO_MPEG+AUDIO_MP4+DRM+3D+NATIVELAUNCH+OFFLINEAPP+WEBSTORAGE) ; pl) AppleWebKit/534.1 (KHTML, like Gecko)
+TV	Linux	Mozilla/5.0 (Linux mipsel; U; HbbTV/1.1.1 (; TOSHIBA; DTV_TL938; 7.0.27.9; a5; ) ; ToshibaTP/1.3.0 (+VIDEO_MP4+VIDEO_X_MS_ASF+AUDIO_MPEG+AUDIO_MP4+DRM+3D+NATIVELAUNCH+WEBSTORAGE+OFFLINEAPP+HAS_CMD_HTTP_SERVER) ; en) AppleWebKit/534.1 (KHTML, like Gecko)
+TV	Linux	Mozilla/5.0 (Linux mipsel; U; HbbTV/1.1.1 (; TOSHIBA; DTV_VL963; 64.4.08.7; t12; ) ; ToshibaTP/1.3.0 (+VIDEO_MP4+VIDEO_X_MS_ASF+AUDIO_MPEG+AUDIO_MP4+DRM+3D+NATIVELAUNCH+OFFLINEAPP+WEBSTORAGE) ; pl) AppleWebKit/534.1 (KHTML, like Gecko)
+TV	Linux	Mozilla/5.0 (Linux mipsel; U; HbbTV/1.1.1 (; TOSHIBA; RL858; 43.2.54.0; 1; ) ; ToshibaTP/1.1.0 () ; en) AppleWebKit/534.1 (KHTML, like Gecko)
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.4.2 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.6.2 like Chrome/126.0.6478.238 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.3.2 like Chrome/128.0.6613.146 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.5.4 like Chrome/128.0.6613.194 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.6.1 like Chrome/128.0.6613.194 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.1.71 like Chrome/130.0.6723.86 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.5.7 like Chrome/130.0.6723.142 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.6.5 like Chrome/130.0.6723.184 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/132.1.101 like Chrome/132.0.6834.163 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/136.1.129 like Chrome/136.0.7103.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/138.1.150 like Chrome/138.0.7204.157 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKRT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.3.3 like Chrome/126.0.6478.186 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKRT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.3.2 like Chrome/128.0.6613.146 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKRT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.5.7 like Chrome/130.0.6723.142 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKRT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.6.5 like Chrome/130.0.6723.184 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKRT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/132.1.101 like Chrome/132.0.6834.163 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKRT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/136.3.3 like Chrome/136.0.7103.159 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTKRT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/138.1.150 like Chrome/138.0.7204.157 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.1.84 like Chrome/118.0.5993.111 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.4.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.1.60 like Chrome/122.0.6261.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.2.2 like Chrome/122.0.6261.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.3.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.4.2 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.6.4 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 11; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.2.1 like Chrome/126.0.6478.186 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 12.0; Build/STTL.240206.002) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.0 Safari/537.36 CrKey/1.56.500000 DeviceType/AndroidTV
+TV	Android	Mozilla/5.0 (Linux; Android 4.0.4; Mystery Android Smart TV Build/MYSTERY.SMARTTV.20130816) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.107 Safari/537.36 OPR/29.0.1809.93516
+TV	Android	Mozilla/5.0 (Linux; Android 4.0.4; Woxter Android TV BOX 600 Build/V1.03.02MC03_20121227) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19
+TV	Android	Mozilla/5.0 (Linux; Android 4.1.1; Woxter Android TV 700 Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.63 Safari/537.36 OPR/15.0.1162.61647
+TV	Android	Mozilla/5.0 (Linux; Android 4.2.2; POV_TV-SMARTTV-500 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTB) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTB) AppleWebKit/537.36 (KHTML, like Gecko) Silk/104.2.16 like Chrome/104.0.5112.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTB) AppleWebKit/537.36 (KHTML, like Gecko) Silk/80.1.145 like Chrome/80.0.3987.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTB) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.2.11 like Chrome/88.0.4324.152 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTB) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.3.15 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTB) AppleWebKit/537.36 (KHTML, like Gecko) Silk/92.2.15 like Chrome/92.0.4515.159 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTB) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.4.4 like Chrome/94.0.4606.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.1.135 like Chrome/108.0.5359.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.4.6 like Chrome/108.0.5359.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/80.1.145 like Chrome/80.0.3987.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/81.1.248 like Chrome/81.0.4044.117 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/83.3.19 like Chrome/83.0.4103.106 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.3.20 like Chrome/86.0.4240.198 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.4.18 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.1.159 like Chrome/89.0.4389.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.4.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTRS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.1.135 like Chrome/108.0.5359.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS Build/LVY48F) AppleWebKit/537.36 (KHTML, like Gecko) Silk/62.7.2 like Chrome/62.0.3202.84 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/104.2.16 like Chrome/104.0.5112.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.1.135 like Chrome/108.0.5359.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.16.2 like Chrome/108.0.5359.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.17.5 like Chrome/108.0.5359.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.3.7 like Chrome/108.0.5359.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/81.1.248 like Chrome/81.0.4044.117 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/83.1.135 like Chrome/83.0.4103.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.2.40 like Chrome/86.0.4240.185 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.3.20 like Chrome/86.0.4240.198 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/87.1.160 like Chrome/87.0.4280.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.2.11 like Chrome/88.0.4324.152 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/92.2.15 like Chrome/92.0.4515.159 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.3.18 like Chrome/94.0.4606.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.4.4 like Chrome/94.0.4606.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.1.237 like Chrome/96.0.4664.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.2.5 like Chrome/98.0.4758.123 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/108.3.7 like Chrome/108.0.5359.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/93.2.7 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.1.153 like Chrome/100.0.4896.127 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.1.178 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.2.1 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.3.17 like Chrome/102.0.5005.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/104.2.16 like Chrome/104.0.5112.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.1.144 like Chrome/106.0.5249.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.2.7 like Chrome/106.0.5249.170 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.3.7 like Chrome/106.0.5249.170 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.4.4 like Chrome/106.0.5249.190 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.5.14 like Chrome/106.0.5249.208 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.1.135 like Chrome/108.0.5359.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.10.4 like Chrome/108.0.5359.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.12.8 like Chrome/108.0.5359.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.13.3 like Chrome/108.0.5359.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.14.4 like Chrome/108.0.5359.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.16.2 like Chrome/108.0.5359.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.17.5 like Chrome/108.0.5359.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.3.7 like Chrome/108.0.5359.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.4.6 like Chrome/108.0.5359.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.6.6 like Chrome/108.0.5359.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.7.2 like Chrome/108.0.5359.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.8.5 like Chrome/108.0.5359.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.9.6 like Chrome/108.0.5359.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.4.3 like Chrome/110.0.5481.212 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/79.5.1 like Chrome/79.0.3945.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/79.6.3 like Chrome/79.0.3945.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/80.1.145 like Chrome/80.0.3987.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/80.5.11 like Chrome/80.0.3987.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/81.1.248 like Chrome/81.0.4044.117 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/83.1.135 like Chrome/83.0.4103.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/83.2.20 like Chrome/83.0.4103.106 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/83.3.19 like Chrome/83.0.4103.106 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/84.2.3 like Chrome/84.0.4147.111 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/84.3.5 like Chrome/84.0.4147.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.2.1 like Chrome/85.0.4183.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.3.7 like Chrome/85.0.4183.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.4.5 like Chrome/85.0.4183.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.1.106 like Chrome/86.0.4240.110 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.2.40 like Chrome/86.0.4240.185 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.3.20 like Chrome/86.0.4240.198 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/87.1.160 like Chrome/87.0.4280.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/87.2.4 like Chrome/87.0.4280.141 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.2.11 like Chrome/88.0.4324.152 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.3.15 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.4.18 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.1.122 like Chrome/89.0.4389.90 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.1.159 like Chrome/89.0.4389.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/90.2.29 like Chrome/90.0.4430.210 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/90.3.2 like Chrome/90.0.4430.210 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.1.138 like Chrome/91.0.4472.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.4.3 like Chrome/91.0.4472.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/92.2.15 like Chrome/92.0.4515.159 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.1.131 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.2.7 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.3.51 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.1.208 like Chrome/94.0.4606.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.3.18 like Chrome/94.0.4606.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.4.4 like Chrome/94.0.4606.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.1.237 like Chrome/96.0.4664.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.2.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.4.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.1.152 like Chrome/98.0.4758.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.2.5 like Chrome/98.0.4758.123 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.4.4 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.6.10 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1.1; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.7.2 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 5.1; AFTS Build/LMY47O) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/41.99900.2250.0242 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/79.5.1 like Chrome/79.0.3945.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/83.1.135 like Chrome/83.0.4103.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.2.1 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.3.17 like Chrome/102.0.5005.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.16.1 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/81.1.248 like Chrome/81.0.4044.117 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/83.1.135 like Chrome/83.0.4103.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.4.5 like Chrome/85.0.4183.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.2.40 like Chrome/86.0.4240.185 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.3.20 like Chrome/86.0.4240.198 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/87.1.160 like Chrome/87.0.4280.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/87.2.4 like Chrome/87.0.4280.141 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.2.11 like Chrome/88.0.4324.152 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.3.15 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.4.18 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.1.159 like Chrome/89.0.4389.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/90.3.2 like Chrome/90.0.4430.210 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.4.3 like Chrome/91.0.4472.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/92.2.15 like Chrome/92.0.4515.159 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.3.51 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.1.208 like Chrome/94.0.4606.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.4.4 like Chrome/94.0.4606.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.2.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.1.152 like Chrome/98.0.4758.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBU001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.1.237 like Chrome/96.0.4664.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTBU001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.2.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.2.1 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.3.17 like Chrome/102.0.5005.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.5.14 like Chrome/106.0.5249.208 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.6.7 like Chrome/110.0.5481.212 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.18.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.25.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.3.1 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.5.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.7.1 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/83.3.19 like Chrome/83.0.4103.106 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.4.5 like Chrome/85.0.4183.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.2.40 like Chrome/86.0.4240.185 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/87.1.160 like Chrome/87.0.4280.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/87.2.4 like Chrome/87.0.4280.141 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.4.18 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.1.159 like Chrome/89.0.4389.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/90.3.2 like Chrome/90.0.4430.210 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.1.138 like Chrome/91.0.4472.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.4.3 like Chrome/91.0.4472.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/92.2.15 like Chrome/92.0.4515.159 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.2.7 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.3.51 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.1.208 like Chrome/94.0.4606.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.3.18 like Chrome/94.0.4606.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.4.4 like Chrome/94.0.4606.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.1.237 like Chrome/96.0.4664.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.4.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.1.152 like Chrome/98.0.4758.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.4.4 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTJMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.4.3 like Chrome/110.0.5481.212 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTJMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/112.2.7 like Chrome/112.0.5615.174 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTJMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/80.1.145 like Chrome/80.0.3987.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTJMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/80.5.11 like Chrome/80.0.3987.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTJMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/81.1.248 like Chrome/81.0.4044.117 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTJMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/83.1.135 like Chrome/83.0.4103.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTJMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/84.2.3 like Chrome/84.0.4147.111 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTJMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/84.3.5 like Chrome/84.0.4147.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTJMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.3.7 like Chrome/85.0.4183.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTJMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.2.40 like Chrome/86.0.4240.185 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTJMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/90.3.2 like Chrome/90.0.4430.210 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.1.153 like Chrome/100.0.4896.127 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.2.1 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.3.17 like Chrome/102.0.5005.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/114.3.11 like Chrome/114.0.5735.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.6.1 like Chrome/116.0.5845.229 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.14.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.6.3 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.7.1 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/73.5.7 like Chrome/73.0.3683.90 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/79.5.1 like Chrome/79.0.3945.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/79.6.3 like Chrome/79.0.3945.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/80.1.145 like Chrome/80.0.3987.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/83.1.135 like Chrome/83.0.4103.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.3.7 like Chrome/85.0.4183.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.4.5 like Chrome/85.0.4183.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.1.106 like Chrome/86.0.4240.110 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.3.20 like Chrome/86.0.4240.198 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.4.18 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.1.159 like Chrome/89.0.4389.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/90.3.2 like Chrome/90.0.4430.210 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.1.138 like Chrome/91.0.4472.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.4.3 like Chrome/91.0.4472.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.1.208 like Chrome/94.0.4606.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTKMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.4.4 like Chrome/94.0.4606.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTLE) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTLE) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.2.1 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTLE) AppleWebKit/537.36 (KHTML, like Gecko) Silk/81.1.248 like Chrome/81.0.4044.117 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTLE) AppleWebKit/537.36 (KHTML, like Gecko) Silk/83.3.19 like Chrome/83.0.4103.106 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTLE) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.1.159 like Chrome/89.0.4389.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/116.3.2 like Chrome/116.0.5845.187 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/98.1.152 like Chrome/98.0.4758.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/98.4.4 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.1.153 like Chrome/100.0.4896.127 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.1.178 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.2.1 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.3.17 like Chrome/102.0.5005.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/104.1.154 like Chrome/104.0.5112.97 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/104.2.16 like Chrome/104.0.5112.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.1.144 like Chrome/106.0.5249.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.2.7 like Chrome/106.0.5249.170 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.3.7 like Chrome/106.0.5249.170 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.4.4 like Chrome/106.0.5249.190 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.5.14 like Chrome/106.0.5249.208 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.1.135 like Chrome/108.0.5359.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.1.77 like Chrome/110.0.5481.154 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.4.3 like Chrome/110.0.5481.212 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.6.7 like Chrome/110.0.5481.212 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/112.4.29 like Chrome/112.0.5615.213 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/114.2.7 like Chrome/114.0.5735.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/114.3.11 like Chrome/114.0.5735.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.3.2 like Chrome/116.0.5845.187 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.4.3 like Chrome/116.0.5845.187 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.6.1 like Chrome/116.0.5845.229 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.1.84 like Chrome/118.0.5993.111 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.10.3 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.11.3 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.12.4 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.13.3 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.14.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.15.1 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.16.1 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.18.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.2.12 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.20.12 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.25.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.3.1 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.4.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.5.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.6.3 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.7.1 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/78.3.19 like Chrome/78.0.3904.108 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/79.5.1 like Chrome/79.0.3945.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/79.6.3 like Chrome/79.0.3945.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/80.1.145 like Chrome/80.0.3987.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/80.5.11 like Chrome/80.0.3987.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/81.1.248 like Chrome/81.0.4044.117 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/83.1.135 like Chrome/83.0.4103.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/83.3.19 like Chrome/83.0.4103.106 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/84.2.3 like Chrome/84.0.4147.111 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/84.3.5 like Chrome/84.0.4147.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.2.1 like Chrome/85.0.4183.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.3.7 like Chrome/85.0.4183.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.4.5 like Chrome/85.0.4183.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.1.106 like Chrome/86.0.4240.110 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.2.40 like Chrome/86.0.4240.185 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.3.20 like Chrome/86.0.4240.198 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/87.1.160 like Chrome/87.0.4280.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/87.2.4 like Chrome/87.0.4280.141 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.2.11 like Chrome/88.0.4324.152 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.3.15 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.4.18 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.1.159 like Chrome/89.0.4389.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/90.3.2 like Chrome/90.0.4430.210 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.1.138 like Chrome/91.0.4472.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.4.3 like Chrome/91.0.4472.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/92.1.214 like Chrome/92.0.4515.131 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/92.2.15 like Chrome/92.0.4515.159 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.2.7 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.3.51 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.1.208 like Chrome/94.0.4606.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.3.18 like Chrome/94.0.4606.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.4.4 like Chrome/94.0.4606.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.1.237 like Chrome/96.0.4664.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.2.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.4.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.1.152 like Chrome/98.0.4758.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.2.5 like Chrome/98.0.4758.123 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.4.4 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.5.8 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.6.10 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTMM) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.7.2 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.2.1 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.1.135 like Chrome/108.0.5359.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.12.4 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.13.3 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.14.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.6.3 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.7.1 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.9.1 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/80.1.145 like Chrome/80.0.3987.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/81.1.248 like Chrome/81.0.4044.117 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/83.1.135 like Chrome/83.0.4103.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/84.2.3 like Chrome/84.0.4147.111 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.3.7 like Chrome/85.0.4183.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.3.20 like Chrome/86.0.4240.198 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.1.159 like Chrome/89.0.4389.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.4.3 like Chrome/91.0.4472.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.2.7 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTN) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.1.237 like Chrome/96.0.4664.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTTIFF55) AppleWebKit/537.36 (KHTML, like Gecko) Silk/87.2.4 like Chrome/87.0.4280.141 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 7.1.2; AFTTIFF55) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.1.159 like Chrome/89.0.4389.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFT6E0FA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/132.1.101 like Chrome/132.0.6834.163 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTALMO) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.4.3 like Chrome/116.0.5845.187 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTALMO) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.5.1 like Chrome/116.0.5845.229 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTALMO) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.1.84 like Chrome/118.0.5993.111 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTALMO) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.3.1 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTALMO) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.2.3 like Chrome/120.0.6099.232 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTALMO) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.6.4 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTALMO) AppleWebKit/537.36 (KHTML, like Gecko) Silk/124.3.2 like Chrome/124.0.6367.221 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTANNA0) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.1.135 like Chrome/108.0.5359.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTANNA0) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.3.2 like Chrome/116.0.5845.187 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTANNA0) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.5.1 like Chrome/116.0.5845.229 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTANNA0) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.1.84 like Chrome/118.0.5993.111 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTANNA0) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.4.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTBOXE1) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.4.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTBOXE1) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.4.3 like Chrome/120.0.6099.266 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTBOXE1) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.4.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTBOXE1) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.3.3 like Chrome/126.0.6478.186 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTBOXE1) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.6.2 like Chrome/126.0.6478.238 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTBOXE1) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.3.2 like Chrome/128.0.6613.146 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTBOXE1) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.5.7 like Chrome/130.0.6723.142 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTBOXE1) AppleWebKit/537.36 (KHTML, like Gecko) Silk/132.1.101 like Chrome/132.0.6834.163 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTBOXE1) AppleWebKit/537.36 (KHTML, like Gecko) Silk/134.4.17 like Chrome/134.0.6998.207 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.2.1 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.3.17 like Chrome/102.0.5005.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.5.14 like Chrome/106.0.5249.208 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.6.2 like Chrome/126.0.6478.238 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.6.1 like Chrome/128.0.6613.194 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.6.5 like Chrome/130.0.6723.184 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/132.5.5 like Chrome/132.0.6834.209 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/136.3.3 like Chrome/136.0.7103.159 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/84.3.5 like Chrome/84.0.4147.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.2.40 like Chrome/86.0.4240.185 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.3.20 like Chrome/86.0.4240.198 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.3.15 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.4.18 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/90.3.2 like Chrome/90.0.4430.210 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.1.138 like Chrome/91.0.4472.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.4.3 like Chrome/91.0.4472.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/92.2.15 like Chrome/92.0.4515.159 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.2.7 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.3.51 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.1.208 like Chrome/94.0.4606.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.4.4 like Chrome/94.0.4606.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.1.152 like Chrome/98.0.4758.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTDCT31) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.7.2 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU011) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.6.7 like Chrome/110.0.5481.212 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU011) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.1.138 like Chrome/91.0.4472.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.2.1 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/104.2.16 like Chrome/104.0.5112.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.2.7 like Chrome/106.0.5249.170 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.5.14 like Chrome/106.0.5249.208 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.1.135 like Chrome/108.0.5359.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.1.77 like Chrome/110.0.5481.154 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.4.3 like Chrome/110.0.5481.212 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.6.7 like Chrome/110.0.5481.212 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/112.2.7 like Chrome/112.0.5615.174 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/112.5.1 like Chrome/112.0.5615.213 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/114.3.11 like Chrome/114.0.5735.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.1.84 like Chrome/118.0.5993.111 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.4.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.1.159 like Chrome/89.0.4389.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.1.208 like Chrome/94.0.4606.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.1.237 like Chrome/96.0.4664.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.1.152 like Chrome/98.0.4758.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTEU014) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.6.10 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTGAZL) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.4.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTGAZL) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.4.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTGAZL) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.3.2 like Chrome/128.0.6613.146 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTGAZL) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.6.1 like Chrome/128.0.6613.194 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTHA001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTHA001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.2.3 like Chrome/120.0.6099.232 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTHA001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/136.3.3 like Chrome/136.0.7103.159 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTHA001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/136.7.3 like Chrome/136.0.7103.169 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTHA001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.4.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTHA001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.7.2 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTHA002) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.5.1 like Chrome/126.0.6478.238 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTHA002) AppleWebKit/537.36 (KHTML, like Gecko) Silk/132.5.5 like Chrome/132.0.6834.209 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTHA003) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTHA004) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.6.2 like Chrome/126.0.6478.238 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTHA004) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.6.5 like Chrome/130.0.6723.184 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTHA004) AppleWebKit/537.36 (KHTML, like Gecko) Silk/132.1.101 like Chrome/132.0.6834.163 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTJULI1) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.3.17 like Chrome/102.0.5005.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTJULI1) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.5.14 like Chrome/106.0.5249.208 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTJULI1) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.3.1 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTJULI1) AppleWebKit/537.36 (KHTML, like Gecko) Silk/124.5.2 like Chrome/124.0.6367.248 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/118.1.84 like Chrome/118.0.5993.111 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.1.153 like Chrome/100.0.4896.127 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.2.1 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.3.17 like Chrome/102.0.5005.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/104.1.154 like Chrome/104.0.5112.97 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/104.2.16 like Chrome/104.0.5112.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.1.144 like Chrome/106.0.5249.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.3.7 like Chrome/106.0.5249.170 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.4.4 like Chrome/106.0.5249.190 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.5.14 like Chrome/106.0.5249.208 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.1.135 like Chrome/108.0.5359.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.4.3 like Chrome/110.0.5481.212 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.6.7 like Chrome/110.0.5481.212 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/112.5.1 like Chrome/112.0.5615.213 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/112.6.11 like Chrome/112.0.5615.213 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/112.7.5 like Chrome/112.0.5615.213 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/114.2.7 like Chrome/114.0.5735.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/114.3.11 like Chrome/114.0.5735.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.3.2 like Chrome/116.0.5845.187 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.4.3 like Chrome/116.0.5845.187 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.5.1 like Chrome/116.0.5845.229 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.6.1 like Chrome/116.0.5845.229 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.1.84 like Chrome/118.0.5993.111 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.2.12 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.3.1 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.4.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.1.53 like Chrome/120.0.6099.193 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.2.3 like Chrome/120.0.6099.232 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.4.3 like Chrome/120.0.6099.266 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.5.10 like Chrome/120.0.6099.295 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.1.60 like Chrome/122.0.6261.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.2.2 like Chrome/122.0.6261.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.3.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.4.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.4.2 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.5.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.6.4 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/124.3.2 like Chrome/124.0.6367.221 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.2.1 like Chrome/126.0.6478.186 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.3.3 like Chrome/126.0.6478.186 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.5.1 like Chrome/126.0.6478.238 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.6.2 like Chrome/126.0.6478.238 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.3.2 like Chrome/128.0.6613.146 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.6.1 like Chrome/128.0.6613.194 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.1.71 like Chrome/130.0.6723.86 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.6.5 like Chrome/130.0.6723.184 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/132.1.101 like Chrome/132.0.6834.163 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/136.7.3 like Chrome/136.0.7103.169 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.2.7 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.3.51 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.1.208 like Chrome/94.0.4606.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.4.4 like Chrome/94.0.4606.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.1.237 like Chrome/96.0.4664.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.4.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.2.5 like Chrome/98.0.4758.123 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.4.4 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKA002) AppleWebKit/537.36 (KHTML, like Gecko) Silk/134.4.17 like Chrome/134.0.6998.207 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKAUK001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.2.3 like Chrome/120.0.6099.232 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTKAUK001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.3.2 like Chrome/128.0.6613.146 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTPR001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.2.1 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTPR001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.3.17 like Chrome/102.0.5005.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTPR001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.4.18 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTPR001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.1.138 like Chrome/91.0.4472.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTPR001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.1.237 like Chrome/96.0.4664.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/120.2.3 like Chrome/120.0.6099.232 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.1.153 like Chrome/100.0.4896.127 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.2.1 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.3.17 like Chrome/102.0.5005.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/104.2.16 like Chrome/104.0.5112.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.1.135 like Chrome/108.0.5359.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.1.77 like Chrome/110.0.5481.154 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.6.7 like Chrome/110.0.5481.212 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/114.2.7 like Chrome/114.0.5735.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.4.3 like Chrome/116.0.5845.187 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.5.1 like Chrome/116.0.5845.229 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.6.1 like Chrome/116.0.5845.229 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.1.84 like Chrome/118.0.5993.111 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.2.12 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.3.1 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.4.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.3.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.6.2 like Chrome/126.0.6478.238 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.5.7 like Chrome/130.0.6723.142 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/132.1.101 like Chrome/132.0.6834.163 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/136.3.3 like Chrome/136.0.7103.159 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/80.1.145 like Chrome/80.0.3987.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/80.5.11 like Chrome/80.0.3987.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/83.3.19 like Chrome/83.0.4103.106 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.3.7 like Chrome/85.0.4183.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.4.5 like Chrome/85.0.4183.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.3.20 like Chrome/86.0.4240.198 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/87.1.160 like Chrome/87.0.4280.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/87.2.4 like Chrome/87.0.4280.141 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.2.11 like Chrome/88.0.4324.152 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.3.15 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.4.18 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.1.159 like Chrome/89.0.4389.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/90.3.2 like Chrome/90.0.4430.210 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.1.138 like Chrome/91.0.4472.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.1.151 like Chrome/91.0.4472.120 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.4.3 like Chrome/91.0.4472.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/92.2.15 like Chrome/92.0.4515.159 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.2.7 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.1.208 like Chrome/94.0.4606.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.4.4 like Chrome/94.0.4606.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.1.237 like Chrome/96.0.4664.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.4.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.2.5 like Chrome/98.0.4758.123 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTR) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.4.4 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSHN01) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.4.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSHN01) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.2.3 like Chrome/120.0.6099.232 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSHN01) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.4.3 like Chrome/120.0.6099.266 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSHN01) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.5.10 like Chrome/120.0.6099.295 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSHN01) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.2.2 like Chrome/122.0.6261.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSHN01) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.3.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSHN01) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.4.2 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSHN01) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.6.4 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSHN01) AppleWebKit/537.36 (KHTML, like Gecko) Silk/124.5.2 like Chrome/124.0.6367.248 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSHN01) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.3.3 like Chrome/126.0.6478.186 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSHN01) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.6.2 like Chrome/126.0.6478.238 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSHN01) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.3.2 like Chrome/128.0.6613.146 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSHN01) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.6.1 like Chrome/128.0.6613.194 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.1.153 like Chrome/100.0.4896.127 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.2.1 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.3.17 like Chrome/102.0.5005.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/104.2.16 like Chrome/104.0.5112.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.5.14 like Chrome/106.0.5249.208 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.1.135 like Chrome/108.0.5359.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.1.77 like Chrome/110.0.5481.154 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.6.7 like Chrome/110.0.5481.212 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/114.2.7 like Chrome/114.0.5735.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.1.84 like Chrome/118.0.5993.111 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.2.12 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.3.1 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.4.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.2.3 like Chrome/120.0.6099.232 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.4.3 like Chrome/120.0.6099.266 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.4.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.4.2 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/81.1.248 like Chrome/81.0.4044.117 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.4.5 like Chrome/85.0.4183.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.3.20 like Chrome/86.0.4240.198 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.1.159 like Chrome/89.0.4389.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.2.7 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.3.51 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.1.208 like Chrome/94.0.4606.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.4.4 like Chrome/94.0.4606.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.4.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSO001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.4.4 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/110.1.77 like Chrome/110.0.5481.154 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/116.6.1 like Chrome/116.0.5845.229 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/122.4.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/94.4.4 like Chrome/94.0.4606.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/98.6.10 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.1.153 like Chrome/100.0.4896.127 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.1.178 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.2.1 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.3.17 like Chrome/102.0.5005.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/104.1.154 like Chrome/104.0.5112.97 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/104.2.16 like Chrome/104.0.5112.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.1.144 like Chrome/106.0.5249.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.2.7 like Chrome/106.0.5249.170 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.3.7 like Chrome/106.0.5249.170 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.4.4 like Chrome/106.0.5249.190 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.5.14 like Chrome/106.0.5249.208 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.1.135 like Chrome/108.0.5359.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.1.77 like Chrome/110.0.5481.154 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.4.3 like Chrome/110.0.5481.212 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.6.7 like Chrome/110.0.5481.212 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/112.2.7 like Chrome/112.0.5615.174 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/112.6.11 like Chrome/112.0.5615.213 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/112.7.5 like Chrome/112.0.5615.213 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/114.2.7 like Chrome/114.0.5735.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/114.3.11 like Chrome/114.0.5735.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.1.80 like Chrome/116.0.5845.163 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.3.2 like Chrome/116.0.5845.187 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.4.3 like Chrome/116.0.5845.187 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.5.1 like Chrome/116.0.5845.229 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.6.1 like Chrome/116.0.5845.229 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.1.84 like Chrome/118.0.5993.111 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.2.12 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.3.1 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.4.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.2.3 like Chrome/120.0.6099.232 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.4.3 like Chrome/120.0.6099.266 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.5.10 like Chrome/120.0.6099.295 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.1.60 like Chrome/122.0.6261.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.2.2 like Chrome/122.0.6261.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.3.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.4.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.4.2 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.5.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.6.4 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/124.3.2 like Chrome/124.0.6367.221 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/124.5.2 like Chrome/124.0.6367.248 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.3.3 like Chrome/126.0.6478.186 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.5.1 like Chrome/126.0.6478.238 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.6.2 like Chrome/126.0.6478.238 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.2.3 like Chrome/128.0.6613.146 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.3.2 like Chrome/128.0.6613.146 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.6.1 like Chrome/128.0.6613.194 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.1.71 like Chrome/130.0.6723.86 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.5.7 like Chrome/130.0.6723.142 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.6.5 like Chrome/130.0.6723.184 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/132.1.101 like Chrome/132.0.6834.163 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/132.4.1 like Chrome/132.0.6834.209 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/132.5.5 like Chrome/132.0.6834.209 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/134.2.6 like Chrome/134.0.6998.188 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/134.4.17 like Chrome/134.0.6998.207 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/136.1.129 like Chrome/136.0.7103.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/136.3.3 like Chrome/136.0.7103.159 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/136.7.3 like Chrome/136.0.7103.169 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.4.5 like Chrome/85.0.4183.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.2.40 like Chrome/86.0.4240.185 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.3.20 like Chrome/86.0.4240.198 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/87.1.160 like Chrome/87.0.4280.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/87.2.4 like Chrome/87.0.4280.141 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.2.11 like Chrome/88.0.4324.152 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.3.15 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.4.18 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.1.159 like Chrome/89.0.4389.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/90.3.2 like Chrome/90.0.4430.210 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.1.138 like Chrome/91.0.4472.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.4.3 like Chrome/91.0.4472.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/92.1.214 like Chrome/92.0.4515.131 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/92.2.15 like Chrome/92.0.4515.159 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.2.7 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.3.51 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.1.208 like Chrome/94.0.4606.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.3.18 like Chrome/94.0.4606.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.4.4 like Chrome/94.0.4606.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.1.237 like Chrome/96.0.4664.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.2.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.4.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.1.152 like Chrome/98.0.4758.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.2.5 like Chrome/98.0.4758.123 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.4.4 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.5.8 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.6.10 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.7.2 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/108.1.135 like Chrome/108.0.5359.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/91.4.3 like Chrome/91.0.4472.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/93.2.7 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.1.153 like Chrome/100.0.4896.127 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.1.178 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.2.1 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.3.17 like Chrome/102.0.5005.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/104.1.154 like Chrome/104.0.5112.97 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/104.2.16 like Chrome/104.0.5112.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.1.144 like Chrome/106.0.5249.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.2.7 like Chrome/106.0.5249.170 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.3.7 like Chrome/106.0.5249.170 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.4.4 like Chrome/106.0.5249.190 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.5.14 like Chrome/106.0.5249.208 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/108.1.135 like Chrome/108.0.5359.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.4.3 like Chrome/110.0.5481.212 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.6.7 like Chrome/110.0.5481.212 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/112.2.7 like Chrome/112.0.5615.174 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/112.5.1 like Chrome/112.0.5615.213 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/112.6.11 like Chrome/112.0.5615.213 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/114.2.7 like Chrome/114.0.5735.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/114.3.11 like Chrome/114.0.5735.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.1.80 like Chrome/116.0.5845.163 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.3.2 like Chrome/116.0.5845.187 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.4.3 like Chrome/116.0.5845.187 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.5.1 like Chrome/116.0.5845.229 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.6.1 like Chrome/116.0.5845.229 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.1.84 like Chrome/118.0.5993.111 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.2.12 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.4.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.2.3 like Chrome/120.0.6099.232 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.4.3 like Chrome/120.0.6099.266 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.5.10 like Chrome/120.0.6099.295 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.1.60 like Chrome/122.0.6261.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.2.2 like Chrome/122.0.6261.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.3.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.4.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.4.2 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.5.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.6.4 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/124.5.2 like Chrome/124.0.6367.248 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.2.1 like Chrome/126.0.6478.186 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.5.1 like Chrome/126.0.6478.238 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.6.2 like Chrome/126.0.6478.238 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.3.2 like Chrome/128.0.6613.146 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.5.4 like Chrome/128.0.6613.194 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.1.71 like Chrome/130.0.6723.86 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.5.7 like Chrome/130.0.6723.142 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/130.6.5 like Chrome/130.0.6723.184 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/132.1.101 like Chrome/132.0.6834.163 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/132.5.5 like Chrome/132.0.6834.209 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/134.2.6 like Chrome/134.0.6998.188 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/136.1.129 like Chrome/136.0.7103.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/136.7.3 like Chrome/136.0.7103.169 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.3.7 like Chrome/85.0.4183.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/85.4.5 like Chrome/85.0.4183.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.2.40 like Chrome/86.0.4240.185 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/86.3.20 like Chrome/86.0.4240.198 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/87.1.160 like Chrome/87.0.4280.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/87.2.4 like Chrome/87.0.4280.141 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.2.11 like Chrome/88.0.4324.152 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.3.15 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.4.18 like Chrome/88.0.4324.181 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.1.159 like Chrome/89.0.4389.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/90.2.29 like Chrome/90.0.4430.210 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/90.3.2 like Chrome/90.0.4430.210 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.1.138 like Chrome/91.0.4472.114 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.2.16 like Chrome/91.0.4472.133 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/91.4.3 like Chrome/91.0.4472.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/92.1.214 like Chrome/92.0.4515.131 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/92.2.15 like Chrome/92.0.4515.159 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.1.131 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.2.7 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.3.51 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.1.208 like Chrome/94.0.4606.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.3.18 like Chrome/94.0.4606.126 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.4.4 like Chrome/94.0.4606.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.1.237 like Chrome/96.0.4664.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.2.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.4.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.1.152 like Chrome/98.0.4758.101 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.2.5 like Chrome/98.0.4758.123 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.4.4 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.6.10 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTSSS) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.7.2 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.5.10 like Chrome/120.0.6099.295 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/124.5.2 like Chrome/124.0.6367.248 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/134.2.6 like Chrome/134.0.6998.188 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/93.2.7 like Chrome/93.0.4577.82 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTT) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.1.237 like Chrome/96.0.4664.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML%2C like Gecko) Silk/114.2.7 like Chrome/114.0.5735.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.2.1 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.3.17 like Chrome/102.0.5005.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.4.4 like Chrome/106.0.5249.190 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/112.7.5 like Chrome/112.0.5615.213 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/114.2.7 like Chrome/114.0.5735.220 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.3.2 like Chrome/116.0.5845.187 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.5.1 like Chrome/116.0.5845.229 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/116.6.1 like Chrome/116.0.5845.229 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.4.3 like Chrome/120.0.6099.266 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.5.10 like Chrome/120.0.6099.295 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.2.2 like Chrome/122.0.6261.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.6.4 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.3.3 like Chrome/126.0.6478.186 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/126.6.2 like Chrome/126.0.6478.238 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.3.2 like Chrome/128.0.6613.146 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTI43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/132.1.101 like Chrome/132.0.6834.163 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTIFF43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.2.23 like Chrome/100.0.4896.162 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTIFF43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.2.1 like Chrome/102.0.5005.125 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTIFF43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/102.3.17 like Chrome/102.0.5005.164 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTIFF43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/106.5.14 like Chrome/106.0.5249.208 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTIFF43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/120.5.10 like Chrome/120.0.6099.295 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTIFF43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/128.3.2 like Chrome/128.0.6613.146 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTIFF43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.1.237 like Chrome/96.0.4664.128 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTTIFF43) AppleWebKit/537.36 (KHTML, like Gecko) Silk/98.4.4 like Chrome/98.0.4758.136 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTWI001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/100.1.153 like Chrome/100.0.4896.127 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTWI001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/110.4.3 like Chrome/110.0.5481.212 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTWI001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/118.4.2 like Chrome/118.0.5993.155 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTWI001) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.2.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTWMST22 Build/PS7233; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/88.0.4324.152 Mobile Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTWMST22) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.3.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTWMST22) AppleWebKit/537.36 (KHTML, like Gecko) Silk/122.4.1 like Chrome/122.0.6261.160 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTWMST22) AppleWebKit/537.36 (KHTML, like Gecko) Silk/124.5.2 like Chrome/124.0.6367.248 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTWMST22) AppleWebKit/537.36 (KHTML, like Gecko) Silk/138.1.150 like Chrome/138.0.7204.157 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTWMST22) AppleWebKit/537.36 (KHTML, like Gecko) Silk/88.2.11 like Chrome/88.0.4324.152 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTWMST22) AppleWebKit/537.36 (KHTML, like Gecko) Silk/89.1.159 like Chrome/89.0.4389.105 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTWMST22) AppleWebKit/537.36 (KHTML, like Gecko) Silk/94.1.208 like Chrome/94.0.4606.119 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; AFTWMST22) AppleWebKit/537.36 (KHTML, like Gecko) Silk/96.2.18 like Chrome/96.0.4664.175 Safari/537.36
+TV	Android	Mozilla/5.0 (Linux; Android 9; SHIELD Android TV Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Silk/62.4.4 like Chrome/62.0.3202.84 Safari/537.36
+TV	Linux	Mozilla/5.0 (Linux; BRAVIA 2015 Build/LMY48E.S39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.101 Safari/537.36 OPR/28.0.1754.0 OMI/4.4.22.20.E102586-1.113 SonyCEBrowser/1.0 (KDL-50W800C; CTV/PKG2.465.0017PAA; AUS;)
+TV	Android	Mozilla/5.0 (Linux; GoogleTV 3.2; LG Google TV G3 Build/MASTER) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.77 Safari/534.24
+TV	Android	Mozilla/5.0 (Linux; GoogleTV 3.2; NSZ-GS7/GX70 Build/MASTER) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.77 Safari/534.24
+TV	Android	Mozilla/5.0 (Linux; GoogleTV 4.0.4; LG Google TV Build/000000) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.77 Safari/534.24
+TV	Linux	Mozilla/5.0 (Linux; NetCast; U) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.33 Safari/537.31 SmartTV/5.0
+TV	Linux	Mozilla/5.0 (Linux; NetCast; U) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/34.0.1847.137 Safari/537.31 SmartTV/6.0
+TV	Linux	Mozilla/5.0 (Linux; NetCast; U) AppleWebKit/537.4 (KHTML, like Gecko) Chrome/22.0.1229.79 Safari/537.4 SmartTV/4.6
+TV	Tizen	Mozilla/5.0 (Linux; Tizen 2.3) AppleWebKit/538.1 (KHTML, like Gecko)Version/2.3 TV Safari/538.1
+TV	Android	Mozilla/5.0 (Linux; U; Android 4.2.2; en-gb; AFTM Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
+TV	Android	Mozilla/5.0 (Linux; U; Android 5.1.1; de-de; AFTT Build/JDQ39) waipu/4.1.0-bf2db044d (TV; Amazon; AFTT; waipu; FireOS 5.1.1) AppleWebKit/537.36 (KHTML, like Gecko) Silk/62.6.25 like Chrome/62.0.3202.84 Safari/537.36
+TV	Linux	Mozilla/5.0 (QtEmbedded; Linux) AppleWebKit/537.4 (KHTML, like Gecko) MWB/1.0 Safari/537.4 HbbTV/1.1.1 (; TOSHIBA; MWB;;;)
+TV	Linux	Mozilla/5.0 (SAMSUNG; SAMSUNG-SMART-TV; U; Linux/SmartTV) AppleWebKit/531.2+ (KHTML, like Gecko) WebBrowser/1.0 SmartTV Safari/531.2+
+TV	Tizen	Mozilla/5.0 (SMART-TV; LINUX; Tizen 6.5) AppleWebKit/537.36 (KHTML, like Gecko) 85.0.4183.93/6.5 TV Safari/537.36
+TV	Tizen	Mozilla/5.0 (SMART-TV; Linux; Tizen 2.3) AppleWebkit/538.1 (KHTML, like Gecko) SamsungBrowser/1.0 TV Safari/538.1
+TV	Tizen	Mozilla/5.0 (SMART-TV; Linux; Tizen 4.0) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.1 Chrome/56.0.2924.0 TV Safari/537.36
+TV	Linux	Mozilla/5.0 (SMART-TV; X11; Linux armv7l) AppleWebKit/537.42 (KHTML, like Gecko) Chromium/25.0.1349.2 Chrome/25.0.1349.2 Safari/537.42
+TV	Linux	Mozilla/5.0 (SMART-TV; X11; Linux i686) AppleWebKit/534.7 (KHTML, like Gecko) Version/5.0 Safari/534.7
+TV	Linux	Mozilla/5.0 (SMART-TV; X11; Linux i686) AppleWebKit/535.20+ (KHTML, like Gecko) Version/5.0 Safari/535.20+
+TV	Unknown	Mozilla/5.0 (Spyglass 3.0; OpenTV) Gecko/20081010  InettvBrowser/1.0 (F00001;OTV-IB24L;2.4;00000),gzip(gfe),gzip(gfe),gzip(gfe)
+TV	Linux	Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ HbbTV/1.1.1 ( ;LGE ;NetCast 4.0 ;03.01.42 ;1.0M ;)
+TV	Linux	Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ HbbTV/1.1.1 ( ;LGE ;NetCast 4.0 ;03.20.30 ;1.0M ;)
+TV	Linux	Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ LG Browser/6.00.00(+mouse+3D+SCREEN+TUNER; LGE; 42LA6208-ZA; 04.00.49; 0x00000001;); LG NetCast.TV-2013 /04.00.49 (LG, 42LA6208-ZA, wireless)
+TV	Linux	Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ LG Browser/6.00.00(+mouse+3D+SCREEN+TUNER; LGE; 42LA620S-ZA; 04.22.11; 0x00000001;); LG NetCast.TV-2013 /04.22.11 (LG, 42LA620S-ZA, wireless)
+TV	Linux	Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ LG Browser/6.00.00(+mouse+3D+SCREEN+TUNER; LGE; 42LA6608-ZA; 04.00.13; 0x00000001;); LG NetCast.TV-2013 /04.00.13 (LG, 42LA6608-ZA, wireless)
+TV	Linux	Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ LG Browser/6.00.00(+mouse+3D+SCREEN+TUNER; LGE; 42LA6928-ZC; 04.04.17; 0x00000001;); LG NetCast.TV-2013 /04.04.17 (LG, 42LA6928-ZC, wireless)
+TV	Linux	Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ LG Browser/6.00.00(+mouse+3D+SCREEN+TUNER; LGE; 47LA6208-ZA; 04.00.13; 0x00000001;); LG NetCast.TV-2013 /04.00.13 (LG, 47LA6208-ZA, wireless)
+TV	Linux	Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ LG Browser/6.00.00(+mouse+3D+SCREEN+TUNER; LGE; 47LA6418-ZC; 04.00.13; 0x00000001;); LG NetCast.TV-2013 /04.00.13 (LG, 47LA6418-ZC, wireless)
+TV	Linux	Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ LG Browser/6.00.00(+mouse+SCREEN+TUNER; LGE; 32LN5758-ZE; 04.22.11; 0x00000001;); LG NetCast.TV-2013 /04.22.11 (LG, 32LN5758-ZE, wireless)
+TV	Linux	Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ LG Browser/6.00.00(+mouse+SCREEN+TUNER; LGE; 42LN5758-ZE; 04.00.41; 0x00000001;); LG NetCast.TV-2013 /04.00.41 (LG, 42LN5758-ZE, wireless)
+TV	WebOS	Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.41 (KHTML, like Gecko) Large Screen WebAppManager Safari/537.41
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; bg-BG) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.4.10 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; cs-CZ) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.17 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; da-DK) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.21 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; de-DE) AppleWebKit/535.1 (KHTML, like Gecko) Viera/1.5.2 Chrome/14.0.835.202 Safari/535.1
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; de-DE) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.21 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; de-DE) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.51 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; de-DE) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.12.5 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; de-DE) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.18.1 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; de-DE) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.4.13 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; el-GR) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.21 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; en) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.14 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; en) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.17 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; en) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.18 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; en) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.18.1 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; en) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.4.13 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; en-GB) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.3.3 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; en-IE) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.14 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; en-IE) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.20 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; en-IE) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.21 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; en-IE) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.12.5 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; en-US) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.4.13 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; es-BR) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.17 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; es-BR) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.18.0 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; es-BR) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.5.15 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; es-US) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.18.0 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; fr-CA) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.18 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; fr-FR) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.21 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; fr-FR) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.4.13 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; it-IT) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.14 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; it-IT) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.17 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; it-IT) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.21 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; it-IT) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.51 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; it-IT) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.12.5 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; it-IT) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.18.1 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; it-IT) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.4.13 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; ja-JP) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.18.1 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; nl-NL) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.12.5 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; pl-PL) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.14 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; pl-PL) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.15 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; pl-PL) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.17 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; pl-PL) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.21 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; pl-PL) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.18.1 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; pl-PL) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.3.3 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; pl-PL) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.4.13 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; pt-BR) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.12 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; pt-BR) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.17 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; pt-BR) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.18.1 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; pt-PT) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.14 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; pt-PT) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.4.13 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; ru-RU) AppleWebKit/535.1 (KHTML, like Gecko) Viera/1.5.2 Chrome/14.0.835.202 Safari/535.1
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; ru-RU) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.14 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; ru-RU) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.17 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; ru-RU) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.20 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; ru-RU) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.21 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; ru-RU) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.51 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; ru-RU) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.18.1 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; ru-RU) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.3.2 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; ru-RU) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.3.3 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; ru-RU) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.4.10 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; sk-SK) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.51 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; sk-SK) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.4.13 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; sv-SE) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.17 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; sv-SE) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.21 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; sv-SE) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.4.13 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; tr-TR) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.18.1 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; FreeBSD; U; Viera; vi-SG) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.18.1 Chrome/23.0.1271.97 Safari/537.11
+TV	Linux	Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.47 Safari/537.36 CrKey/1.36.159268
+TV	Linux	Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.225 Safari/537.36 CrKey/1.56.500000 DeviceType/Chromecast
+TV	Linux	Mozilla/5.0 (X11; Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.225 Safari/537.36 CrKey/1.56.500000 DeviceType/SmartSpeaker
+TV	Linux	Mozilla/5.0 (X11; Linux armv7l) CrKey/1
+TV	Android	Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.77 Large Screen Safari/534.24 GoogleTV/092754
+TV	Android	Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.77 Large Screen Safari/534.24 GoogleTV/092811
+TV	Linux	Mozilla/5.0 (X11; U; Linux i686; de) AppleWebKit/534.1 (KHTML, like Gecko) HbbTV/1.1.1 (+PVR;Mstar;OWB;;;)
+TV	Linux	Mozilla/5.0 (X11; U; Linux i686; en-US) AppleWebKit/534.0 (KHTML, like Gecko) HbbTV/1.1.1 (+DL+PVR; inverto; IDL-6650N Volksbox; 1.0; 1.0;) hdplusinteraktiv/1.0 (NETRANGEMMH;)  CE-HTML/1.0
+TV	Linux	Mozilla/5.0 (X11; U; Linux i686; en-US; 1.9.2.10) AppleWebKit/533.1 (KHTML, like Gecko) HbbTV/1.1.1 (+DL+PVR;TRIDENT;HBBTV;1.0;1.0;)
+TV	Linux	Opera/10.60 (Linux i686 ; U; HbbTV/1.1.1 (;;;;;); CE-HTML; TechniSat MultyVision ISIO; de) Presto/2.6.33 Version/10.60
+TV	Linux	Opera/10.60 (Linux sh4 ; U; HbbTV/1.1.1 (+PVR; Loewe; SL121; LOH/3.10;;) CE-HTML/1.0 Config(L:deu,CC:DEU); en) Presto/2.6.33 Version/10.60
+TV	Linux	Opera/10.60 (Linux sh4 ; U; HbbTV/1.1.1 (+PVR; Loewe; SL150; LOH/3.00;;) CE-HTML/1.0 Config(L:deu,CC:DEU); en) Presto/2.6.33 Version/10.60
+TV	Linux	Opera/10.60 (Linux sh4 ; U; HbbTV/1.1.1 (;;;;;); CE-HTML; TechniSat DIGIT ISIO S; de) Presto/2.6.33 Version/10.60
+TV	Linux	Opera/9.80 (Linux 7325b0; U; HbbTV/1.1.1 (; Humax; HD NANO; 1.00.28; 1.0;  hdplusSmartTV/1.0 (NETRANGEMMH; )); ce-html/1.0; en) Presto/2.10.250 Version/11.60
+TV	Linux	Opera/9.80 (Linux 7335b0-smp; U; HbbTV/1.1.1 (; Humax; iCord MINI; 1.00.28; 1.0;  hdplusSmartTV/1.0 (NETRANGEMMH; )); ce-html/1.0; en) Presto/2.10.250 Version/11.60
+TV	Linux	Opera/9.80 (Linux 7405b0-smp; U; HbbTV/1.1.1 (; Humax; HD-FOX C; 1.00.01; 1.0; ); ce-html/1.0; en) Presto/2.9.167 Version/11.50
+TV	Linux	Opera/9.80 (Linux armv6l; Opera TV Store/4563; U; (SonyBDP/BDV12); en) Presto/2.10.250 Version/11.60
+TV	Linux	Opera/9.80 (Linux armv6l; Opera TV Store/5557; (SonyBDP/BDV13)) Presto/2.12.362 Version/12.11
+TV	Linux	Opera/9.80 (Linux armv6l; Opera TV Store/5599; (SonyBDP/BDV13)) Presto/2.12.362 Version/12.11
+TV	Linux	Opera/9.80 (Linux armv6l; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;IKEA LF1V362; en) Presto/2.10.250 Version/11.60
+TV	Linux	Opera/9.80 (Linux armv6l; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;IKEA LF1V365; en) Presto/2.10.250 Version/11.60
+TV	Linux	Opera/9.80 (Linux armv6l; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;PEAQ LF1V359; en) Presto/2.10.250 Version/11.60
+TV	Linux	Opera/9.80 (Linux armv6l; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;PEAQ LF1V368; en) Presto/2.10.250 Version/11.60
+TV	Linux	Opera/9.80 (Linux armv6l; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;PEAQ LF1V389; en) Presto/2.10.250 Version/11.60
+TV	Linux	Opera/9.80 (Linux armv6l; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;THOM LF1V373; en) Presto/2.10.250 Version/11.60
+TV	Linux	Opera/9.80 (Linux armv6l; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;THOMSON LF1V394; en) Presto/2.10.250 Version/11.60
+TV	Linux	Opera/9.80 (Linux armv6l; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;THOMSON LF1V401; en) Presto/2.10.250 Version/11.60
+TV	Linux	Opera/9.80 (Linux armv7l;  HbbTV/1.1.1 (; Philips; ; ; PHILIPSTV; ) CE-HTML/1.0 NETTV/4.3.1 PHILIPSTV/2.1.1 Firmware/003.001.000.001 (PhilipsTV, 2.1.1,) en) Presto/2.12.362 Version/12.11
+TV	Linux	Opera/9.80 (Linux armv7l;  HbbTV/1.1.1 (; Sony; KDL42W655A; PKG4.201EUA; 2013;); ) Presto/2.12.362 Version/12.11
+TV	Linux	Opera/9.80 (Linux armv7l;  HbbTV/1.1.1 (; Sony; KDL42W805A; PKG3.208EUA; 2013;); ) Presto/2.12.362 Version/12.11
+TV	Linux	Opera/9.80 (Linux armv7l;  HbbTV/1.1.1 (; Sony; KDL47W805A; PKG3.710EUA; 2013;); ) Presto/2.12.362 Version/12.11
+TV	Linux	Opera/9.80 (Linux armv7l;  HbbTV/1.1.1 (; Sony; KDL50W685A; PKG3.712EUA; 2013;); ) Presto/2.12.362 Version/12.11
+TV	Linux	Opera/9.80 (Linux armv7l; HbbTV/1.1.1 (; Sony; KDL32W650A; PKG3.211EUA; 2013;); ) Presto/2.12.362 Version/12.11
+TV	Linux	Opera/9.80 (Linux armv7l; HbbTV/1.2.1 (; Philips; 40PFK671912; ; PhilipsTV;  CE-HTML/1.0 NETTV/4.4.1 SmartTvA/3.0.0 Firmware/012.003.038.128 (PhilipsTV, 3.1.1,)en) ) Presto/2.12.407 Version/12.50
+TV	Linux	Opera/9.80 (Linux armv7l; HbbTV/1.2.1 (; Philips; 42PFK710912; ; PHILIPSTV;  CE-HTML/1.0 NETTV/4.4.1 SmartTvA/3.0.0 Firmware/012.002.016.128 (PhilipsTV, 3.1.1,)en) ) Presto/2.12.407 Version/12.50
+TV	Linux	Opera/9.80 (Linux armv7l; HbbTV/1.2.1 (; Philips; 42PFT560912; ; PHILIPSTV;  CE-HTML/1.0 NETTV/4.4.1 SmartTvA/3.0.0 Firmware/010.003.002.128 (PhilipsTV, 3.1.1,)en) ) Presto/2.12.407 Version/12.50
+TV	Linux	Opera/9.80 (Linux armv7l; HbbTV/1.2.1 (; Philips; 55PFH550988; ; PHILIPSTV;  CE-HTML/1.0 NETTV/4.4.1 SmartTvA/3.0.0 Firmware/010.003.010.128 (PhilipsTV, 3.1.1,)en) ) Presto/2.12.407 Version/12.50
+TV	Linux	Opera/9.80 (Linux armv7l; InettvBrowser/2.2 (00014A;SonyDTV115;0002;0100) KD55X9005A; CC/DEU) Presto/2.12.362 Version/12.11
+TV	Linux	Opera/9.80 (Linux armv7l; InettvBrowser/2.2 (00014A;SonyDTV115;0002;0100) KDL42W674A; CC/VNM) Presto/2.12.362 Version/12.11
+TV	Linux	Opera/9.80 (Linux armv7l; InettvBrowser/2.2 (00014A;SonyDTV115;0002;0100) KDL42W805A; CC/ARG) Presto/2.12.362 Version/12.11
+TV	Linux	Opera/9.80 (Linux armv7l; InettvBrowser/2.2 (00014A;SonyDTV115;0002;0100) KDL42W807A; CC/FIN) Presto/2.12.362 Version/12.11
+TV	Linux	Opera/9.80 (Linux armv7l; InettvBrowser/2.2 (00014A;SonyDTV115;0002;0100) KDL47W805A; CC/POL) Presto/2.12.362 Version/12.11
+TV	Linux	Opera/9.80 (Linux armv7l; InettvBrowser/2.2 (00014A;SonyDTV140;0001;0001) KDL32W705B; CC/DEU) Presto/2.12.407 Version/12.50
+TV	Linux	Opera/9.80 (Linux armv7l; InettvBrowser/2.2 (00014A;SonyDTV140;0001;0001) KDL40W600B; CC/MEX) Presto/2.12.407 Version/12.50
+TV	Linux	Opera/9.80 (Linux armv7l; InettvBrowser/2.2 (00014A;SonyDTV140;0001;0001) KDL40W705C; CC/SWE) Presto/2.12.407 Version/12.50
+TV	Linux	Opera/9.80 (Linux armv7l; InettvBrowser/2.2 (00014A;SonyDTV140;0001;0001) KDL50W828B; CC/FIN) Presto/2.12.407 Version/12.50
+TV	Linux	Opera/9.80 (Linux armv7l; U; HbbTV/1.1.1 (; INTEK; VANTAGE-ibox; 1.0; 1.0;) CE-HTML/1.0; FXM-U2FsdGVkX1+h0H+PQGvIkY1hx1djZ+X1R7vhB4maaA6ft4c7ZxQcruknL9ekvukS-END; en) Presto/2.9.167 Version/11.50
+TV	Linux	Opera/9.80 (Linux armv7l; U; HbbTV/1.1.1 (;tv2n;videoweb;1.0.0;1.0;); en) Presto/2.8.115 Version/11.10
+TV	Linux	Opera/9.80 (Linux armv7l; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;Vendor/THOM;SW-Version/V8-MT51F01-LF1V307;Cnt/DEU;Lan/bul) Presto/2.12.362 Version/12.11
+TV	Linux	Opera/9.80 (Linux armv7l; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;Vendor/THOMSON;SW-Version/V8-MT51F01-LF1V325;Cnt/HRV;Lan/swe; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0) Presto/2.12.362 Version/12.11
+TV	Linux	Opera/9.80 (Linux i686; HbbTV/1.1.1 (+PVR; BANGOLUFSEN; A3; ; ; ) CE-HTML/1.0 NETTV/4.3.9) Presto/2.12.407 Version/12.50 A3/1.0.5.33043 (BANGOLUFSEN, A3, wired)
+TV	Linux	Opera/9.80 (Linux mips ; U; HbbTV/1.1.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/3.1.0; en) Presto/2.6.33 Version/10.70
+TV	Linux	Opera/9.80 (Linux mips ; U; HbbTV/1.1.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/3.2.1; en) Presto/2.6.33 Version/10.70
+TV	Linux	Opera/9.80 (Linux mips; HbbTV/1.2.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/4.3.3 PHILIPSTV/1.1.1 Firmware/173.65.0 (PhilipsTV, 1.1.1,) en) Presto/2.12.362 Version/12.11
+TV	Linux	Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL22EX320; PKG4.017EUA; 2011;);; en) Presto/2.7.61 Version/11.00
+TV	Linux	Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL40EX725; PKG4.021EUA; 2011;);; en) Presto/2.7.61 Version/11.00
+TV	Linux	Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL40HX751; PKG1.902EUA; 2012;);; en) Presto/2.10.250 Version/11.60
+TV	Linux	Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL40HX755; PKG1.920EUA; 2012;);; en) Presto/2.10.250 Version/11.60
+TV	Linux	Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL46EX720; PKG4.022EUA; 2011;);; en) Presto/2.7.61 Version/11.00
+TV	Linux	Opera/9.80 (Linux mips; U; HbbTV/1.1.1 (; Opera Software; videowebtv; ; ; ); en) Presto/2.10.287 Version/12.00
+TV	Linux	Opera/9.80 (Linux sh4; HbbTV/1.2.1 (+PVR; Loewe; SL210; LOH/10.2.1.63;;) CE-HTML/1.0 Config(L:nld,CC:NLD) NETRANGEMMH) Presto/2.12.362 Version/12.10
+TV	Linux	Opera/9.80 (Linux sh4; HbbTV/1.2.1 (+PVR; Loewe; SL220; LOH/2.1.36.0;;) CE-HTML/1.0 Config(L:deu,CC:DEU) NETRANGEMMH) Presto/2.12.362 Version/12.10
+TV	Linux	Opera/9.80 (Linux sh4; HbbTV/1.2.1 (;Sharp;LE652;v0.2.3.3;;) CE-HTML/1.0 Config(L:deu,CC:DEU) NETRANGEMMH) Presto/2.12.362 Version/12.10
+TV	Linux	Opera/9.80 (Linux sh4; U; ; en; CreNova Build) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 HbbTV/1.1.1 (;CreNova;CNV001;1.0;1.0; FXM-U2FsdGVkX1+ck0PszsOkJ85Ph0dtmJlCmp7M2VZeoERwEwVagOkMaqjfAh8Gb7JU-END; en) Presto/2.9.167 Version/11.50
+TV	Linux	Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (; INTEK; VT-100 HD+;;;) hdplusSmartTV/1.0 (NETRANGEMMH;) Bee/3.2 CE-HTML/1.0; FXM-U2FsdGVkX1/N3/2AunjF4HAWRQygAcGqj02QZuofQI5yHfuXsLw507L8Q1cbFwrQ-END; en) Presto/2.10.250 Version/11.60
+TV	Linux	Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (; INTEK; Vantage Full HD Model;;;) hdplusSmartTV/1.0 (NETRANGEMMH;) Bee/3.2 CE-HTML/1.0; FXM-U2FsdGVkX19Qg/USD6FU3img+tXTDE7V5tSiPuMpHRrd3vp0JyPLfoYS/+dL6w/H-END; en) Presto/2.10.250 Version/11.60
+TV	Linux	Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (;;;;;); CE-HTML; TechniSat DigiCorder ISIO C; de) Presto/2.9.167 Version/11.50
+TV	Linux	Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (;;;;;); CE-HTML; TechniSat DigiCorder ISIO S; de) Presto/2.9.167 Version/11.50
+TV	Linux	Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (;;;;;); CE-HTML; TechniSat Digit ISIO C; de) Presto/2.9.167 Version/11.50
+TV	Linux	Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (;;;;;); CE-HTML; TechniSat Digit ISIO S International; de) Presto/2.9.167 Version/11.50
+TV	Linux	Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (;;;;;); CE-HTML; TechniSat Digit ISIO S; de) Presto/2.9.167 Version/11.50
+TV	Roku	Roku/DVP-5.0 (025.00E08043A)
+TV	Roku	Roku/DVP-5.1 (025.01E01195A)
+TV	Roku	Roku/DVP-6.2 (096.02E06005A)

--- a/uasurfer.go
+++ b/uasurfer.go
@@ -93,7 +93,16 @@ const (
 	BrowserTwitterBot
 	BrowserYandexBot
 	BrowserCocCocBot
-	BrowserYahooBot // Bot list ends here
+	BrowserYahooBot
+	BrowserOpenAIBot
+	BrowserAnthropicBot
+	BrowserPerplexityBot
+	BrowserAmazonBot
+	BrowserBytedanceBot
+	BrowserCommonCrawlBot
+	BrowserAhrefsBot
+	BrowserSemrushBot
+	BrowserPetalBot // Bot list ends here
 
 	// _browserNameFinal terminates the list so tests can enumerate it; keep it last.
 	_browserNameFinal
@@ -167,6 +176,24 @@ func (b BrowserName) String() string {
 		return "BrowserCocCocBot"
 	case BrowserYahooBot:
 		return "BrowserYahooBot"
+	case BrowserOpenAIBot:
+		return "BrowserOpenAIBot"
+	case BrowserAnthropicBot:
+		return "BrowserAnthropicBot"
+	case BrowserPerplexityBot:
+		return "BrowserPerplexityBot"
+	case BrowserAmazonBot:
+		return "BrowserAmazonBot"
+	case BrowserBytedanceBot:
+		return "BrowserBytedanceBot"
+	case BrowserCommonCrawlBot:
+		return "BrowserCommonCrawlBot"
+	case BrowserAhrefsBot:
+		return "BrowserAhrefsBot"
+	case BrowserSemrushBot:
+		return "BrowserSemrushBot"
+	case BrowserPetalBot:
+		return "BrowserPetalBot"
 	default:
 		// anything out of range, including a value cast from a newer
 		// release, reads as unknown rather than a numeric placeholder
@@ -203,6 +230,9 @@ const (
 	OSXbox
 	OSNintendo
 	OSBot
+	OSTizen // Samsung smart TVs, and the handful of Tizen phones
+	OSRoku
+	OSTvOS
 
 	// _osNameFinal terminates the list so tests can enumerate it; keep it last.
 	_osNameFinal
@@ -240,6 +270,12 @@ func (o OSName) String() string {
 		return "OSNintendo"
 	case OSBot:
 		return "OSBot"
+	case OSTizen:
+		return "OSTizen"
+	case OSRoku:
+		return "OSRoku"
+	case OSTvOS:
+		return "OSTvOS"
 	default:
 		// anything out of range, including a value cast from a newer
 		// release, reads as unknown rather than a numeric placeholder
@@ -273,6 +309,7 @@ const (
 	PlatformXbox
 	PlatformNintendo
 	PlatformBot
+	PlatformAppleTV
 
 	// _platformFinal terminates the list so tests can enumerate it; keep it last.
 	_platformFinal
@@ -304,6 +341,8 @@ func (p Platform) String() string {
 		return "PlatformNintendo"
 	case PlatformBot:
 		return "PlatformBot"
+	case PlatformAppleTV:
+		return "PlatformAppleTV"
 	default:
 		// anything out of range, including a value cast from a newer
 		// release, reads as unknown rather than a numeric placeholder
@@ -365,7 +404,10 @@ func (u *UserAgent) Reset() {
 
 // IsBot returns true if the UserAgent represent a bot
 func (u *UserAgent) IsBot() bool {
-	if u.Browser.Name >= BrowserBot && u.Browser.Name <= BrowserYahooBot {
+	// The bot constants are a contiguous block that ends the BrowserName list,
+	// so the upper bound is the terminator rather than the last bot by name;
+	// TestBrowserNameStrings pins the block to the end of the list.
+	if u.Browser.Name >= BrowserBot && u.Browser.Name < _browserNameFinal {
 		return true
 	}
 	if u.OS.Name == OSBot {

--- a/uasurfer_test.go
+++ b/uasurfer_test.go
@@ -361,11 +361,11 @@ var testUAVars = []struct {
 
 	{"Roku/DVP-5.2 (025.02E03197A)", // Roku
 		UserAgent{
-			Browser{BrowserUnknown, Version{0, 0, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DeviceTV}},
+			Browser{BrowserUnknown, Version{0, 0, 0}}, OS{PlatformLinux, OSRoku, Version{5, 2, 0}}, DeviceTV}},
 
 	{"mozilla/5.0 (smart-tv; linux; tizen 2.3) applewebkit/538.1 (khtml, like gecko) samsungbrowser/1.0 tv safari/538.1", // Samsung SmartTV
 		UserAgent{
-			Browser{BrowserSamsung, Version{0, 0, 0}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceTV}},
+			Browser{BrowserSamsung, Version{0, 0, 0}}, OS{PlatformLinux, OSTizen, Version{2, 3, 0}}, DeviceTV}},
 
 	{"mozilla/5.0 (linux; u) applewebkit/537.36 (khtml, like gecko) version/4.0 mobile safari/537.36 smarttv/6.0 (netcast)",
 		UserAgent{
@@ -1050,9 +1050,10 @@ var testUAVars = []struct {
 	{"Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0. 3865.120 Safari/537.36 OPR/46.0.2207.0 OMI/4.20.5.80.Catcher3.128 Model/Hisense-MT9602 VIDAA/4.0(Hisense;SmartTV;32A35EUV_0002;MTK9602/V0000.01.00K.M0713;HD)",
 		UserAgent{
 			Browser{BrowserOpera, Version{46, 0, 2207}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceTV}},
+	// LG spells its TV OS "Web0S", with a zero
 	{"Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.34 Safari/537.36 WebAppManager",
 		UserAgent{
-			Browser{BrowserChrome, Version{53, 0, 2785}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceTV}},
+			Browser{BrowserChrome, Version{53, 0, 2785}}, OS{PlatformLinux, OSWebOS, Version{0, 0, 0}}, DeviceTV}},
 	{"Mozilla/5.0 (PlayStation 4 WebMAF) AppleWebKit/601.2 (KHTML, like Gecko) WebMAF/v3.0.2-0-g0f0b69bc SDK: (0x09508001u), Built: Aug 17 2022 20:04:00",
 		UserAgent{
 			Browser{BrowserUnknown, Version{0, 0, 0}}, OS{PlatformPlaystation, OSPlaystation, Version{0, 0, 0}}, DeviceConsole}},
@@ -1061,7 +1062,7 @@ var testUAVars = []struct {
 			Browser{BrowserSafari, Version{15, 4, 0}}, OS{PlatformPlaystation, OSPlaystation, Version{0, 0, 0}}, DeviceConsole}},
 	{"Mozilla/5.0 (Linux; Tizen 2.3; SmartHub; SMART-TV; SmartTV; U; Maple2012) AppleWebKit/538.1+ (KHTML, like Gecko) TV Safari/538.1+",
 		UserAgent{
-			Browser{BrowserUnknown, Version{0, 0, 0}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceTV}},
+			Browser{BrowserUnknown, Version{0, 0, 0}}, OS{PlatformLinux, OSTizen, Version{2, 3, 0}}, DeviceTV}},
 	{"Mozilla/5.0 (Linux; Andr0id 12; IP2300) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.5735.198 Safari/537.36 OPR/46.0.2207.0 OMI/4.24.0.81.CRON5.4 Model/Swisscom-IP2300",
 		UserAgent{
 			Browser{BrowserOpera, Version{46, 0, 2207}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceTV}},
@@ -1297,100 +1298,96 @@ func TestAgentSurfer(t *testing.T) {
 }
 
 func BenchmarkAgentSurfer(b *testing.B) {
-	num := len(testUAVars)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		Parse(testUAVars[i%num].UA)
+	i := 0
+	for b.Loop() {
+		Parse(testUAVars[i%len(testUAVars)].UA)
+		i++
 	}
 }
 
 func BenchmarkAgentSurferReuse(b *testing.B) {
 	dest := new(UserAgent)
-	num := len(testUAVars)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	i := 0
+	for b.Loop() {
 		dest.Reset()
-		ParseUserAgent(testUAVars[i%num].UA, dest)
+		ParseUserAgent(testUAVars[i%len(testUAVars)].UA, dest)
+		i++
 	}
 }
 
 func BenchmarkParseOS(b *testing.B) {
-	num := len(testUAVars)
-	v := UserAgent{}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		v.parseOS(testUAVars[i%num].UA, nil)
+	var v UserAgent
+	i := 0
+	for b.Loop() {
+		v.parseOS(testUAVars[i%len(testUAVars)].UA, nil)
+		i++
 	}
 }
 
 func BenchmarkParseBrowserName(b *testing.B) {
-	num := len(testUAVars)
-	v := UserAgent{}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		v.parseBrowserName(testUAVars[i%num].UA)
+	var v UserAgent
+	i := 0
+	for b.Loop() {
+		v.parseBrowserName(testUAVars[i%len(testUAVars)].UA)
+		i++
 	}
 }
 
 func BenchmarkParseBrowserVersion(b *testing.B) {
-	num := len(testUAVars)
-	v := UserAgent{}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		v.Browser.Name = testUAVars[i%num].Browser.Name
-		v.parseBrowserVersion(testUAVars[i%num].UA)
+	var v UserAgent
+	i := 0
+	for b.Loop() {
+		want := testUAVars[i%len(testUAVars)]
+		v.Browser.Name = want.Browser.Name
+		v.parseBrowserVersion(want.UA)
+		i++
 	}
 }
 
 func BenchmarkParseDevice(b *testing.B) {
-	num := len(testUAVars)
-	v := UserAgent{}
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		v.OS.Name = testUAVars[i%num].OS.Name
-		v.OS.Platform = testUAVars[i%num].OS.Platform
-		v.Browser.Name = testUAVars[i%num].Browser.Name
-		v.parseDevice(testUAVars[i%num].UA)
+	var v UserAgent
+	i := 0
+	for b.Loop() {
+		want := testUAVars[i%len(testUAVars)]
+		v.OS.Name = want.OS.Name
+		v.OS.Platform = want.OS.Platform
+		v.Browser.Name = want.Browser.Name
+		v.parseDevice(want.UA)
+		i++
 	}
 }
 
 // Chrome for Mac
 func BenchmarkParseChromeMac(b *testing.B) {
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36")
 	}
 }
 
 // Chrome for Windows
 func BenchmarkParseChromeWin(b *testing.B) {
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Parse("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.134 Safari/537.36")
 	}
 }
 
 // Chrome for Android
 func BenchmarkParseChromeAndroid(b *testing.B) {
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Parse("Mozilla/5.0 (Linux; Android 4.4.2; GT-P5210 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Safari/537.36")
 	}
 }
 
 // Safari for Mac
 func BenchmarkParseSafariMac(b *testing.B) {
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Parse("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12")
 	}
 }
 
 // Safari for iPad
 func BenchmarkParseSafariiPad(b *testing.B) {
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Parse("Mozilla/5.0 (iPad; CPU OS 8_1_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B440 Safari/600.1.4")
 	}
 }
@@ -1483,7 +1480,7 @@ func TestParseUserAgentReuse(t *testing.T) {
 
 func TestIsBot(t *testing.T) {
 	// every bot browser constant must report as a bot
-	for name := BrowserBot; name <= BrowserYahooBot; name++ {
+	for name := BrowserBot; name < _browserNameFinal; name++ {
 		if ua := (&UserAgent{Browser: Browser{Name: name}}); !ua.IsBot() {
 			t.Errorf("Browser %v: IsBot() = false, want true", name)
 		}
@@ -1555,11 +1552,12 @@ func TestDeviceTypeStrings(t *testing.T) {
 func TestBrowserNameStrings(t *testing.T) {
 	assertNames(t, "BrowserName", "Browser", int(_browserNameFinal), func(i int) string { return BrowserName(i).String() })
 
-	// IsBot keys off the BrowserBot..BrowserYahooBot range, so the bot block has
-	// to stay contiguous and stay at the end of the list.
-	if BrowserYahooBot != _browserNameFinal-1 {
-		t.Errorf("BrowserYahooBot = %d but the list ends at %d: a non-bot constant was "+
-			"added after the bot block, which breaks IsBot", BrowserYahooBot, _browserNameFinal-1)
+	// IsBot treats everything from BrowserBot to the terminator as a bot, so the
+	// bot block has to stay contiguous and stay at the end of the list. Adding a
+	// bot means naming it here; adding a browser after it breaks IsBot.
+	if BrowserPetalBot != _browserNameFinal-1 {
+		t.Errorf("BrowserPetalBot = %d but the list ends at %d: a non-bot constant was "+
+			"added after the bot block, which breaks IsBot", BrowserPetalBot, _browserNameFinal-1)
 	}
 }
 


### PR DESCRIPTION
As part on my _Friday recreational coding sessions_, I thought I'd address some of our uasurfer issues. It is gradually falling behind the leading UA detection solutions. The main culprits are:

1. Bot detection
2. CTV OS coverage (important!!!)
3. Android tablet detection
4. Missing client hints
5. In-app web views
6. Wearables
7. Chromium based browsers

There are also structural problems that we should address:

- most test fixtures are from 2016
- we have no fuzz testing

This first PR tries to address issues 1 + 2 + add more tests:

- **Bots:** 7.7% → 83% (1,639/1,975 real crawler agents), with zero false positives across 2,906 real device agents.
- **CTV:** OSTizen, OSRoku, OSTvOS, PlatformAppleTV. LG's Web0S (with a zero) now maps to OSWebOS. 
- **CTV:** Fire TV models are matched as a family — that alone moved 254 Fire TV sticks out of DevicePhone.
- **CTV:** Bug fix - AFTKM was reading as a phone.
- **Fix:** java/ is what J2ME feature phones announce, and whatsapp/ is the messenger as often as the link fetcher — both dropped. 
- **Fix:** dalvik/cfnetwork/okhttp were never added: they carry real ad requests from real apps.
- **Fix:** bot needs a trailing-delimiter check or the phone brand CUBOT matches (the only such collision in 16k device agents).
- **Fix:** The pre-existing loose yahoo rule was calling 46 real devices crawlers — Yahoo Japan's apps and Japanese TVs. Replaced with tokens.
- **Fix:** version parsing integer overflow protection.
- **Tests:** 3 fixture sets in testdata/ (5,959 rows), a fuzz target with 8 invariants (2.85M execs clean, plus a 60s CI job that uploads any crasher as a seed), and unit tests for every new function; Coverage 88.8% → 98.9%
